### PR TITLE
Changed processing errors types to non-blockers

### DIFF
--- a/.changeset/fuzzy-dolls-report.md
+++ b/.changeset/fuzzy-dolls-report.md
@@ -1,0 +1,5 @@
+---
+"@mirohq/cloud-data-import": patch
+---
+
+Changed processing errors types to non-blockers

--- a/src/aws-app/cliMessages.ts
+++ b/src/aws-app/cliMessages.ts
@@ -1,4 +1,4 @@
-import {blueBright, yellowBright} from 'colorette'
+import {blueBright, yellowBright, redBright} from 'colorette'
 
 export const getIntro = () => `
 
@@ -32,4 +32,16 @@ ${blueBright(`Resource discovery completed successfully! 🚀`)}
 
 Happy visualizing!
 
+`
+
+export const getProcessingErrorMessage = (errors: Record<string, string[]>) => `
+🚨 Some errors occurred while processing following containers and resources:
+
+${redBright(
+	Object.entries(errors)
+		.map(([arn, errors]) => `- ${arn}\n${errors.map((err) => `    - ${err}`).join('\n')}`)
+		.join('\n\n'),
+)}
+
+${redBright('This might cause mentioned resources to be missing in the visualization.')}
 `

--- a/src/aws-app/cliMessages.ts
+++ b/src/aws-app/cliMessages.ts
@@ -35,6 +35,9 @@ Happy visualizing!
 `
 
 export const getProcessingErrorMessage = (errors: Record<string, string[]>) => `
+
+--
+
 🚨 Some errors occurred while processing following containers and resources:
 
 ${redBright(

--- a/src/aws-app/process/containers/assignResourcesToContainers.ts
+++ b/src/aws-app/process/containers/assignResourcesToContainers.ts
@@ -1,16 +1,11 @@
-import {PlacementData, ProcessedContainers} from '../types'
+import {ErrorManager, PlacementData, ProcessedContainers} from '../types'
 
 export const assignResourcesToContainers = (
 	placementData: PlacementData,
 	emptyContainers: ProcessedContainers,
+	errorManager: ErrorManager,
 ): ProcessedContainers => {
 	const containers = JSON.parse(JSON.stringify(emptyContainers)) as ProcessedContainers
-	const errors: Record<string, string[]> = {}
-
-	const addError = (arn: string, message: string) => {
-		if (!errors[arn]) errors[arn] = []
-		errors[arn].push(message)
-	}
 
 	for (const [arn, placement] of Object.entries(placementData)) {
 		// Subnet and Security Group placement
@@ -20,7 +15,7 @@ export const assignResourcesToContainers = (
 				if (containers.subnets[subnetId]) {
 					containers.subnets[subnetId].children.resources.push(arn)
 				} else {
-					addError(arn, `Could not assign to ${subnetId}. Subnet not found`)
+					errorManager.log(arn, `Could not assign to ${subnetId}. Subnet not found`)
 				}
 			}
 
@@ -29,7 +24,7 @@ export const assignResourcesToContainers = (
 				if (containers.securityGroups[securityGroupId]) {
 					containers.securityGroups[securityGroupId].children.resources.push(arn)
 				} else {
-					addError(arn, `Could not assign to ${securityGroupId}. Security Group not found`)
+					errorManager.log(arn, `Could not assign to ${securityGroupId}. Security Group not found`)
 				}
 			}
 
@@ -44,7 +39,7 @@ export const assignResourcesToContainers = (
 				if (containers.vpcs[placement.vpc]) {
 					containers.vpcs[placement.vpc].children.resources.push(arn)
 				} else {
-					addError(arn, `Could not assign to ${placement.vpc}. VPC not found`)
+					errorManager.log(arn, `Could not assign to ${placement.vpc}. VPC not found`)
 				}
 			}
 
@@ -55,7 +50,7 @@ export const assignResourcesToContainers = (
 				if (containers.availabilityZones[azIdentifier]) {
 					containers.availabilityZones[azIdentifier].children.resources.push(arn)
 				} else {
-					addError(arn, `Could not assign to ${azIdentifier}. Availability Zone not found`)
+					errorManager.log(arn, `Could not assign to ${azIdentifier}. Availability Zone not found`)
 				}
 			}
 
@@ -70,7 +65,7 @@ export const assignResourcesToContainers = (
 			if (containers.regions[regionIdentifier]) {
 				containers.regions[regionIdentifier].children.resources.push(arn)
 			} else {
-				addError(arn, `Could not assign to ${regionIdentifier}. Region not found`)
+				errorManager.log(arn, `Could not assign to ${regionIdentifier}. Region not found`)
 			}
 
 			// If the resource can be place in a region, we can skip the rest of the loop
@@ -82,7 +77,7 @@ export const assignResourcesToContainers = (
 			if (containers.accounts[placement.account]) {
 				containers.accounts[placement.account].children.resources.push(arn)
 			} else {
-				addError(arn, `Could not assign to ${placement.account}. Account not found`)
+				errorManager.log(arn, `Could not assign to ${placement.account}. Account not found`)
 			}
 
 			// If the resource can be place in an account, we can skip the rest of the loop
@@ -90,16 +85,7 @@ export const assignResourcesToContainers = (
 		}
 
 		// If the resource cannot be placed in any container, we can throw an error
-		addError(arn, 'Cannot be placed in any container')
-	}
-
-	// Log errors
-	if (Object.keys(errors).length > 0) {
-		console.error('\n\nNon-critical errors occurred while processing scanned resources:')
-		for (const [arn, messages] of Object.entries(errors)) {
-			console.error(`Resource "${arn}":`)
-			messages.forEach((message) => console.error(`  - ${message}`))
-		}
+		errorManager.log(arn, 'Cannot be placed in any container')
 	}
 
 	return containers

--- a/src/aws-app/process/containers/processContainers.ts
+++ b/src/aws-app/process/containers/processContainers.ts
@@ -1,14 +1,18 @@
 import {Resources} from '@/types'
-import {PlacementData, ProcessedContainers} from '../types'
+import {ErrorManager, PlacementData, ProcessedContainers} from '../types'
 import {assignResourcesToContainers} from './assignResourcesToContainers'
 import {createContainerScaffolding} from './createContainerScaffolding'
 
-export const getProcessedContainers = (placementData: PlacementData, resources: Resources): ProcessedContainers => {
+export const getProcessedContainers = (
+	placementData: PlacementData,
+	resources: Resources,
+	errorManager: ErrorManager,
+): ProcessedContainers => {
 	// Create the empty container scaffolding
-	const scaffolding = createContainerScaffolding(placementData, resources)
+	const scaffolding = createContainerScaffolding(placementData, resources, errorManager)
 
 	// Fill the containers with the resources
-	const containers = assignResourcesToContainers(placementData, scaffolding)
+	const containers = assignResourcesToContainers(placementData, scaffolding, errorManager)
 
 	return containers
 }

--- a/src/aws-app/process/index.ts
+++ b/src/aws-app/process/index.ts
@@ -3,14 +3,20 @@ import type {ProcessedData, Resources} from '@/types'
 import {getPlacementData} from './getPlacementData'
 import {getProcessedResources} from './resources'
 import {getProcessedContainers} from './containers'
+import {ProcessingErrorManager} from './utils/ProcessingErrorManager'
 
 export const getProcessedData = (resources: Resources): ProcessedData => {
+	const processingErrorsManager = new ProcessingErrorManager()
+
 	// Get the placement data which is a simplified version of the resources focusing on the location of the resources
 	const placementData = getPlacementData(resources)
 
 	// Calculate the containers, connections and resources
 	const processedResources = getProcessedResources(placementData)
-	const containers = getProcessedContainers(placementData, resources)
+	const containers = getProcessedContainers(placementData, resources, processingErrorsManager)
+
+	// Log all collected errors
+	processingErrorsManager.render()
 
 	// Return the processed data
 	return {

--- a/src/aws-app/process/types.ts
+++ b/src/aws-app/process/types.ts
@@ -17,6 +17,11 @@ export type PlacementData = {
 	[arn: string]: ResourcePlacementData
 }
 
+export interface ErrorManager {
+	log: (topic: string, message: string) => void
+	render: () => void
+}
+
 export type ProcessedResources = ProcessedData['resources']
 export type ProcessedConnections = ProcessedData['connections']
 export type ProcessedContainers = ProcessedData['containers']

--- a/src/aws-app/process/utils/ProcessingErrorManager.ts
+++ b/src/aws-app/process/utils/ProcessingErrorManager.ts
@@ -1,0 +1,20 @@
+import {getProcessingErrorMessage} from '@/aws-app/cliMessages'
+import {ErrorManager} from '../types'
+
+export class ProcessingErrorManager implements ErrorManager {
+	errors: Record<string, string[]> = {}
+
+	log(arn: string, message: string) {
+		if (!this.errors[arn]) {
+			this.errors[arn] = []
+		}
+		this.errors[arn].push(message)
+	}
+
+	render() {
+		if (Object.keys(this.errors).length > 0) {
+			const message = getProcessingErrorMessage(this.errors)
+			console.log(message)
+		}
+	}
+}


### PR DESCRIPTION
Some users may encounter critical errors simply because they lack sufficient permissions to scan all necessary resources. In such situations, if an error occurs, we should inform user about it. However, we shouldn't prevent them from generating the JSON schema.