### PR TITLE
More reliable RateLimiter

### DIFF
--- a/.changeset/poor-shrimps-work.md
+++ b/.changeset/poor-shrimps-work.md
@@ -1,0 +1,9 @@
+---
+"@mirohq/cloud-data-import": minor
+---
+
+- (RateLimiter) Implemented strict throttling instead of windowed throttling
+- (RateLimiter) Added pause, resume, and abort functionality to rate-limiter
+- (RateLimiter) Introduced RetryStrategy concept for customizable retry logic
+- (RateLimiter) Created AWSRateLimitExhaustionRetryStrategy based on RetryStrategy
+- (lib) Integrated new retry strategy in CLI and exposed via library

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mirohq/cloud-data-import",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mirohq/cloud-data-import",
-			"version": "0.7.0",
+			"version": "0.8.0",
 			"license": "MIT",
 			"dependencies": {
 				"@aws-sdk/client-athena": "^3.621.0",

--- a/src/aws-app/main.ts
+++ b/src/aws-app/main.ts
@@ -10,6 +10,7 @@ import {getConfig} from './config'
 import {createRateLimiterFactory} from './utils/createRateLimiterFactory'
 import {getAwsAccountId} from '@/scanners/scan-functions/aws/common/getAwsAccountId'
 import {buildCredentialIdentity} from '@/aws-app/utils/buildCredentialIdentity'
+import {AWSRateLimitExhaustionRetryStrategy} from './utils/AWSRateLimitExhaustionRetryStrategy'
 
 export default async () => {
 	console.log(cliMessages.getIntro())
@@ -19,7 +20,7 @@ export default async () => {
 	// setting the AWS_REGION explicitly to meet SDK requirements
 	process.env.AWS_REGION = config.regions[0]
 
-	const getRateLimiter = createRateLimiterFactory(config['call-rate-rps'])
+	const getRateLimiter = createRateLimiterFactory(config['call-rate-rps'], new AWSRateLimitExhaustionRetryStrategy())
 
 	const credentials = await buildCredentialIdentity(config.profile)
 

--- a/src/aws-app/utils/AWSRateLimitExhaustionRetryStrategy.ts
+++ b/src/aws-app/utils/AWSRateLimitExhaustionRetryStrategy.ts
@@ -1,6 +1,6 @@
-import {RetryOptions, RetryStrategy} from './RetryStrategy'
+import {RetryOptions, RetryStrategy} from '@/scanners/common/RetryStrategy'
 
-export class AWSRateLimitExhaustionStrategy extends RetryStrategy {
+export class AWSRateLimitExhaustionRetryStrategy extends RetryStrategy {
 	constructor(options: Partial<RetryOptions> = {}) {
 		super({
 			maxRetries: 5,

--- a/src/aws-app/utils/createRateLimiterFactory.ts
+++ b/src/aws-app/utils/createRateLimiterFactory.ts
@@ -1,4 +1,5 @@
 import {createRateLimiter} from '@/scanners'
+import {RetryStrategy} from '@/scanners/common/RetryStrategy'
 import {GetRateLimiterFunction} from '@/scanners/types'
 import {RateLimiter} from '@/types'
 
@@ -7,7 +8,7 @@ import {RateLimiter} from '@/types'
  *
  * this also handles the shared rate limiters for services like `ec2` and `ec2/volumes` or `rds/clusters` and `rds/db-instances`
  */
-export const createRateLimiterFactory = (callRateRps: number): GetRateLimiterFunction => {
+export const createRateLimiterFactory = (callRateRps: number, retryStrategy: RetryStrategy): GetRateLimiterFunction => {
 	const rateLimiters = new Map<string, RateLimiter>()
 
 	return (service: string, region?: string) => {
@@ -15,7 +16,7 @@ export const createRateLimiterFactory = (callRateRps: number): GetRateLimiterFun
 		const key = region ? `${quotaServiceName}-${region}` : quotaServiceName
 
 		if (!rateLimiters.has(key)) {
-			rateLimiters.set(key, createRateLimiter(callRateRps))
+			rateLimiters.set(key, createRateLimiter(callRateRps, retryStrategy))
 		}
 
 		return rateLimiters.get(key) as RateLimiter

--- a/src/aws-app/utils/createRateLimiterFactory.ts
+++ b/src/aws-app/utils/createRateLimiterFactory.ts
@@ -1,5 +1,6 @@
-import {RateLimiter, createRateLimiter} from '@/scanners'
+import {createRateLimiter} from '@/scanners'
 import {GetRateLimiterFunction} from '@/scanners/types'
+import {RateLimiter} from '@/types'
 
 /**
  * Returns the getRateLimiter function for a given service and region

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,6 +6,8 @@ export type * from '@/types'
 
 export {awsRegionIds} from '@/constants'
 
+export {AWSRateLimitExhaustionRetryStrategy} from '@/aws-app/utils/AWSRateLimitExhaustionRetryStrategy'
+
 /**
  * @public
  * @experimental This export is experimental and may change or be removed in future versions.

--- a/src/scanners/common/AWSRateLimitExhaustionStrategy.ts
+++ b/src/scanners/common/AWSRateLimitExhaustionStrategy.ts
@@ -1,0 +1,28 @@
+import {RetryOptions, RetryStrategy} from './RetryStrategy'
+
+export class AWSRateLimitExhaustionStrategy extends RetryStrategy {
+	constructor(options: Partial<RetryOptions> = {}) {
+		super({
+			maxRetries: 5,
+			initialDelay: 1000,
+			maxDelay: 20000,
+			backoffFactor: 2,
+			...options,
+		})
+	}
+
+	shouldRetry(error: any): boolean {
+		// AWS-specific error codes for rate limit exhaustion
+		const rateLimitErrorCodes = [
+			'ThrottlingException',
+			'TooManyRequestsException',
+			'RequestLimitExceeded',
+			'Throttling',
+			'RequestThrottled',
+			'RequestThrottledException',
+			'SlowDown',
+		]
+
+		return rateLimitErrorCodes.includes(error.code) || error.statusCode === 429
+	}
+}

--- a/src/scanners/common/RateLimiter.ts
+++ b/src/scanners/common/RateLimiter.ts
@@ -100,4 +100,5 @@ export class RateLimiterImpl implements RateLimiter {
 	}
 }
 
-export const createRateLimiter = (rate: number) => new RateLimiterImpl(rate)
+export const createRateLimiter = (rate: number, retryStrategy?: RetryStrategy) =>
+	new RateLimiterImpl(rate, retryStrategy)

--- a/src/scanners/common/RateLimiter.ts
+++ b/src/scanners/common/RateLimiter.ts
@@ -1,120 +1,103 @@
-const BASE_RETRY_DELAY = 1000 // 1 second
-const MAX_RETRIES = 6 // last attempt will take 64 seconds (2^6 = 64 * base retry delay) and overall will take 127 seconds for all retries to complete, before giving up
-const CAPACITY_USAGE_PERCENTAGE = 0.6
+import {RateLimiter} from '@/types'
+import {RetryStrategy} from './RetryStrategy'
 
-const ONE_SECOND = 1000
+export class RateLimiterImpl implements RateLimiter {
+	private executionTimesMs: number[] = []
+	private pendingQueue: (() => void)[] = []
+	private timeoutId: NodeJS.Timeout | null = null
+	private _isPaused = false
+	private readonly intervalMs: number
+	private retryStrategy: RetryStrategy | null
 
-export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
-
-export interface RateLimiter {
-	throttle<U>(fn: () => Promise<U>): Promise<U>
-}
-
-class RateLimiterImpl implements RateLimiter {
-	private allowance: number
-	private lastCheck: number
-	private maxUsage: number
-	private queue: (() => void)[]
-
-	constructor(rate: number) {
-		this.maxUsage = rate * CAPACITY_USAGE_PERCENTAGE
-		this.allowance = this.maxUsage
-		this.lastCheck = Date.now()
-		this.queue = []
+	constructor(
+		private _rate: number,
+		retryStrategy: RetryStrategy | null = null,
+	) {
+		if (!Number.isFinite(_rate) || _rate <= 0) {
+			throw new TypeError('Expected `rate` to be a positive finite number')
+		}
+		this.intervalMs = 1000 / _rate
+		this.retryStrategy = retryStrategy
 	}
 
-	// Acquire permission to proceed with a function call
-	private async acquire() {
-		const current = Date.now()
-		const timePassed = current - this.lastCheck
-		this.lastCheck = current
-		this.allowance += (timePassed / ONE_SECOND) * this.maxUsage
-
-		if (this.allowance > this.maxUsage) {
-			this.allowance = this.maxUsage
+	private scheduleNextExecution(): void {
+		if (this.timeoutId) {
+			clearTimeout(this.timeoutId)
 		}
 
-		// If allowance is insufficient, wait for more capacity
-		if (this.allowance < 1) {
-			const waitTime = (1 - this.allowance) * (ONE_SECOND / this.maxUsage)
-			await sleep(waitTime)
-			this.allowance = 0
-		} else {
-			this.allowance -= 1
+		if (this._isPaused || this.pendingQueue.length === 0) {
+			return
 		}
+
+		const now = Date.now()
+		let delay = 0
+
+		if (this.executionTimesMs.length > 0) {
+			const nextExecutionTime = this.executionTimesMs[this.executionTimesMs.length - 1] + this.intervalMs
+			delay = Math.max(0, nextExecutionTime - now)
+		}
+
+		this.timeoutId = setTimeout(() => {
+			const fn = this.pendingQueue.shift()
+			if (fn) {
+				this.executionTimesMs.push(Date.now())
+				if (this.executionTimesMs.length > 10) {
+					this.executionTimesMs.shift()
+				}
+				fn()
+			}
+			this.scheduleNextExecution()
+		}, delay)
 	}
 
-	// Throttle function execution
-	async throttle<U>(fn: () => Promise<U>): Promise<U> {
+	throttle<U>(fn: () => Promise<U>): Promise<U> {
 		return new Promise<U>((resolve, reject) => {
-			const execute = async () => {
-				try {
-					await this.acquire()
-					resolve(await fn())
-				} catch (error: any) {
-					if (this.isRequestLimitError(error)) {
-						this.retry(fn, resolve, reject, 1)
-					} else {
-						reject(error)
-					}
+			const wrappedFn = () => {
+				if (this.retryStrategy) {
+					this.retryStrategy.retry(fn).then(resolve).catch(reject)
+				} else {
+					fn().then(resolve).catch(reject)
 				}
 			}
 
-			this.queue.push(execute)
-
-			// If it's the only function in the queue, it means that we just added it. So we should start the process.
-			// But, if it's more in the queue, it means that we are already processing the queue, and the function will be processed when it's its turn.
-			if (this.queue.length === 1) {
-				this.dequeue()
-			}
+			this.pendingQueue.push(wrappedFn)
+			this.scheduleNextExecution()
 		})
 	}
 
-	// Retry function with exponential backoff
-	private async retry<U>(
-		fn: () => Promise<U>,
-		resolve: (value: U | PromiseLike<U>) => void,
-		reject: (reason?: any) => void,
-		attempt: number,
-	) {
-		if (attempt < MAX_RETRIES) {
-			// Exponential backoff
-			// https://en.wikipedia.org/wiki/Exponential_backoff
-			await sleep(BASE_RETRY_DELAY * Math.pow(2, attempt))
-			try {
-				// acquire permission to proceed and add enough sleep time
-				await this.acquire()
-				resolve(await fn())
-			} catch (error: any) {
-				if (this.isRequestLimitError(error)) {
-					this.retry(fn, resolve, reject, attempt + 1)
-				} else {
-					reject(error)
-				}
-			}
-		} else {
-			reject(new Error('Max retries reached'))
+	pause(): void {
+		this._isPaused = true
+		if (this.timeoutId) {
+			clearTimeout(this.timeoutId)
+			this.timeoutId = null
 		}
 	}
 
-	// Check if error is a request limit error
-	private isRequestLimitError(error: Error) {
-		return [
-			'TooManyRequestsException',
-			'ThrottlingException',
-			'ProvisionedThroughputExceededException',
-			'RequestLimitExceeded',
-		].includes(error.name)
+	resume(): void {
+		this._isPaused = false
+		this.scheduleNextExecution()
 	}
 
-	// Process the queue of function calls
-	// @idea Maybe we can add some lifecycle hooks here in the future?
-	private async dequeue() {
-		while (this.queue.length > 0) {
-			const fn = this.queue.shift()
-			if (fn) await fn()
+	abort(): void {
+		this.pendingQueue = []
+		this.executionTimesMs = []
+		if (this.timeoutId) {
+			clearTimeout(this.timeoutId)
+			this.timeoutId = null
 		}
+	}
+
+	get queueSize(): number {
+		return this.pendingQueue.length
+	}
+
+	get isPaused(): boolean {
+		return this._isPaused
+	}
+
+	get rate(): number {
+		return this._rate
 	}
 }
 
-export const createRateLimiter = (rate: number): RateLimiter => new RateLimiterImpl(rate)
+export const createRateLimiter = (rate: number) => new RateLimiterImpl(rate)

--- a/src/scanners/common/RetryStrategy.ts
+++ b/src/scanners/common/RetryStrategy.ts
@@ -1,0 +1,28 @@
+export interface RetryOptions {
+	maxRetries: number
+	initialDelay: number
+	maxDelay: number
+	backoffFactor: number
+}
+
+export abstract class RetryStrategy {
+	constructor(protected options: RetryOptions) {}
+
+	abstract shouldRetry(error: any): boolean
+
+	async retry<T>(fn: () => Promise<T>, retryCount: number = 0): Promise<T> {
+		try {
+			return await fn()
+		} catch (error) {
+			if (retryCount < this.options.maxRetries && this.shouldRetry(error)) {
+				const delay = Math.min(
+					this.options.initialDelay * Math.pow(this.options.backoffFactor, retryCount),
+					this.options.maxDelay,
+				)
+				await new Promise((resolve) => setTimeout(resolve, delay))
+				return this.retry(fn, retryCount + 1)
+			}
+			throw error
+		}
+	}
+}

--- a/src/scanners/common/createGlobalScanner.ts
+++ b/src/scanners/common/createGlobalScanner.ts
@@ -1,6 +1,12 @@
-import {Resources, ResourceDescription, GlobalScanFunction, Credentials, ScannerLifecycleHook} from '@/types'
+import {
+	Resources,
+	ResourceDescription,
+	GlobalScanFunction,
+	Credentials,
+	ScannerLifecycleHook,
+	RateLimiter,
+} from '@/types'
 import {CreateGlobalScannerFunction, GetRateLimiterFunction} from '@/scanners/types'
-import {RateLimiter} from './RateLimiter'
 
 type GlobalScanResult<T extends ResourceDescription> = {
 	resources: Resources<T>

--- a/src/scanners/common/createRegionalScanner.ts
+++ b/src/scanners/common/createRegionalScanner.ts
@@ -5,9 +5,9 @@ import {
 	RegionalScanFunction,
 	Credentials,
 	ScannerLifecycleHook,
+	RateLimiter,
 } from '@/types'
 import {CreateRegionalScannerFunction, GetRateLimiterFunction} from '@/scanners/types'
-import {RateLimiter} from './RateLimiter'
 
 type RegionScanResult<T extends ResourceDescription> = {
 	region: string

--- a/src/scanners/index.ts
+++ b/src/scanners/index.ts
@@ -1,4 +1,4 @@
-export {RateLimiter, createRateLimiter} from './common/RateLimiter'
+export {createRateLimiter} from './common/RateLimiter'
 export {createGlobalScanner} from './common/createGlobalScanner'
 export {createRegionalScanner} from './common/createRegionalScanner'
 export {getAwsScanners} from './getAwsScanners'

--- a/src/scanners/scan-functions/aws/_boilerplate.ts
+++ b/src/scanners/scan-functions/aws/_boilerplate.ts
@@ -1,6 +1,5 @@
 import {DBInstance} from '@aws-sdk/client-rds'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 /**
  * 0️⃣ I put DBInstance just as an example of a real aws type.

--- a/src/scanners/scan-functions/aws/athena-named-queries.ts
+++ b/src/scanners/scan-functions/aws/athena-named-queries.ts
@@ -1,6 +1,5 @@
 import {AthenaClient, ListNamedQueriesCommand, GetNamedQueryCommand, NamedQuery} from '@aws-sdk/client-athena'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 import {buildARN} from './common/buildArn'
 import {getAwsAccountId} from './common/getAwsAccountId'
 

--- a/src/scanners/scan-functions/aws/autoscaling-groups.ts
+++ b/src/scanners/scan-functions/aws/autoscaling-groups.ts
@@ -1,6 +1,5 @@
 import {AutoScalingClient, DescribeAutoScalingGroupsCommand, AutoScalingGroup} from '@aws-sdk/client-auto-scaling'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 async function getAutoScalingGroups(
 	credentials: Credentials,

--- a/src/scanners/scan-functions/aws/cloudfront-distributions.ts
+++ b/src/scanners/scan-functions/aws/cloudfront-distributions.ts
@@ -1,6 +1,5 @@
 import {CloudFrontClient, ListDistributionsCommand, DistributionSummary} from '@aws-sdk/client-cloudfront'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 export async function getCloudFrontDistributions(
 	credentials: Credentials,

--- a/src/scanners/scan-functions/aws/cloudtrail-trails.ts
+++ b/src/scanners/scan-functions/aws/cloudtrail-trails.ts
@@ -1,6 +1,5 @@
 import {CloudTrailClient, ListTrailsCommand, ListTrailsCommandOutput, TrailInfo} from '@aws-sdk/client-cloudtrail'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 export async function getCloudTrailTrails(
 	credentials: Credentials,

--- a/src/scanners/scan-functions/aws/cloudwatch-metric-alarms.ts
+++ b/src/scanners/scan-functions/aws/cloudwatch-metric-alarms.ts
@@ -1,6 +1,5 @@
 import {CloudWatchClient, DescribeAlarmsCommand, MetricAlarm} from '@aws-sdk/client-cloudwatch'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
-import {Credentials, Resources} from '@/types'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 export async function getCloudWatchMetricAlarms(
 	credentials: Credentials,

--- a/src/scanners/scan-functions/aws/cloudwatch-metric-streams.ts
+++ b/src/scanners/scan-functions/aws/cloudwatch-metric-streams.ts
@@ -1,6 +1,5 @@
 import {CloudWatchClient, ListMetricStreamsCommand, MetricStreamEntry} from '@aws-sdk/client-cloudwatch'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
-import {Credentials, Resources} from '@/types'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 export async function getCloudWatchMetricStreams(
 	credentials: Credentials,

--- a/src/scanners/scan-functions/aws/dynamodb-tables.ts
+++ b/src/scanners/scan-functions/aws/dynamodb-tables.ts
@@ -1,6 +1,5 @@
 import {DynamoDBClient, ListTablesCommand, DescribeTableCommand, TableDescription} from '@aws-sdk/client-dynamodb'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 export async function getDynamoDBTables(
 	credentials: Credentials,

--- a/src/scanners/scan-functions/aws/ec2-instances.ts
+++ b/src/scanners/scan-functions/aws/ec2-instances.ts
@@ -1,7 +1,6 @@
 import {EC2Client, DescribeInstancesCommand, Instance} from '@aws-sdk/client-ec2'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
 import {buildARN} from './common/buildArn'
-import {Credentials, Resources} from '@/types'
+import {Credentials, Resources, RateLimiter} from '@/types'
 import {getAwsAccountId} from './common/getAwsAccountId'
 
 export async function getEC2Instances(

--- a/src/scanners/scan-functions/aws/ec2-internet-gateways.ts
+++ b/src/scanners/scan-functions/aws/ec2-internet-gateways.ts
@@ -1,7 +1,6 @@
 import {EC2Client, DescribeInternetGatewaysCommand, InternetGateway} from '@aws-sdk/client-ec2'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
 import {buildARN} from './common/buildArn'
-import {Credentials, Resources} from '@/types'
+import {Credentials, Resources, RateLimiter} from '@/types'
 import {getAwsAccountId} from './common/getAwsAccountId'
 
 export async function getEC2InternetGateways(

--- a/src/scanners/scan-functions/aws/ec2-nat-gateways.ts
+++ b/src/scanners/scan-functions/aws/ec2-nat-gateways.ts
@@ -1,7 +1,6 @@
 import {EC2Client, DescribeNatGatewaysCommand, NatGateway} from '@aws-sdk/client-ec2'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
 import {buildARN} from './common/buildArn'
-import {Credentials, Resources} from '@/types'
+import {Credentials, Resources, RateLimiter} from '@/types'
 import {getAwsAccountId} from './common/getAwsAccountId'
 
 export async function getEC2NatGateways(

--- a/src/scanners/scan-functions/aws/ec2-network-acls.ts
+++ b/src/scanners/scan-functions/aws/ec2-network-acls.ts
@@ -1,7 +1,6 @@
 import {EC2Client, DescribeNetworkAclsCommand, NetworkAcl} from '@aws-sdk/client-ec2'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
 import {buildARN} from './common/buildArn'
-import {Credentials, Resources} from '@/types'
+import {Credentials, Resources, RateLimiter} from '@/types'
 import {getAwsAccountId} from './common/getAwsAccountId'
 
 export async function getEC2NetworkAcls(

--- a/src/scanners/scan-functions/aws/ec2-network-interfaces.ts
+++ b/src/scanners/scan-functions/aws/ec2-network-interfaces.ts
@@ -1,6 +1,5 @@
 import {EC2Client, DescribeNetworkInterfacesCommand, NetworkInterface} from '@aws-sdk/client-ec2'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
-import {Credentials, Resources} from '@/types'
+import {Credentials, Resources, RateLimiter} from '@/types'
 import {buildARN} from './common/buildArn'
 import {getAwsAccountId} from './common/getAwsAccountId'
 

--- a/src/scanners/scan-functions/aws/ec2-route-tables.ts
+++ b/src/scanners/scan-functions/aws/ec2-route-tables.ts
@@ -1,7 +1,6 @@
 import {EC2Client, DescribeRouteTablesCommand, RouteTable} from '@aws-sdk/client-ec2'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
 import {buildARN} from './common/buildArn'
-import {Credentials, Resources} from '@/types'
+import {Credentials, Resources, RateLimiter} from '@/types'
 import {getAwsAccountId} from './common/getAwsAccountId'
 
 export async function getEC2RouteTables(

--- a/src/scanners/scan-functions/aws/ec2-subnets.ts
+++ b/src/scanners/scan-functions/aws/ec2-subnets.ts
@@ -1,7 +1,6 @@
 import {EC2Client, DescribeSubnetsCommand, Subnet} from '@aws-sdk/client-ec2'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
 import {buildARN} from './common/buildArn'
-import {Credentials, Resources} from '@/types'
+import {Credentials, Resources, RateLimiter} from '@/types'
 import {getAwsAccountId} from './common/getAwsAccountId'
 
 export async function getEC2Subnets(

--- a/src/scanners/scan-functions/aws/ec2-transit-gateways.ts
+++ b/src/scanners/scan-functions/aws/ec2-transit-gateways.ts
@@ -1,7 +1,6 @@
 import {EC2Client, DescribeTransitGatewaysCommand, TransitGateway} from '@aws-sdk/client-ec2'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
 import {buildARN} from './common/buildArn'
-import {Credentials, Resources} from '@/types'
+import {Credentials, Resources, RateLimiter} from '@/types'
 import {getAwsAccountId} from './common/getAwsAccountId'
 
 export async function getEC2TransitGateways(

--- a/src/scanners/scan-functions/aws/ec2-volumes.ts
+++ b/src/scanners/scan-functions/aws/ec2-volumes.ts
@@ -1,7 +1,6 @@
 import {EC2Client, DescribeVolumesCommand, Volume} from '@aws-sdk/client-ec2'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
 import {buildARN} from './common/buildArn'
-import {Credentials, Resources} from '@/types'
+import {Credentials, Resources, RateLimiter} from '@/types'
 import {getAwsAccountId} from './common/getAwsAccountId'
 
 export async function getEC2Volumes(

--- a/src/scanners/scan-functions/aws/ec2-vpc-endpoints.ts
+++ b/src/scanners/scan-functions/aws/ec2-vpc-endpoints.ts
@@ -1,7 +1,6 @@
 import {EC2Client, DescribeVpcEndpointsCommand, VpcEndpoint} from '@aws-sdk/client-ec2'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
 import {buildARN} from './common/buildArn'
-import {Credentials, Resources} from '@/types'
+import {Credentials, Resources, RateLimiter} from '@/types'
 import {getAwsAccountId} from './common/getAwsAccountId'
 
 export async function getEC2VpcEndpoints(

--- a/src/scanners/scan-functions/aws/ec2-vpcs.ts
+++ b/src/scanners/scan-functions/aws/ec2-vpcs.ts
@@ -1,7 +1,6 @@
 import {EC2Client, DescribeVpcsCommand, Vpc} from '@aws-sdk/client-ec2'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
 import {buildARN} from './common/buildArn'
-import {Credentials, Resources} from '@/types'
+import {Credentials, Resources, RateLimiter} from '@/types'
 import {getAwsAccountId} from './common/getAwsAccountId'
 
 export async function getEC2Vpcs(

--- a/src/scanners/scan-functions/aws/ec2-vpn-gateways.ts
+++ b/src/scanners/scan-functions/aws/ec2-vpn-gateways.ts
@@ -1,6 +1,5 @@
 import {EC2Client, DescribeVpnGatewaysCommand, VpnGateway} from '@aws-sdk/client-ec2'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
-import {Credentials, Resources} from '@/types'
+import {Credentials, Resources, RateLimiter} from '@/types'
 import {getAwsAccountId} from './common/getAwsAccountId'
 import {buildARN} from './common/buildArn'
 

--- a/src/scanners/scan-functions/aws/ecs.ts
+++ b/src/scanners/scan-functions/aws/ecs.ts
@@ -10,8 +10,7 @@ import {
 	Service,
 	Task,
 } from '@aws-sdk/client-ecs'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 async function getECSClusters(client: ECSClient, rateLimiter: RateLimiter): Promise<Cluster[]> {
 	const listClustersCommand = new ListClustersCommand({})

--- a/src/scanners/scan-functions/aws/efs-file-systems.ts
+++ b/src/scanners/scan-functions/aws/efs-file-systems.ts
@@ -1,6 +1,5 @@
 import {EFSClient, DescribeFileSystemsCommand, FileSystemDescription} from '@aws-sdk/client-efs'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 export async function getEFSFileSystems(
 	credentials: Credentials,

--- a/src/scanners/scan-functions/aws/eks-clusters.ts
+++ b/src/scanners/scan-functions/aws/eks-clusters.ts
@@ -1,6 +1,5 @@
 import {EKSClient, ListClustersCommand, DescribeClusterCommand, Cluster} from '@aws-sdk/client-eks'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 export async function getEKSClusters(
 	credentials: Credentials,

--- a/src/scanners/scan-functions/aws/elasticache-clusters.ts
+++ b/src/scanners/scan-functions/aws/elasticache-clusters.ts
@@ -1,6 +1,5 @@
 import {ElastiCacheClient, DescribeCacheClustersCommand, CacheCluster} from '@aws-sdk/client-elasticache'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 export async function getElastiCacheClusters(
 	credentials: Credentials,

--- a/src/scanners/scan-functions/aws/elbv1-load-balancers.ts
+++ b/src/scanners/scan-functions/aws/elbv1-load-balancers.ts
@@ -3,8 +3,7 @@ import {
 	DescribeLoadBalancersCommand,
 	LoadBalancerDescription,
 } from '@aws-sdk/client-elastic-load-balancing'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 import {getAwsAccountId} from './common/getAwsAccountId'
 
 export async function getELBv1LoadBalancers(

--- a/src/scanners/scan-functions/aws/elbv2-load-balancers.ts
+++ b/src/scanners/scan-functions/aws/elbv2-load-balancers.ts
@@ -3,8 +3,7 @@ import {
 	DescribeLoadBalancersCommand,
 	LoadBalancer,
 } from '@aws-sdk/client-elastic-load-balancing-v2'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 export async function getELBv2LoadBalancers(
 	credentials: Credentials,

--- a/src/scanners/scan-functions/aws/elbv2-target-groups.ts
+++ b/src/scanners/scan-functions/aws/elbv2-target-groups.ts
@@ -3,8 +3,7 @@ import {
 	DescribeTargetGroupsCommand,
 	TargetGroup,
 } from '@aws-sdk/client-elastic-load-balancing-v2'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
-import {Credentials, Resources} from '@/types'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 export async function getELBv2TargetGroups(
 	credentials: Credentials,

--- a/src/scanners/scan-functions/aws/lambda-functions.ts
+++ b/src/scanners/scan-functions/aws/lambda-functions.ts
@@ -1,6 +1,5 @@
 import {LambdaClient, ListFunctionsCommand, GetFunctionCommand, FunctionConfiguration} from '@aws-sdk/client-lambda'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 export async function getLambdaFunctions(
 	credentials: Credentials,

--- a/src/scanners/scan-functions/aws/rds-clusters.ts
+++ b/src/scanners/scan-functions/aws/rds-clusters.ts
@@ -1,6 +1,5 @@
 import {RDSClient, DescribeDBClustersCommand, DBCluster} from '@aws-sdk/client-rds'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 export async function getRDSClusters(
 	credentials: Credentials,

--- a/src/scanners/scan-functions/aws/rds-instances.ts
+++ b/src/scanners/scan-functions/aws/rds-instances.ts
@@ -1,6 +1,5 @@
 import {RDSClient, DescribeDBInstancesCommand, DBInstance} from '@aws-sdk/client-rds'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 export async function getRDSInstances(
 	credentials: Credentials,

--- a/src/scanners/scan-functions/aws/rds-proxies.ts
+++ b/src/scanners/scan-functions/aws/rds-proxies.ts
@@ -1,6 +1,5 @@
 import {RDSClient, DescribeDBProxiesCommand, DBProxy} from '@aws-sdk/client-rds'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 export async function getRDSProxies(
 	credentials: Credentials,

--- a/src/scanners/scan-functions/aws/redshift-clusters.ts
+++ b/src/scanners/scan-functions/aws/redshift-clusters.ts
@@ -1,7 +1,6 @@
 import {RedshiftClient, DescribeClustersCommand, Cluster} from '@aws-sdk/client-redshift'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
 import {buildARN} from './common/buildArn'
-import {Credentials, Resources} from '@/types'
+import {Credentials, Resources, RateLimiter} from '@/types'
 import {getAwsAccountId} from './common/getAwsAccountId'
 
 export async function getRedshiftClusters(

--- a/src/scanners/scan-functions/aws/route53-hosted-zones.ts
+++ b/src/scanners/scan-functions/aws/route53-hosted-zones.ts
@@ -1,6 +1,5 @@
 import {Route53Client, ListHostedZonesCommand, GetHostedZoneCommand, HostedZone} from '@aws-sdk/client-route-53'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 import {buildARN} from './common/buildArn'
 import {getAwsAccountId} from './common/getAwsAccountId'
 

--- a/src/scanners/scan-functions/aws/s3-buckets.ts
+++ b/src/scanners/scan-functions/aws/s3-buckets.ts
@@ -1,6 +1,5 @@
-import {S3Client, ListBucketsCommand, GetBucketLocationCommand, Bucket} from '@aws-sdk/client-s3'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {S3Client, ListBucketsCommand, Bucket} from '@aws-sdk/client-s3'
+import {Credentials, Resources, RateLimiter} from '@/types'
 import {buildARN} from './common/buildArn'
 import {getAwsAccountId} from './common/getAwsAccountId'
 

--- a/src/scanners/scan-functions/aws/sns-topics.ts
+++ b/src/scanners/scan-functions/aws/sns-topics.ts
@@ -1,6 +1,5 @@
 import {ListTopicsCommand, SNSClient, Topic} from '@aws-sdk/client-sns'
-import {Credentials, Resources} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {Credentials, Resources, RateLimiter} from '@/types'
 
 export async function getSNSTopics(
 	credentials: Credentials,

--- a/src/scanners/scan-functions/aws/sqs-queues.ts
+++ b/src/scanners/scan-functions/aws/sqs-queues.ts
@@ -1,11 +1,5 @@
-import {
-	SQSClient,
-	ListQueuesCommand,
-	GetQueueAttributesCommand,
-	GetQueueAttributesCommandOutput,
-} from '@aws-sdk/client-sqs'
-import {Credentials, Resources, SQSQueue} from '@/types'
-import {RateLimiter} from '@/scanners/common/RateLimiter'
+import {SQSClient, ListQueuesCommand, GetQueueAttributesCommand} from '@aws-sdk/client-sqs'
+import {Credentials, Resources, SQSQueue, RateLimiter} from '@/types'
 
 export async function getSQSQueues(
 	credentials: Credentials,

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,6 @@ import type * as Redshift from '@aws-sdk/client-redshift'
 import type * as CloudWatch from '@aws-sdk/client-cloudwatch'
 import type * as Athena from '@aws-sdk/client-athena'
 
-import type {RateLimiter} from './scanners/common/RateLimiter'
 import type {AwsCredentialIdentity} from '@aws-sdk/types'
 import {awsRegionIds} from './constants'
 
@@ -71,6 +70,16 @@ export type Resources<T extends ResourceDescription = ResourceDescription> = {
 }
 
 export type Credentials = AwsCredentialIdentity | undefined
+
+export interface RateLimiter {
+	throttle<U>(fn: () => Promise<U>): Promise<U>
+	pause(): void
+	resume(): void
+	abort(): void
+	readonly queueSize: number
+	readonly isPaused: boolean
+	readonly rate: number
+}
 
 export type RegionalScanFunction<T extends ResourceDescription> = (
 	credentials: Credentials,

--- a/tests/aws-app/config/getConfigViaGui.test.ts
+++ b/tests/aws-app/config/getConfigViaGui.test.ts
@@ -7,7 +7,7 @@ describe('getConfigViaGui', () => {
 	const defaultConfigResponse = {
 		output: 'dummyOutputName',
 		regions: undefined,
-		profile: 'default',
+		profile: expect.any(String),
 		regionalOnly: false,
 		callRate: 10,
 		compressed: false,

--- a/tests/aws-app/utils/createRateLimiterFactory.test.ts
+++ b/tests/aws-app/utils/createRateLimiterFactory.test.ts
@@ -1,4 +1,5 @@
 import {createRateLimiterFactory} from '@/aws-app/utils/createRateLimiterFactory'
+import {AWSRateLimitExhaustionRetryStrategy} from '@/lib'
 import {createRateLimiter} from '@/scanners'
 
 jest.mock('@/scanners', () => ({
@@ -8,10 +9,11 @@ jest.mock('@/scanners', () => ({
 }))
 
 describe('createRateLimiterFactory', () => {
+	const retryStrategy = new AWSRateLimitExhaustionRetryStrategy()
 	let getRateLimiter: ReturnType<typeof createRateLimiterFactory>
 
 	beforeEach(() => {
-		getRateLimiter = createRateLimiterFactory(10)
+		getRateLimiter = createRateLimiterFactory(10, retryStrategy)
 	})
 
 	afterEach(() => {
@@ -23,7 +25,7 @@ describe('createRateLimiterFactory', () => {
 		const region = 'us-east-1'
 		const rateLimiter = getRateLimiter(service, region)
 
-		expect(createRateLimiter).toHaveBeenCalledWith(10)
+		expect(createRateLimiter).toHaveBeenCalledWith(10, retryStrategy)
 		expect(rateLimiter).toBeDefined()
 	})
 

--- a/tests/mocks/RateLimiterMock.ts
+++ b/tests/mocks/RateLimiterMock.ts
@@ -1,7 +1,47 @@
-import {RateLimiter} from '@/scanners'
+import {RateLimiter} from '@/types'
 
 export class RateLimiterMockImpl implements RateLimiter {
+	private _isPaused: boolean = false
+	private _queueSize: number = 0
+	private _rate: number = 0
+
+	constructor(rate: number = 0) {
+		this._rate = rate
+	}
+
 	async throttle<T>(callback: () => Promise<T>): Promise<T> {
-		return callback()
+		if (this._isPaused) {
+			throw new Error('RateLimiter is paused')
+		}
+		this._queueSize++
+		try {
+			return await callback()
+		} finally {
+			this._queueSize--
+		}
+	}
+
+	pause(): void {
+		this._isPaused = true
+	}
+
+	resume(): void {
+		this._isPaused = false
+	}
+
+	abort(): void {
+		this._queueSize = 0
+	}
+
+	get queueSize(): number {
+		return this._queueSize
+	}
+
+	get isPaused(): boolean {
+		return this._isPaused
+	}
+
+	get rate(): number {
+		return this._rate
 	}
 }


### PR DESCRIPTION
This PR involves several changes:
- the overall rate-limiting functionality should work
- switched our rate-limiting approach from windowed throttling to strict throttling. Instead of counting how many requests fit within a specific time frame, we now enforce strict time gaps between requests.
- rate-limiter now accepts `pause`, `resume` and `abort` which could be later used for more advanced functionalities
- a new concept called `RetryStrategy` is defined in which you can define when to retry and how to retry
- an AWSRateLimitExhaustionRetryStrategy added based on RetryStrategy abstract and used in CLI app. also exposed via the lib