### PR TITLE
fix: container-scaffolding-creation error fixed

### DIFF
--- a/.changeset/breezy-seals-promise.md
+++ b/.changeset/breezy-seals-promise.md
@@ -1,0 +1,5 @@
+---
+"@mirohq/cloud-data-import": patch
+---
+
+fix: container-scaffolding-creation error fixed


### PR DESCRIPTION
Sometimes a new Security Group or Subnet introduces a VPC or AZ that wasn't previously detected. In these cases, we'll attempt to add the missing VPC and AZ. Currently, this situation throws an error, which it shouldn't. Here's a fix for this issue.