### PR TITLE
fix: start and dev scripts are now pointing to cli.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"node": ">=20.x"
 	},
 	"scripts": {
-		"start": "node -r tsconfig-paths/register dist/index.js",
+		"start": "node -r tsconfig-paths/register dist/cli.js",
 		"test": "jest",
 		"test:watch": "jest --watch",
 		"lint": "eslint .",
@@ -30,7 +30,7 @@
 		"build": "npm run build:cjs && npm run build:esm",
 		"release": "npm run build && changeset publish",
 		"dev:setup": "npm install && npm run build && npm link",
-		"dev": "ts-node -r tsconfig-paths/register src/index.ts",
+		"dev": "ts-node -r tsconfig-paths/register src/cli.ts",
 		"changeset": "changeset"
 	},
 	"license": "MIT",


### PR DESCRIPTION
After converting the package into an npm module and a CLI script app, we overlooked setting the scripts to point to `cli.ts`. This PR addresses that issue.