### PR TITLE
Group `@aws-sdk/*` package updates into single dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    groups:
+      aws-sdk:
+        patterns:
+          - '@aws-sdk/*'


### PR DESCRIPTION
This PR groups the frequent AWS SDK package updates into one PR instead of multiple separate ones. This approach simplifies package dependency management.

How Dependabot updates look at this moment:

<img width="1000" alt="" src="https://github.com/user-attachments/assets/e57f45d5-4b74-4797-91c4-7bd70a773146">
