### PR TITLE
fix: when using the module, ARN's accountId is generated correctly

### DIFF
--- a/.changeset/warm-otters-visit.md
+++ b/.changeset/warm-otters-visit.md
@@ -1,0 +1,5 @@
+---
+"@mirohq/cloud-data-import": patch
+---
+
+fix: when using the module, ARN's accountId is generated correctly

--- a/src/aws-app/main.ts
+++ b/src/aws-app/main.ts
@@ -20,9 +20,11 @@ export default async () => {
 
 	const getRateLimiter = createRateLimiterFactory(config['call-rate-rps'])
 
+	const credentials = undefined // assume that the credentials are already set in the environment
+
 	// prepare scanners
 	const scanners = getAwsScanners({
-		credentials: undefined, // assume that the credentials are already set in the environment
+		credentials,
 		regions: config.regions,
 		getRateLimiter,
 		shouldIncludeGlobalServices: !config['regional-only'],
@@ -57,7 +59,7 @@ export default async () => {
 		processed: await getProcessedData(resources),
 		errors,
 		metadata: {
-			account: await getAwsAccountId(),
+			account: await getAwsAccountId(credentials),
 			regions: config.regions,
 			startedAt: startedAt.toISOString(),
 			finishedAt: finishedAt.toISOString(),

--- a/src/scanners/scan-functions/aws/athena-named-queries.ts
+++ b/src/scanners/scan-functions/aws/athena-named-queries.ts
@@ -10,7 +10,7 @@ export async function getAthenaNamedQueries(
 	region: string,
 ): Promise<Resources<NamedQuery>> {
 	const client = new AthenaClient({credentials, region})
-	const accountId = await getAwsAccountId()
+	const accountId = await getAwsAccountId(credentials)
 
 	const resources: Resources<NamedQuery> = {}
 	let nextToken: string | undefined

--- a/src/scanners/scan-functions/aws/ec2-instances.ts
+++ b/src/scanners/scan-functions/aws/ec2-instances.ts
@@ -11,7 +11,7 @@ export async function getEC2Instances(
 ): Promise<Resources<Instance>> {
 	const client = new EC2Client({credentials, region})
 
-	const accountId = await getAwsAccountId()
+	const accountId = await getAwsAccountId(credentials)
 
 	const describeInstancesCommand = new DescribeInstancesCommand({})
 	const describeInstancesResponse = await rateLimiter.throttle(() => client.send(describeInstancesCommand))

--- a/src/scanners/scan-functions/aws/ec2-internet-gateways.ts
+++ b/src/scanners/scan-functions/aws/ec2-internet-gateways.ts
@@ -11,7 +11,7 @@ export async function getEC2InternetGateways(
 ): Promise<Resources<InternetGateway>> {
 	const client = new EC2Client({credentials, region})
 
-	const accountId = await getAwsAccountId()
+	const accountId = await getAwsAccountId(credentials)
 
 	const describeInternetGatewaysCommand = new DescribeInternetGatewaysCommand({})
 	const describeInternetGatewaysResponse = await rateLimiter.throttle(() =>

--- a/src/scanners/scan-functions/aws/ec2-nat-gateways.ts
+++ b/src/scanners/scan-functions/aws/ec2-nat-gateways.ts
@@ -11,7 +11,7 @@ export async function getEC2NatGateways(
 ): Promise<Resources<NatGateway>> {
 	const client = new EC2Client({credentials, region})
 
-	const accountId = await getAwsAccountId()
+	const accountId = await getAwsAccountId(credentials)
 
 	const describeNatGatewaysCommand = new DescribeNatGatewaysCommand({})
 	const describeNatGatewaysResponse = await rateLimiter.throttle(() => client.send(describeNatGatewaysCommand))

--- a/src/scanners/scan-functions/aws/ec2-network-acls.ts
+++ b/src/scanners/scan-functions/aws/ec2-network-acls.ts
@@ -11,7 +11,7 @@ export async function getEC2NetworkAcls(
 ): Promise<Resources<NetworkAcl>> {
 	const client = new EC2Client({credentials, region})
 
-	const accountId = await getAwsAccountId()
+	const accountId = await getAwsAccountId(credentials)
 
 	const describeNetworkAclsCommand = new DescribeNetworkAclsCommand({})
 	const describeSubnetsResponse = await rateLimiter.throttle(() => client.send(describeNetworkAclsCommand))

--- a/src/scanners/scan-functions/aws/ec2-network-interfaces.ts
+++ b/src/scanners/scan-functions/aws/ec2-network-interfaces.ts
@@ -11,7 +11,7 @@ export async function getEC2NetworkInterfaces(
 ): Promise<Resources<NetworkInterface>> {
 	const client = new EC2Client({credentials, region})
 
-	const accountId = await getAwsAccountId()
+	const accountId = await getAwsAccountId(credentials)
 
 	const resources: Resources<NetworkInterface> = {}
 	let nextToken: string | undefined

--- a/src/scanners/scan-functions/aws/ec2-route-tables.ts
+++ b/src/scanners/scan-functions/aws/ec2-route-tables.ts
@@ -11,7 +11,7 @@ export async function getEC2RouteTables(
 ): Promise<Resources<RouteTable>> {
 	const client = new EC2Client({credentials, region})
 
-	const accountId = await getAwsAccountId()
+	const accountId = await getAwsAccountId(credentials)
 
 	const describeRouteTablesCommand = new DescribeRouteTablesCommand({})
 	const describeRouteTablesResponse = await rateLimiter.throttle(() => client.send(describeRouteTablesCommand))

--- a/src/scanners/scan-functions/aws/ec2-subnets.ts
+++ b/src/scanners/scan-functions/aws/ec2-subnets.ts
@@ -11,7 +11,7 @@ export async function getEC2Subnets(
 ): Promise<Resources<Subnet>> {
 	const client = new EC2Client({credentials, region})
 
-	const accountId = await getAwsAccountId()
+	const accountId = await getAwsAccountId(credentials)
 
 	const describeSubnetsCommand = new DescribeSubnetsCommand({})
 	const describeSubnetsResponse = await rateLimiter.throttle(() => client.send(describeSubnetsCommand))

--- a/src/scanners/scan-functions/aws/ec2-transit-gateways.ts
+++ b/src/scanners/scan-functions/aws/ec2-transit-gateways.ts
@@ -11,7 +11,7 @@ export async function getEC2TransitGateways(
 ): Promise<Resources<TransitGateway>> {
 	const client = new EC2Client({credentials, region})
 
-	const accountId = await getAwsAccountId()
+	const accountId = await getAwsAccountId(credentials)
 
 	const describeTransitGatewaysCommand = new DescribeTransitGatewaysCommand({})
 	const describeTransitGatewaysResponse = await rateLimiter.throttle(() => client.send(describeTransitGatewaysCommand))

--- a/src/scanners/scan-functions/aws/ec2-volumes.ts
+++ b/src/scanners/scan-functions/aws/ec2-volumes.ts
@@ -11,7 +11,7 @@ export async function getEC2Volumes(
 ): Promise<Resources<Volume>> {
 	const client = new EC2Client({credentials, region})
 
-	const accountId = await getAwsAccountId()
+	const accountId = await getAwsAccountId(credentials)
 
 	const describeVolumesCommand = new DescribeVolumesCommand({})
 	const describeVolumesResponse = await rateLimiter.throttle(() => client.send(describeVolumesCommand))

--- a/src/scanners/scan-functions/aws/ec2-vpc-endpoints.ts
+++ b/src/scanners/scan-functions/aws/ec2-vpc-endpoints.ts
@@ -11,7 +11,7 @@ export async function getEC2VpcEndpoints(
 ): Promise<Resources<VpcEndpoint>> {
 	const client = new EC2Client({credentials, region})
 
-	const accountId = await getAwsAccountId()
+	const accountId = await getAwsAccountId(credentials)
 
 	const describeVpcEndpointsCommand = new DescribeVpcEndpointsCommand({})
 	const describeVpcEndpointsResponse = await rateLimiter.throttle(() => client.send(describeVpcEndpointsCommand))

--- a/src/scanners/scan-functions/aws/ec2-vpcs.ts
+++ b/src/scanners/scan-functions/aws/ec2-vpcs.ts
@@ -11,7 +11,7 @@ export async function getEC2Vpcs(
 ): Promise<Resources<Vpc>> {
 	const client = new EC2Client({credentials, region})
 
-	const accountId = await getAwsAccountId()
+	const accountId = await getAwsAccountId(credentials)
 
 	const describeVpcsCommand = new DescribeVpcsCommand({})
 	const describeVpcsResponse = await rateLimiter.throttle(() => client.send(describeVpcsCommand))

--- a/src/scanners/scan-functions/aws/ec2-vpn-gateways.ts
+++ b/src/scanners/scan-functions/aws/ec2-vpn-gateways.ts
@@ -10,7 +10,7 @@ export async function getEC2VpnGateways(
 	region: string,
 ): Promise<Resources<VpnGateway>> {
 	const client = new EC2Client({credentials, region})
-	const accountId = await getAwsAccountId()
+	const accountId = await getAwsAccountId(credentials)
 
 	const resources: Resources<VpnGateway> = {}
 

--- a/src/scanners/scan-functions/aws/elbv1-load-balancers.ts
+++ b/src/scanners/scan-functions/aws/elbv1-load-balancers.ts
@@ -14,7 +14,7 @@ export async function getELBv1LoadBalancers(
 ): Promise<Resources<LoadBalancerDescription>> {
 	const client = new ElasticLoadBalancingClient({credentials, region})
 
-	const accountId = await getAwsAccountId()
+	const accountId = await getAwsAccountId(credentials)
 
 	const describeLoadBalancersCommand = new DescribeLoadBalancersCommand({})
 	const describeLoadBalancersResponse = await rateLimiter.throttle(() => client.send(describeLoadBalancersCommand))

--- a/src/scanners/scan-functions/aws/redshift-clusters.ts
+++ b/src/scanners/scan-functions/aws/redshift-clusters.ts
@@ -10,7 +10,7 @@ export async function getRedshiftClusters(
 	region: string,
 ): Promise<Resources<Cluster>> {
 	const client = new RedshiftClient({credentials, region})
-	const accountId = await getAwsAccountId()
+	const accountId = await getAwsAccountId(credentials)
 	const resources: {[arn: string]: Cluster} = {}
 
 	let marker: string | undefined

--- a/src/scanners/scan-functions/aws/route53-hosted-zones.ts
+++ b/src/scanners/scan-functions/aws/route53-hosted-zones.ts
@@ -11,7 +11,7 @@ export async function getHostedZones(
 ): Promise<Resources<HostedZone>> {
 	const client = new Route53Client({credentials, region})
 
-	const accountId = await getAwsAccountId()
+	const accountId = await getAwsAccountId(credentials)
 
 	const hostedZones: Resources<HostedZone> = {}
 

--- a/src/scanners/scan-functions/aws/s3-buckets.ts
+++ b/src/scanners/scan-functions/aws/s3-buckets.ts
@@ -11,7 +11,7 @@ export async function getS3Buckets(
 ): Promise<Resources<Bucket>> {
 	const client = new S3Client({credentials, region})
 
-	const accountId = await getAwsAccountId()
+	const accountId = await getAwsAccountId(credentials)
 
 	const listBucketsCommand = new ListBucketsCommand({})
 	const listBucketsResponse = await rateLimiter.throttle(() => client.send(listBucketsCommand))


### PR DESCRIPTION
- The accountId was being generated using the credentials coming from environmental variables
- Now it generates based on whatever credentials is passed to it