### PR TITLE
Fix: Add missing build step to publish process

### DIFF
--- a/.changeset/breezy-planets-arrive.md
+++ b/.changeset/breezy-planets-arrive.md
@@ -1,0 +1,5 @@
+---
+"@mirohq/cloud-data-import": patch
+---
+
+fix: build step added to the publish workflow

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Build package
+        run: npm run build
+
       # Creates a release PR if unpublished changesets exist; publishes directly if there are no new changesets
       - name: Create Release Pull Request or Publish
         id: changesets


### PR DESCRIPTION
The publish process previously depended on CI Lint and CI test workflows for builds. After removing this dependency, we forgot to add the build script to the publish process, which caused problems. This PR adds the required build step directly to the publish workflow.