### PR TITLE
Multiple small fixes related to JSON Schema

### DIFF
--- a/.github/workflows/json-schema-validation.yml
+++ b/.github/workflows/json-schema-validation.yml
@@ -24,4 +24,4 @@ jobs:
         run: npm ci
 
       - name: Run schema validate
-        run: npm run validate-json-schema
+        run: npm run json-schema:validate

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
 		"dev:setup": "npm install && npm run build && npm link",
 		"dev": "ts-node -r tsconfig-paths/register src/cli.ts",
 		"changeset": "changeset",
-		"generate-json-schema": "ts-node scripts/generate-json-schema.ts",
-		"validate-json-schema": "ts-node scripts/validate-json-schema.ts"
+		"json-schema:generate": "npm install && ts-node scripts/generate-json-schema.ts",
+		"json-schema:validate": "ts-node scripts/validate-json-schema.ts"
 	},
 	"license": "MIT",
 	"devDependencies": {

--- a/schemas/miro-cloudview-aws-latest.json
+++ b/schemas/miro-cloudview-aws-latest.json
@@ -1,1 +1,13194 @@
-miro-cloudview-aws-v0.1.1.json
+{
+  "description": "Miro's Standard Schema for AWS resources.",
+  "type": "object",
+  "properties": {
+    "provider": {
+      "type": "string",
+      "const": "aws"
+    },
+    "docVersion": {
+      "type": "string",
+      "const": "0.1.1"
+    },
+    "resources": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/AutoScalingGroup"
+        },
+        {
+          "$ref": "#/definitions/TrailInfo"
+        },
+        {
+          "$ref": "#/definitions/TableDescription"
+        },
+        {
+          "$ref": "#/definitions/Volume"
+        },
+        {
+          "$ref": "#/definitions/Subnet"
+        },
+        {
+          "$ref": "#/definitions/Vpc"
+        },
+        {
+          "$ref": "#/definitions/InternetGateway"
+        },
+        {
+          "$ref": "#/definitions/NatGateway"
+        },
+        {
+          "$ref": "#/definitions/NetworkAcl"
+        },
+        {
+          "$ref": "#/definitions/NetworkInterface"
+        },
+        {
+          "$ref": "#/definitions/RouteTable"
+        },
+        {
+          "$ref": "#/definitions/TransitGateway"
+        },
+        {
+          "$ref": "#/definitions/VpcEndpoint"
+        },
+        {
+          "$ref": "#/definitions/VpnGateway"
+        },
+        {
+          "$ref": "#/definitions/Instance_1"
+        },
+        {
+          "$ref": "#/definitions/FunctionConfiguration"
+        },
+        {
+          "$ref": "#/definitions/DBCluster"
+        },
+        {
+          "$ref": "#/definitions/DBInstance"
+        },
+        {
+          "$ref": "#/definitions/DBProxy"
+        },
+        {
+          "$ref": "#/definitions/Cluster"
+        },
+        {
+          "$ref": "#/definitions/Service"
+        },
+        {
+          "$ref": "#/definitions/Task"
+        },
+        {
+          "$ref": "#/definitions/Cluster_1"
+        },
+        {
+          "$ref": "#/definitions/Topic"
+        },
+        {
+          "$ref": "#/definitions/LoadBalancer_1"
+        },
+        {
+          "$ref": "#/definitions/TargetGroup"
+        },
+        {
+          "$ref": "#/definitions/LoadBalancerDescription"
+        },
+        {
+          "$ref": "#/definitions/DistributionSummary"
+        },
+        {
+          "$ref": "#/definitions/FileSystemDescription"
+        },
+        {
+          "$ref": "#/definitions/Partial<Record<QueueAttributeName,string>>"
+        },
+        {
+          "$ref": "#/definitions/CacheCluster"
+        },
+        {
+          "$ref": "#/definitions/Cluster_2"
+        },
+        {
+          "$ref": "#/definitions/MetricAlarm"
+        },
+        {
+          "$ref": "#/definitions/MetricStreamEntry"
+        },
+        {
+          "$ref": "#/definitions/NamedQuery"
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/definitions/HostedZone"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "Account": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "Account"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Bucket"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "Account": {
+                  "type": "string"
+                },
+                "Location": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "Account",
+                "Location"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "tags": {
+      "$ref": "#/definitions/AwsTags"
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "service": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message",
+          "service"
+        ]
+      }
+    },
+    "metadata": {
+      "$ref": "#/definitions/AwsScanJobMetadata"
+    }
+  },
+  "required": [
+    "docVersion",
+    "errors",
+    "provider",
+    "resources",
+    "tags"
+  ],
+  "definitions": {
+    "AutoScalingGroup": {
+      "description": "<p>Describes an Auto Scaling group.</p>",
+      "type": "object",
+      "properties": {
+        "AutoScalingGroupName": {
+          "description": "<p>The name of the Auto Scaling group.</p>",
+          "type": "string"
+        },
+        "AutoScalingGroupARN": {
+          "description": "<p>The Amazon Resource Name (ARN) of the Auto Scaling group.</p>",
+          "type": "string"
+        },
+        "LaunchConfigurationName": {
+          "description": "<p>The name of the associated launch configuration.</p>",
+          "type": "string"
+        },
+        "LaunchTemplate": {
+          "description": "<p>The launch template for the group.</p>",
+          "$ref": "#/definitions/LaunchTemplateSpecification"
+        },
+        "MixedInstancesPolicy": {
+          "description": "<p>The mixed instances policy for the group.</p>",
+          "$ref": "#/definitions/MixedInstancesPolicy"
+        },
+        "MinSize": {
+          "description": "<p>The minimum size of the group.</p>",
+          "type": "number"
+        },
+        "MaxSize": {
+          "description": "<p>The maximum size of the group.</p>",
+          "type": "number"
+        },
+        "DesiredCapacity": {
+          "description": "<p>The desired size of the group.</p>",
+          "type": "number"
+        },
+        "PredictedCapacity": {
+          "description": "<p>The predicted capacity of the group when it has a predictive scaling policy.</p>",
+          "type": "number"
+        },
+        "DefaultCooldown": {
+          "description": "<p>The duration of the default cooldown period, in seconds.</p>",
+          "type": "number"
+        },
+        "AvailabilityZones": {
+          "description": "<p>One or more Availability Zones for the group.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "LoadBalancerNames": {
+          "description": "<p>One or more load balancers associated with the group.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TargetGroupARNs": {
+          "description": "<p>The Amazon Resource Names (ARN) of the target groups for your load balancer.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "HealthCheckType": {
+          "description": "<p>A comma-separated value string of one or more health check types.</p>",
+          "type": "string"
+        },
+        "HealthCheckGracePeriod": {
+          "description": "<p>The duration of the health check grace period, in seconds.</p>",
+          "type": "number"
+        },
+        "Instances": {
+          "description": "<p>The EC2 instances associated with the group.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Instance"
+          }
+        },
+        "CreatedTime": {
+          "description": "<p>The date and time the group was created.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "SuspendedProcesses": {
+          "description": "<p>The suspended processes associated with the group.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SuspendedProcess"
+          }
+        },
+        "PlacementGroup": {
+          "description": "<p>The name of the placement group into which to launch your instances, if any.</p>",
+          "type": "string"
+        },
+        "VPCZoneIdentifier": {
+          "description": "<p>One or more subnet IDs, if applicable, separated by commas.</p>",
+          "type": "string"
+        },
+        "EnabledMetrics": {
+          "description": "<p>The metrics enabled for the group.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EnabledMetric"
+          }
+        },
+        "Status": {
+          "description": "<p>The current state of the group when the <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_DeleteAutoScalingGroup.html\">DeleteAutoScalingGroup</a>\n            operation is in progress.</p>",
+          "type": "string"
+        },
+        "Tags": {
+          "description": "<p>The tags for the group.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TagDescription"
+          }
+        },
+        "TerminationPolicies": {
+          "description": "<p>The termination policies for the group.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "NewInstancesProtectedFromScaleIn": {
+          "description": "<p>Indicates whether newly launched instances are protected from termination by Amazon EC2 Auto Scaling\n            when scaling in.</p>",
+          "type": "boolean"
+        },
+        "ServiceLinkedRoleARN": {
+          "description": "<p>The Amazon Resource Name (ARN) of the service-linked role that the Auto Scaling group uses to\n            call other Amazon Web Services on your behalf.</p>",
+          "type": "string"
+        },
+        "MaxInstanceLifetime": {
+          "description": "<p>The maximum amount of time, in seconds, that an instance can be in service.</p>\n         <p>Valid Range: Minimum value of 0.</p>",
+          "type": "number"
+        },
+        "CapacityRebalance": {
+          "description": "<p>Indicates whether Capacity Rebalancing is enabled.</p>",
+          "type": "boolean"
+        },
+        "WarmPoolConfiguration": {
+          "description": "<p>The warm pool for the group.</p>",
+          "$ref": "#/definitions/WarmPoolConfiguration"
+        },
+        "WarmPoolSize": {
+          "description": "<p>The current size of the warm pool.</p>",
+          "type": "number"
+        },
+        "Context": {
+          "description": "<p>Reserved.</p>",
+          "type": "string"
+        },
+        "DesiredCapacityType": {
+          "description": "<p>The unit of measurement for the value specified for desired capacity. Amazon EC2 Auto Scaling\n            supports <code>DesiredCapacityType</code> for attribute-based instance type selection\n            only.</p>",
+          "type": "string"
+        },
+        "DefaultInstanceWarmup": {
+          "description": "<p>The duration of the default instance warmup, in seconds.</p>",
+          "type": "number"
+        },
+        "TrafficSources": {
+          "description": "<p>The traffic sources associated with this Auto Scaling group.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TrafficSourceIdentifier"
+          }
+        },
+        "InstanceMaintenancePolicy": {
+          "description": "<p>An instance maintenance policy.</p>",
+          "$ref": "#/definitions/InstanceMaintenancePolicy"
+        },
+        "AvailabilityZoneDistribution": {
+          "description": "<p>\n            The instance capacity distribution across Availability Zones.\n        </p>",
+          "$ref": "#/definitions/AvailabilityZoneDistribution"
+        }
+      },
+      "required": [
+        "AutoScalingGroupName",
+        "AvailabilityZones",
+        "CreatedTime",
+        "DefaultCooldown",
+        "DesiredCapacity",
+        "HealthCheckType",
+        "MaxSize",
+        "MinSize"
+      ]
+    },
+    "LaunchTemplateSpecification": {
+      "description": "<p>Describes the launch template and the version of the launch template that Amazon EC2 Auto Scaling\n            uses to launch Amazon EC2 instances. For more information about launch templates, see <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-templates.html\">Launch\n                templates</a> in the <i>Amazon EC2 Auto Scaling User Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "LaunchTemplateId": {
+          "description": "<p>The ID of the launch template. To get the template ID, use the Amazon EC2 <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeLaunchTemplates.html\">DescribeLaunchTemplates</a> API operation. New launch templates can be created\n            using the Amazon EC2 <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateLaunchTemplate.html\">CreateLaunchTemplate</a> API. </p>\n         <p>Conditional: You must specify either a <code>LaunchTemplateId</code> or a\n                <code>LaunchTemplateName</code>.</p>",
+          "type": "string"
+        },
+        "LaunchTemplateName": {
+          "description": "<p>The name of the launch template. To get the template name, use the Amazon EC2 <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeLaunchTemplates.html\">DescribeLaunchTemplates</a> API operation. New launch templates can be created\n            using the Amazon EC2 <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateLaunchTemplate.html\">CreateLaunchTemplate</a> API. </p>\n         <p>Conditional: You must specify either a <code>LaunchTemplateId</code> or a\n                <code>LaunchTemplateName</code>.</p>",
+          "type": "string"
+        },
+        "Version": {
+          "description": "<p>The version number, <code>$Latest</code>, or <code>$Default</code>. To get the version\n            number, use the Amazon EC2 <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeLaunchTemplateVersions.html\">DescribeLaunchTemplateVersions</a> API operation. New launch template versions\n            can be created using the Amazon EC2 <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateLaunchTemplateVersion.html\">CreateLaunchTemplateVersion</a> API. If the value is <code>$Latest</code>,\n            Amazon EC2 Auto Scaling selects the latest version of the launch template when launching instances. If\n            the value is <code>$Default</code>, Amazon EC2 Auto Scaling selects the default version of the launch\n            template when launching instances. The default value is <code>$Default</code>.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "MixedInstancesPolicy": {
+      "description": "<p>Use this structure to launch multiple instance types and On-Demand Instances and Spot\n            Instances within a single Auto Scaling group.</p>\n         <p>A mixed instances policy contains information that Amazon EC2 Auto Scaling can use to launch\n            instances and help optimize your costs. For more information, see <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-mixed-instances-groups.html\">Auto Scaling\n                groups with multiple instance types and purchase options</a> in the\n                <i>Amazon EC2 Auto Scaling User Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "LaunchTemplate": {
+          "description": "<p>One or more launch templates and the instance types (overrides) that are used to\n            launch EC2 instances to fulfill On-Demand and Spot capacities.</p>",
+          "$ref": "#/definitions/LaunchTemplate"
+        },
+        "InstancesDistribution": {
+          "description": "<p>The instances distribution.</p>",
+          "$ref": "#/definitions/InstancesDistribution"
+        }
+      }
+    },
+    "LaunchTemplate": {
+      "description": "<p>Use this structure to specify the launch templates and instance types (overrides) for\n            a mixed instances policy.</p>",
+      "type": "object",
+      "properties": {
+        "LaunchTemplateSpecification": {
+          "description": "<p>The launch template.</p>",
+          "$ref": "#/definitions/LaunchTemplateSpecification"
+        },
+        "Overrides": {
+          "description": "<p>Any properties that you specify override the same properties in the launch\n            template.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LaunchTemplateOverrides"
+          }
+        }
+      }
+    },
+    "LaunchTemplateOverrides": {
+      "description": "<p>Use this structure to let Amazon EC2 Auto Scaling do the following when the Auto Scaling group has a mixed\n            instances policy:</p>\n         <ul>\n            <li>\n               <p>Override the instance type that is specified in the launch template.</p>\n            </li>\n            <li>\n               <p>Use multiple instance types.</p>\n            </li>\n         </ul>\n         <p>Specify the instance types that you want, or define your instance requirements instead\n            and let Amazon EC2 Auto Scaling provision the available instance types that meet your requirements.\n            This can provide Amazon EC2 Auto Scaling with a larger selection of instance types to choose from when\n            fulfilling Spot and On-Demand capacities. You can view which instance types are matched\n            before you apply the instance requirements to your Auto Scaling group.</p>\n         <p>After you define your instance requirements, you don't have to keep updating these\n            settings to get new EC2 instance types automatically. Amazon EC2 Auto Scaling uses the instance\n            requirements of the Auto Scaling group to determine whether a new EC2 instance type can be\n            used.</p>",
+      "type": "object",
+      "properties": {
+        "InstanceType": {
+          "description": "<p>The instance type, such as <code>m3.xlarge</code>. You must specify an instance type\n            that is supported in your requested Region and Availability Zones. For more information,\n            see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html\">Instance types</a> in the <i>Amazon EC2 User Guide for Linux Instances</i>.</p>\n         <p>You can specify up to 40 instance types per Auto Scaling group.</p>",
+          "type": "string"
+        },
+        "WeightedCapacity": {
+          "description": "<p>If you provide a list of instance types to use, you can specify the number of capacity\n            units provided by each instance type in terms of virtual CPUs, memory, storage,\n            throughput, or other relative performance characteristic. When a Spot or On-Demand\n            Instance is launched, the capacity units count toward the desired capacity. Amazon EC2 Auto Scaling\n            launches instances until the desired capacity is totally fulfilled, even if this results\n            in an overage. For example, if there are two units remaining to fulfill capacity, and\n            Amazon EC2 Auto Scaling can only launch an instance with a <code>WeightedCapacity</code> of five units,\n            the instance is launched, and the desired capacity is exceeded by three units. For more\n            information, see <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-mixed-instances-groups-instance-weighting.html\">Configure an Auto Scaling group to use instance weights</a> in the\n                <i>Amazon EC2 Auto Scaling User Guide</i>. Value must be in the range of 1–999.</p>\n         <p>If you specify a value for <code>WeightedCapacity</code> for one instance type, you\n            must specify a value for <code>WeightedCapacity</code> for all of them.</p>\n         <important>\n            <p>Every Auto Scaling group has three size parameters (<code>DesiredCapacity</code>,\n                    <code>MaxSize</code>, and <code>MinSize</code>). Usually, you set these sizes\n                based on a specific number of instances. However, if you configure a mixed instances\n                policy that defines weights for the instance types, you must specify these sizes\n                with the same units that you use for weighting instances. </p>\n         </important>",
+          "type": "string"
+        },
+        "LaunchTemplateSpecification": {
+          "description": "<p>Provides a launch template for the specified instance type or set of instance\n            requirements. For example, some instance types might require a launch template with a\n            different AMI. If not provided, Amazon EC2 Auto Scaling uses the launch template that's specified in\n            the <code>LaunchTemplate</code> definition. For more information, see <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-mixed-instances-groups-launch-template-overrides.html\">Specifying a different launch template for an instance type</a> in the\n                <i>Amazon EC2 Auto Scaling User Guide</i>. </p>\n         <p>You can specify up to 20 launch templates per Auto Scaling group. The launch templates\n            specified in the overrides and in the <code>LaunchTemplate</code> definition count\n            towards this limit.</p>",
+          "$ref": "#/definitions/LaunchTemplateSpecification"
+        },
+        "InstanceRequirements": {
+          "description": "<p>The instance requirements. Amazon EC2 Auto Scaling uses your specified requirements to identify\n            instance types. Then, it uses your On-Demand and Spot allocation strategies to launch\n            instances from these instance types.</p>\n         <p>You can specify up to four separate sets of instance requirements per Auto Scaling group. This\n            is useful for provisioning instances from different Amazon Machine Images (AMIs) in the\n            same Auto Scaling group. To do this, create the AMIs and create a new launch template for each\n            AMI. Then, create a compatible set of instance requirements for each launch template.\n            </p>\n         <note>\n            <p>If you specify <code>InstanceRequirements</code>, you can't specify\n                    <code>InstanceType</code>.</p>\n         </note>",
+          "$ref": "#/definitions/InstanceRequirements"
+        }
+      }
+    },
+    "InstanceRequirements": {
+      "description": "<p>The attributes for the instance types for a mixed instances policy. Amazon EC2 Auto Scaling uses your\n            specified requirements to identify instance types. Then, it uses your On-Demand and Spot\n            allocation strategies to launch instances from these instance types.</p>\n         <p>When you specify multiple attributes, you get instance types that satisfy all of the\n            specified attributes. If you specify multiple values for an attribute, you get instance\n            types that satisfy any of the specified values.</p>\n         <p>To limit the list of instance types from which Amazon EC2 Auto Scaling can identify matching instance\n            types, you can use one of the following parameters, but not both in the same\n            request:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>AllowedInstanceTypes</code> - The instance types to include in the list.\n                    All other instance types are ignored, even if they match your specified\n                    attributes.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ExcludedInstanceTypes</code> - The instance types to exclude from the\n                    list, even if they match your specified attributes.</p>\n            </li>\n         </ul>\n         <note>\n            <p>You must specify <code>VCpuCount</code> and <code>MemoryMiB</code>. All other\n                attributes are optional. Any unspecified optional attribute is set to its\n                default.</p>\n         </note>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-mixed-instances-group-attribute-based-instance-type-selection.html\">Create a mixed instances group using attribute-based instance type\n                selection</a> in the <i>Amazon EC2 Auto Scaling User Guide</i>. For help determining\n            which instance types match your attributes before you apply them to your Auto Scaling group, see\n                <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-attribute-based-instance-type-selection.html#ec2fleet-get-instance-types-from-instance-requirements\">Preview instance types with specified attributes</a> in the\n                <i>Amazon EC2 User Guide for Linux Instances</i>.</p>",
+      "type": "object",
+      "properties": {
+        "VCpuCount": {
+          "description": "<p>The minimum and maximum number of vCPUs for an instance type.</p>",
+          "$ref": "#/definitions/VCpuCountRequest"
+        },
+        "MemoryMiB": {
+          "description": "<p>The minimum and maximum instance memory size for an instance type, in MiB.</p>",
+          "$ref": "#/definitions/MemoryMiBRequest"
+        },
+        "CpuManufacturers": {
+          "description": "<p>Lists which specific CPU manufacturers to include.</p>\n         <ul>\n            <li>\n               <p>For instance types with Intel CPUs, specify <code>intel</code>.</p>\n            </li>\n            <li>\n               <p>For instance types with AMD CPUs, specify <code>amd</code>.</p>\n            </li>\n            <li>\n               <p>For instance types with Amazon Web Services CPUs, specify\n                    <code>amazon-web-services</code>.</p>\n            </li>\n         </ul>\n         <note>\n            <p>Don't confuse the CPU hardware manufacturer with the CPU hardware architecture.\n                Instances will be launched with a compatible CPU architecture based on the Amazon\n                Machine Image (AMI) that you specify in your launch template. </p>\n         </note>\n         <p>Default: Any manufacturer</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CpuManufacturer"
+          }
+        },
+        "MemoryGiBPerVCpu": {
+          "description": "<p>The minimum and maximum amount of memory per vCPU for an instance type, in GiB.</p>\n         <p>Default: No minimum or maximum limits</p>",
+          "$ref": "#/definitions/MemoryGiBPerVCpuRequest"
+        },
+        "ExcludedInstanceTypes": {
+          "description": "<p>The instance types to exclude. You can use strings with one or more wild cards,\n            represented by an asterisk (<code>*</code>), to exclude an instance family, type, size,\n            or generation. The following are examples: <code>m5.8xlarge</code>, <code>c5*.*</code>,\n                <code>m5a.*</code>, <code>r*</code>, <code>*3*</code>. </p>\n         <p>For example, if you specify <code>c5*</code>, you are excluding the entire C5 instance\n            family, which includes all C5a and C5n instance types. If you specify\n            <code>m5a.*</code>, Amazon EC2 Auto Scaling will exclude all the M5a instance types, but not the M5n\n            instance types.</p>\n         <note>\n            <p>If you specify <code>ExcludedInstanceTypes</code>, you can't specify\n                    <code>AllowedInstanceTypes</code>.</p>\n         </note>\n         <p>Default: No excluded instance types</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "InstanceGenerations": {
+          "description": "<p>Indicates whether current or previous generation instance types are included.</p>\n         <ul>\n            <li>\n               <p>For current generation instance types, specify <code>current</code>. The\n                    current generation includes EC2 instance types currently recommended for use.\n                    This typically includes the latest two to three generations in each instance\n                    family. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html\">Instance types</a> in\n                    the <i>Amazon EC2 User Guide for Linux Instances</i>.</p>\n            </li>\n            <li>\n               <p>For previous generation instance types, specify <code>previous</code>.</p>\n            </li>\n         </ul>\n         <p>Default: Any current or previous generation</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InstanceGeneration"
+          }
+        },
+        "SpotMaxPricePercentageOverLowestPrice": {
+          "description": "<p>[Price protection] The price protection threshold for Spot Instances, as a percentage\n            higher than an identified Spot price. The identified Spot price is the price of the\n            lowest priced current generation C, M, or R instance type with your specified\n            attributes. If no current generation C, M, or R instance type matches your attributes,\n            then the identified price is from either the lowest priced current generation instance\n            types or, failing that, the lowest priced previous generation instance types that match\n            your attributes. When Amazon EC2 Auto Scaling selects instance types with your attributes, we will\n            exclude instance types whose price exceeds your specified threshold.</p>\n         <p>The parameter accepts an integer, which Amazon EC2 Auto Scaling interprets as a percentage. </p>\n         <p>If you set <code>DesiredCapacityType</code> to <code>vcpu</code> or\n                <code>memory-mib</code>, the price protection threshold is based on the per-vCPU or\n            per-memory price instead of the per instance price. </p>\n         <note>\n            <p>Only one of <code>SpotMaxPricePercentageOverLowestPrice</code> or\n                    <code>MaxSpotPriceAsPercentageOfOptimalOnDemandPrice</code> can be specified. If\n                you don't specify either, Amazon EC2 Auto Scaling will automatically apply optimal price protection\n                to consistently select from a wide range of instance types. To indicate no price\n                protection threshold for Spot Instances, meaning you want to consider all instance\n                types that match your attributes, include one of these parameters and specify a high\n                value, such as <code>999999</code>. </p>\n         </note>",
+          "type": "number"
+        },
+        "MaxSpotPriceAsPercentageOfOptimalOnDemandPrice": {
+          "description": "<p>[Price protection] The price protection threshold for Spot Instances, as a percentage\n            of an identified On-Demand price. The identified On-Demand price is the price of the\n            lowest priced current generation C, M, or R instance type with your specified\n            attributes. If no current generation C, M, or R instance type matches your attributes,\n            then the identified price is from either the lowest priced current generation instance\n            types or, failing that, the lowest priced previous generation instance types that match\n            your attributes. When Amazon EC2 Auto Scaling selects instance types with your attributes, we will\n            exclude instance types whose price exceeds your specified threshold.</p>\n         <p>The parameter accepts an integer, which Amazon EC2 Auto Scaling interprets as a percentage.</p>\n         <p>If you set <code>DesiredCapacityType</code> to <code>vcpu</code> or\n                <code>memory-mib</code>, the price protection threshold is based on the per-vCPU or\n            per-memory price instead of the per instance price. </p>\n         <note>\n            <p>Only one of <code>SpotMaxPricePercentageOverLowestPrice</code> or\n                    <code>MaxSpotPriceAsPercentageOfOptimalOnDemandPrice</code> can be specified. If\n                you don't specify either, Amazon EC2 Auto Scaling will automatically apply optimal price protection\n                to consistently select from a wide range of instance types. To indicate no price\n                protection threshold for Spot Instances, meaning you want to consider all instance\n                types that match your attributes, include one of these parameters and specify a high\n                value, such as <code>999999</code>. </p>\n         </note>",
+          "type": "number"
+        },
+        "OnDemandMaxPricePercentageOverLowestPrice": {
+          "description": "<p>[Price protection] The price protection threshold for On-Demand Instances, as a\n            percentage higher than an identified On-Demand price. The identified On-Demand price is\n            the price of the lowest priced current generation C, M, or R instance type with your\n            specified attributes. If no current generation C, M, or R instance type matches your\n            attributes, then the identified price is from either the lowest priced current\n            generation instance types or, failing that, the lowest priced previous generation\n            instance types that match your attributes. When Amazon EC2 Auto Scaling selects instance types with\n            your attributes, we will exclude instance types whose price exceeds your specified\n            threshold. </p>\n         <p>The parameter accepts an integer, which Amazon EC2 Auto Scaling interprets as a percentage.</p>\n         <p>To turn off price protection, specify a high value, such as <code>999999</code>. </p>\n         <p>If you set <code>DesiredCapacityType</code> to <code>vcpu</code> or\n                <code>memory-mib</code>, the price protection threshold is applied based on the\n            per-vCPU or per-memory price instead of the per instance price. </p>\n         <p>Default: <code>20</code>\n         </p>",
+          "type": "number"
+        },
+        "BareMetal": {
+          "enum": [
+            "excluded",
+            "included",
+            "required"
+          ],
+          "description": "<p>Indicates whether bare metal instance types are included, excluded, or\n            required.</p>\n         <p>Default: <code>excluded</code>\n         </p>",
+          "type": "string"
+        },
+        "BurstablePerformance": {
+          "enum": [
+            "excluded",
+            "included",
+            "required"
+          ],
+          "description": "<p>Indicates whether burstable performance instance types are included, excluded, or\n            required. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html\">Burstable\n                performance instances</a> in the <i>Amazon EC2 User Guide for Linux Instances</i>.</p>\n         <p>Default: <code>excluded</code>\n         </p>",
+          "type": "string"
+        },
+        "RequireHibernateSupport": {
+          "description": "<p>Indicates whether instance types must provide On-Demand Instance hibernation\n            support.</p>\n         <p>Default: <code>false</code>\n         </p>",
+          "type": "boolean"
+        },
+        "NetworkInterfaceCount": {
+          "description": "<p>The minimum and maximum number of network interfaces for an instance type.</p>\n         <p>Default: No minimum or maximum limits</p>",
+          "$ref": "#/definitions/NetworkInterfaceCountRequest"
+        },
+        "LocalStorage": {
+          "enum": [
+            "excluded",
+            "included",
+            "required"
+          ],
+          "description": "<p>Indicates whether instance types with instance store volumes are included, excluded,\n            or required. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html\">Amazon EC2 instance store</a> in\n            the <i>Amazon EC2 User Guide for Linux Instances</i>.</p>\n         <p>Default: <code>included</code>\n         </p>",
+          "type": "string"
+        },
+        "LocalStorageTypes": {
+          "description": "<p>Indicates the type of local storage that is required.</p>\n         <ul>\n            <li>\n               <p>For instance types with hard disk drive (HDD) storage, specify\n                        <code>hdd</code>.</p>\n            </li>\n            <li>\n               <p>For instance types with solid state drive (SSD) storage, specify\n                        <code>ssd</code>.</p>\n            </li>\n         </ul>\n         <p>Default: Any local storage type</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LocalStorageType"
+          }
+        },
+        "TotalLocalStorageGB": {
+          "description": "<p>The minimum and maximum total local storage size for an instance type, in GB.</p>\n         <p>Default: No minimum or maximum limits</p>",
+          "$ref": "#/definitions/TotalLocalStorageGBRequest"
+        },
+        "BaselineEbsBandwidthMbps": {
+          "description": "<p>The minimum and maximum baseline bandwidth performance for an instance type, in Mbps.\n            For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-optimized.html\">Amazon EBS–optimized instances</a>\n            in the <i>Amazon EC2 User Guide for Linux Instances</i>.</p>\n         <p>Default: No minimum or maximum limits</p>",
+          "$ref": "#/definitions/BaselineEbsBandwidthMbpsRequest"
+        },
+        "AcceleratorTypes": {
+          "description": "<p>Lists the accelerator types that must be on an instance type.</p>\n         <ul>\n            <li>\n               <p>For instance types with GPU accelerators, specify <code>gpu</code>.</p>\n            </li>\n            <li>\n               <p>For instance types with FPGA accelerators, specify <code>fpga</code>.</p>\n            </li>\n            <li>\n               <p>For instance types with inference accelerators, specify\n                    <code>inference</code>.</p>\n            </li>\n         </ul>\n         <p>Default: Any accelerator type</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AcceleratorType"
+          }
+        },
+        "AcceleratorCount": {
+          "description": "<p>The minimum and maximum number of accelerators (GPUs, FPGAs, or Amazon Web Services Inferentia\n            chips) for an instance type.</p>\n         <p>To exclude accelerator-enabled instance types, set <code>Max</code> to\n            <code>0</code>.</p>\n         <p>Default: No minimum or maximum limits</p>",
+          "$ref": "#/definitions/AcceleratorCountRequest"
+        },
+        "AcceleratorManufacturers": {
+          "description": "<p>Indicates whether instance types must have accelerators by specific\n            manufacturers.</p>\n         <ul>\n            <li>\n               <p>For instance types with NVIDIA devices, specify <code>nvidia</code>.</p>\n            </li>\n            <li>\n               <p>For instance types with AMD devices, specify <code>amd</code>.</p>\n            </li>\n            <li>\n               <p>For instance types with Amazon Web Services devices, specify\n                        <code>amazon-web-services</code>.</p>\n            </li>\n            <li>\n               <p>For instance types with Xilinx devices, specify <code>xilinx</code>.</p>\n            </li>\n         </ul>\n         <p>Default: Any manufacturer</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AcceleratorManufacturer"
+          }
+        },
+        "AcceleratorNames": {
+          "description": "<p>Lists the accelerators that must be on an instance type.</p>\n         <ul>\n            <li>\n               <p>For instance types with NVIDIA A100 GPUs, specify <code>a100</code>.</p>\n            </li>\n            <li>\n               <p>For instance types with NVIDIA V100 GPUs, specify <code>v100</code>.</p>\n            </li>\n            <li>\n               <p>For instance types with NVIDIA K80 GPUs, specify <code>k80</code>.</p>\n            </li>\n            <li>\n               <p>For instance types with NVIDIA T4 GPUs, specify <code>t4</code>.</p>\n            </li>\n            <li>\n               <p>For instance types with NVIDIA M60 GPUs, specify <code>m60</code>.</p>\n            </li>\n            <li>\n               <p>For instance types with AMD Radeon Pro V520 GPUs, specify\n                        <code>radeon-pro-v520</code>.</p>\n            </li>\n            <li>\n               <p>For instance types with Xilinx VU9P FPGAs, specify <code>vu9p</code>.</p>\n            </li>\n         </ul>\n         <p>Default: Any accelerator</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AcceleratorName"
+          }
+        },
+        "AcceleratorTotalMemoryMiB": {
+          "description": "<p>The minimum and maximum total memory size for the accelerators on an instance type, in\n            MiB.</p>\n         <p>Default: No minimum or maximum limits</p>",
+          "$ref": "#/definitions/AcceleratorTotalMemoryMiBRequest"
+        },
+        "NetworkBandwidthGbps": {
+          "description": "<p>The minimum and maximum amount of network bandwidth, in gigabits per second\n            (Gbps).</p>\n         <p>Default: No minimum or maximum limits</p>",
+          "$ref": "#/definitions/NetworkBandwidthGbpsRequest"
+        },
+        "AllowedInstanceTypes": {
+          "description": "<p>The instance types to apply your specified attributes against. All other instance\n            types are ignored, even if they match your specified attributes.</p>\n         <p>You can use strings with one or more wild cards, represented by an asterisk\n                (<code>*</code>), to allow an instance type, size, or generation. The following are\n            examples: <code>m5.8xlarge</code>, <code>c5*.*</code>, <code>m5a.*</code>,\n                <code>r*</code>, <code>*3*</code>.</p>\n         <p>For example, if you specify <code>c5*</code>, Amazon EC2 Auto Scaling will allow the entire C5\n            instance family, which includes all C5a and C5n instance types. If you specify\n                <code>m5a.*</code>, Amazon EC2 Auto Scaling will allow all the M5a instance types, but not the M5n\n            instance types.</p>\n         <note>\n            <p>If you specify <code>AllowedInstanceTypes</code>, you can't specify\n                    <code>ExcludedInstanceTypes</code>.</p>\n         </note>\n         <p>Default: All instance types</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "MemoryMiB",
+        "VCpuCount"
+      ]
+    },
+    "VCpuCountRequest": {
+      "description": "<p>Specifies the minimum and maximum for the <code>VCpuCount</code> object when you\n            specify <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstanceRequirements.html\">InstanceRequirements</a> for an Auto Scaling group.</p>",
+      "type": "object",
+      "properties": {
+        "Min": {
+          "description": "<p>The minimum number of vCPUs.</p>",
+          "type": "number"
+        },
+        "Max": {
+          "description": "<p>The maximum number of vCPUs.</p>",
+          "type": "number"
+        }
+      },
+      "required": [
+        "Min"
+      ]
+    },
+    "MemoryMiBRequest": {
+      "description": "<p>Specifies the minimum and maximum for the <code>MemoryMiB</code> object when you\n            specify <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstanceRequirements.html\">InstanceRequirements</a> for an Auto Scaling group.</p>",
+      "type": "object",
+      "properties": {
+        "Min": {
+          "description": "<p>The memory minimum in MiB.</p>",
+          "type": "number"
+        },
+        "Max": {
+          "description": "<p>The memory maximum in MiB.</p>",
+          "type": "number"
+        }
+      },
+      "required": [
+        "Min"
+      ]
+    },
+    "CpuManufacturer": {
+      "enum": [
+        "amazon-web-services",
+        "amd",
+        "intel"
+      ],
+      "type": "string"
+    },
+    "MemoryGiBPerVCpuRequest": {
+      "description": "<p>Specifies the minimum and maximum for the <code>MemoryGiBPerVCpu</code> object when\n            you specify <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstanceRequirements.html\">InstanceRequirements</a> for an Auto Scaling group.</p>",
+      "type": "object",
+      "properties": {
+        "Min": {
+          "description": "<p>The memory minimum in GiB.</p>",
+          "type": "number"
+        },
+        "Max": {
+          "description": "<p>The memory maximum in GiB.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "InstanceGeneration": {
+      "enum": [
+        "current",
+        "previous"
+      ],
+      "type": "string"
+    },
+    "NetworkInterfaceCountRequest": {
+      "description": "<p>Specifies the minimum and maximum for the <code>NetworkInterfaceCount</code> object\n            when you specify <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstanceRequirements.html\">InstanceRequirements</a> for an Auto Scaling group.</p>",
+      "type": "object",
+      "properties": {
+        "Min": {
+          "description": "<p>The minimum number of network interfaces.</p>",
+          "type": "number"
+        },
+        "Max": {
+          "description": "<p>The maximum number of network interfaces.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "LocalStorageType": {
+      "enum": [
+        "hdd",
+        "ssd"
+      ],
+      "type": "string"
+    },
+    "TotalLocalStorageGBRequest": {
+      "description": "<p>Specifies the minimum and maximum for the <code>TotalLocalStorageGB</code> object when\n            you specify <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstanceRequirements.html\">InstanceRequirements</a> for an Auto Scaling group.</p>",
+      "type": "object",
+      "properties": {
+        "Min": {
+          "description": "<p>The storage minimum in GB.</p>",
+          "type": "number"
+        },
+        "Max": {
+          "description": "<p>The storage maximum in GB.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "BaselineEbsBandwidthMbpsRequest": {
+      "description": "<p>Specifies the minimum and maximum for the <code>BaselineEbsBandwidthMbps</code> object\n            when you specify <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstanceRequirements.html\">InstanceRequirements</a> for an Auto Scaling group.</p>",
+      "type": "object",
+      "properties": {
+        "Min": {
+          "description": "<p>The minimum value in Mbps.</p>",
+          "type": "number"
+        },
+        "Max": {
+          "description": "<p>The maximum value in Mbps.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "AcceleratorType": {
+      "enum": [
+        "fpga",
+        "gpu",
+        "inference"
+      ],
+      "type": "string"
+    },
+    "AcceleratorCountRequest": {
+      "description": "<p>Specifies the minimum and maximum for the <code>AcceleratorCount</code> object when\n            you specify <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstanceRequirements.html\">InstanceRequirements</a> for an Auto Scaling group.</p>",
+      "type": "object",
+      "properties": {
+        "Min": {
+          "description": "<p>The minimum value.</p>",
+          "type": "number"
+        },
+        "Max": {
+          "description": "<p>The maximum value.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "AcceleratorManufacturer": {
+      "enum": [
+        "amazon-web-services",
+        "amd",
+        "nvidia",
+        "xilinx"
+      ],
+      "type": "string"
+    },
+    "AcceleratorName": {
+      "enum": [
+        "a100",
+        "k80",
+        "m60",
+        "radeon-pro-v520",
+        "t4",
+        "v100",
+        "vu9p"
+      ],
+      "type": "string"
+    },
+    "AcceleratorTotalMemoryMiBRequest": {
+      "description": "<p>Specifies the minimum and maximum for the <code>AcceleratorTotalMemoryMiB</code>\n            object when you specify <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstanceRequirements.html\">InstanceRequirements</a> for an Auto Scaling group.</p>",
+      "type": "object",
+      "properties": {
+        "Min": {
+          "description": "<p>The memory minimum in MiB.</p>",
+          "type": "number"
+        },
+        "Max": {
+          "description": "<p>The memory maximum in MiB.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "NetworkBandwidthGbpsRequest": {
+      "description": "<p>Specifies the minimum and maximum for the <code>NetworkBandwidthGbps</code> object\n            when you specify <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstanceRequirements.html\">InstanceRequirements</a> for an Auto Scaling group.</p>\n         <note>\n            <p>Setting the minimum bandwidth does not guarantee that your instance will achieve\n                the minimum bandwidth. Amazon EC2 will identify instance types that support the specified\n                minimum bandwidth, but the actual bandwidth of your instance might go below the\n                specified minimum at times. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-network-bandwidth.html#available-instance-bandwidth\">Available instance bandwidth</a> in the\n                <i>Amazon EC2 User Guide for Linux Instances</i>.</p>\n         </note>",
+      "type": "object",
+      "properties": {
+        "Min": {
+          "description": "<p>The minimum amount of network bandwidth, in gigabits per second (Gbps).</p>",
+          "type": "number"
+        },
+        "Max": {
+          "description": "<p>The maximum amount of network bandwidth, in gigabits per second (Gbps).</p>",
+          "type": "number"
+        }
+      }
+    },
+    "InstancesDistribution": {
+      "description": "<p>Use this structure to specify the distribution of On-Demand Instances and Spot\n            Instances and the allocation strategies used to fulfill On-Demand and Spot capacities\n            for a mixed instances policy.</p>",
+      "type": "object",
+      "properties": {
+        "OnDemandAllocationStrategy": {
+          "description": "<p>The allocation strategy to apply to your On-Demand Instances when they are launched.\n            Possible instance types are determined by the launch template overrides that you\n            specify.</p>\n         <p>The following lists the valid values:</p>\n         <dl>\n            <dt>lowest-price</dt>\n            <dd>\n               <p>Uses price to determine which instance types are the highest priority,\n                        launching the lowest priced instance types within an Availability Zone\n                        first. This is the default value for Auto Scaling groups that specify\n                        <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstanceRequirements.html\">InstanceRequirements</a>. </p>\n            </dd>\n            <dt>prioritized</dt>\n            <dd>\n               <p>You set the order of instance types for the launch template overrides from\n                        highest to lowest priority (from first to last in the list). Amazon EC2 Auto Scaling\n                        launches your highest priority instance types first. If all your On-Demand\n                        capacity cannot be fulfilled using your highest priority instance type, then\n                        Amazon EC2 Auto Scaling launches the remaining capacity using the second priority instance\n                        type, and so on. This is the default value for Auto Scaling groups that don't\n                        specify <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstanceRequirements.html\">InstanceRequirements</a> and cannot be used for groups\n                        that do.</p>\n            </dd>\n         </dl>",
+          "type": "string"
+        },
+        "OnDemandBaseCapacity": {
+          "description": "<p>The minimum amount of the Auto Scaling group's capacity that must be fulfilled by On-Demand\n            Instances. This base portion is launched first as your group scales.</p>\n         <p>This number has the same unit of measurement as the group's desired capacity. If you\n            change the default unit of measurement (number of instances) by specifying weighted\n            capacity values in your launch template overrides list, or by changing the default\n            desired capacity type setting of the group, you must specify this number using the same\n            unit of measurement.</p>\n         <p>Default: 0</p>",
+          "type": "number"
+        },
+        "OnDemandPercentageAboveBaseCapacity": {
+          "description": "<p>Controls the percentages of On-Demand Instances and Spot Instances for your additional\n            capacity beyond <code>OnDemandBaseCapacity</code>. Expressed as a number (for example,\n            20 specifies 20% On-Demand Instances, 80% Spot Instances). If set to 100, only On-Demand\n            Instances are used.</p>\n         <p>Default: 100</p>",
+          "type": "number"
+        },
+        "SpotAllocationStrategy": {
+          "description": "<p>The allocation strategy to apply to your Spot Instances when they are launched.\n            Possible instance types are determined by the launch template overrides that you\n            specify.</p>\n         <p>The following lists the valid values:</p>\n         <dl>\n            <dt>capacity-optimized</dt>\n            <dd>\n               <p>Requests Spot Instances using pools that are optimally chosen based on the\n                        available Spot capacity. This strategy has the lowest risk of interruption.\n                        To give certain instance types a higher chance of launching first, use\n                            <code>capacity-optimized-prioritized</code>.</p>\n            </dd>\n            <dt>capacity-optimized-prioritized</dt>\n            <dd>\n               <p>You set the order of instance types for the launch template overrides from\n                        highest to lowest priority (from first to last in the list). Amazon EC2 Auto Scaling honors\n                        the instance type priorities on a best effort basis but optimizes for\n                        capacity first. Note that if the On-Demand allocation strategy is set to\n                            <code>prioritized</code>, the same priority is applied when fulfilling\n                        On-Demand capacity. This is not a valid value for Auto Scaling groups that specify\n                        <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstanceRequirements.html\">InstanceRequirements</a>.</p>\n            </dd>\n            <dt>lowest-price</dt>\n            <dd>\n               <p>Requests Spot Instances using the lowest priced pools within an\n                        Availability Zone, across the number of Spot pools that you specify for the\n                            <code>SpotInstancePools</code> property. To ensure that your desired\n                        capacity is met, you might receive Spot Instances from several pools. This\n                        is the default value, but it might lead to high interruption rates because\n                        this strategy only considers instance price and not available\n                        capacity.</p>\n            </dd>\n            <dt>price-capacity-optimized (recommended)</dt>\n            <dd>\n               <p>The price and capacity optimized allocation strategy looks at both price\n                        and capacity to select the Spot Instance pools that are the least likely to\n                        be interrupted and have the lowest possible price.</p>\n            </dd>\n         </dl>",
+          "type": "string"
+        },
+        "SpotInstancePools": {
+          "description": "<p>The number of Spot Instance pools across which to allocate your Spot Instances. The\n            Spot pools are determined from the different instance types in the overrides. Valid only\n            when the <code>SpotAllocationStrategy</code> is <code>lowest-price</code>. Value must be\n            in the range of 1–20.</p>\n         <p>Default: 2</p>",
+          "type": "number"
+        },
+        "SpotMaxPrice": {
+          "description": "<p>The maximum price per unit hour that you are willing to pay for a Spot Instance. If\n            your maximum price is lower than the Spot price for the instance types that you\n            selected, your Spot Instances are not launched. We do not recommend specifying a maximum\n            price because it can lead to increased interruptions. When Spot Instances launch, you\n            pay the current Spot price. To remove a maximum price that you previously set, include\n            the property but specify an empty string (\"\") for the value.</p>\n         <important>\n            <p>If you specify a maximum price, your instances will be interrupted more frequently\n                than if you do not specify one.</p>\n         </important>\n         <p>Valid Range: Minimum value of 0.001</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Instance": {
+      "description": "<p>Describes an EC2 instance.</p>",
+      "type": "object",
+      "properties": {
+        "InstanceId": {
+          "description": "<p>The ID of the instance.</p>",
+          "type": "string"
+        },
+        "InstanceType": {
+          "description": "<p>The instance type of the EC2 instance.</p>",
+          "type": "string"
+        },
+        "AvailabilityZone": {
+          "description": "<p>The Availability Zone in which the instance is running.</p>",
+          "type": "string"
+        },
+        "LifecycleState": {
+          "description": "<p>A description of the current lifecycle state. The <code>Quarantined</code> state is\n            not used. For more information, see <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-lifecycle.html\">Amazon EC2 Auto Scaling instance\n                lifecycle</a> in the <i>Amazon EC2 Auto Scaling User Guide</i>. </p>",
+          "enum": [
+            "Detached",
+            "Detaching",
+            "EnteringStandby",
+            "InService",
+            "Pending",
+            "Pending:Proceed",
+            "Pending:Wait",
+            "Quarantined",
+            "Standby",
+            "Terminated",
+            "Terminating",
+            "Terminating:Proceed",
+            "Terminating:Wait",
+            "Warmed:Hibernated",
+            "Warmed:Pending",
+            "Warmed:Pending:Proceed",
+            "Warmed:Pending:Wait",
+            "Warmed:Running",
+            "Warmed:Stopped",
+            "Warmed:Terminated",
+            "Warmed:Terminating",
+            "Warmed:Terminating:Proceed",
+            "Warmed:Terminating:Wait"
+          ],
+          "type": "string"
+        },
+        "HealthStatus": {
+          "description": "<p>The last reported health status of the instance. <code>Healthy</code> means that the\n            instance is healthy and should remain in service. <code>Unhealthy</code> means that the\n            instance is unhealthy and that Amazon EC2 Auto Scaling should terminate and replace it.</p>",
+          "type": "string"
+        },
+        "LaunchConfigurationName": {
+          "description": "<p>The launch configuration associated with the instance.</p>",
+          "type": "string"
+        },
+        "LaunchTemplate": {
+          "description": "<p>The launch template for the instance.</p>",
+          "$ref": "#/definitions/LaunchTemplateSpecification"
+        },
+        "ProtectedFromScaleIn": {
+          "description": "<p>Indicates whether the instance is protected from termination by Amazon EC2 Auto Scaling when scaling\n            in.</p>",
+          "type": "boolean"
+        },
+        "WeightedCapacity": {
+          "description": "<p>The number of capacity units contributed by the instance based on its instance\n            type.</p>\n         <p>Valid Range: Minimum value of 1. Maximum value of 999.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "AvailabilityZone",
+        "HealthStatus",
+        "InstanceId",
+        "LifecycleState",
+        "ProtectedFromScaleIn"
+      ]
+    },
+    "SuspendedProcess": {
+      "description": "<p>Describes an auto scaling process that has been suspended.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-suspend-resume-processes.html#process-types\">Types\n                of processes</a> in the <i>Amazon EC2 Auto Scaling User Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "ProcessName": {
+          "description": "<p>The name of the suspended process.</p>",
+          "type": "string"
+        },
+        "SuspensionReason": {
+          "description": "<p>The reason that the process was suspended.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "EnabledMetric": {
+      "description": "<p>Describes an enabled Auto Scaling group metric.</p>",
+      "type": "object",
+      "properties": {
+        "Metric": {
+          "description": "<p>One of the following metrics:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>GroupMinSize</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>GroupMaxSize</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>GroupDesiredCapacity</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>GroupInServiceInstances</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>GroupPendingInstances</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>GroupStandbyInstances</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>GroupTerminatingInstances</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>GroupTotalInstances</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>GroupInServiceCapacity</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>GroupPendingCapacity</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>GroupStandbyCapacity</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>GroupTerminatingCapacity</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>GroupTotalCapacity</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>WarmPoolDesiredCapacity</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>WarmPoolWarmedCapacity</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>WarmPoolPendingCapacity</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>WarmPoolTerminatingCapacity</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>WarmPoolTotalCapacity</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>GroupAndWarmPoolDesiredCapacity</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>GroupAndWarmPoolTotalCapacity</code>\n               </p>\n            </li>\n         </ul>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-metrics.html\">Amazon CloudWatch metrics for\n                Amazon EC2 Auto Scaling</a> in the <i>Amazon EC2 Auto Scaling User Guide</i>.</p>",
+          "type": "string"
+        },
+        "Granularity": {
+          "description": "<p>The granularity of the metric. The only valid value is <code>1Minute</code>.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "TagDescription": {
+      "description": "<p>Describes a tag for an Auto Scaling group.</p>",
+      "type": "object",
+      "properties": {
+        "ResourceId": {
+          "description": "<p>The name of the group.</p>",
+          "type": "string"
+        },
+        "ResourceType": {
+          "description": "<p>The type of resource. The only supported value is\n            <code>auto-scaling-group</code>.</p>",
+          "type": "string"
+        },
+        "Key": {
+          "description": "<p>The tag key.</p>",
+          "type": "string"
+        },
+        "Value": {
+          "description": "<p>The tag value.</p>",
+          "type": "string"
+        },
+        "PropagateAtLaunch": {
+          "description": "<p>Determines whether the tag is added to new instances as they are launched in the\n            group.</p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "WarmPoolConfiguration": {
+      "description": "<p>Describes a warm pool configuration. </p>",
+      "type": "object",
+      "properties": {
+        "MaxGroupPreparedCapacity": {
+          "description": "<p>The maximum number of instances that are allowed to be in the warm pool or in any\n            state except <code>Terminated</code> for the Auto Scaling group.</p>",
+          "type": "number"
+        },
+        "MinSize": {
+          "description": "<p>The minimum number of instances to maintain in the warm pool.</p>",
+          "type": "number"
+        },
+        "PoolState": {
+          "enum": [
+            "Hibernated",
+            "Running",
+            "Stopped"
+          ],
+          "description": "<p>The instance state to transition to after the lifecycle actions are complete.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "enum": "",
+          "description": "<p>The status of a warm pool that is marked for deletion.</p>",
+          "const": "PendingDelete",
+          "type": "string"
+        },
+        "InstanceReusePolicy": {
+          "description": "<p>The instance reuse policy.</p>",
+          "$ref": "#/definitions/InstanceReusePolicy"
+        }
+      }
+    },
+    "InstanceReusePolicy": {
+      "description": "<p>Describes an instance reuse policy for a warm pool. </p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-warm-pools.html\">Warm pools for\n                Amazon EC2 Auto Scaling</a> in the <i>Amazon EC2 Auto Scaling User Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "ReuseOnScaleIn": {
+          "description": "<p>Specifies whether instances in the Auto Scaling group can be returned to the warm pool on\n            scale in. </p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "TrafficSourceIdentifier": {
+      "description": "<p>Identifying information for a traffic source.</p>",
+      "type": "object",
+      "properties": {
+        "Identifier": {
+          "description": "<p>Identifies the traffic source.</p>\n         <p>For Application Load Balancers, Gateway Load Balancers, Network Load Balancers, and VPC Lattice, this will be the Amazon Resource Name\n            (ARN) for a target group in this account and Region. For Classic Load Balancers, this will be the name\n            of the Classic Load Balancer in this account and Region.</p>\n         <p>For example: </p>\n         <ul>\n            <li>\n               <p>Application Load Balancer ARN:\n                        <code>arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/1234567890123456</code>\n               </p>\n            </li>\n            <li>\n               <p>Classic Load Balancer name: <code>my-classic-load-balancer</code>\n               </p>\n            </li>\n            <li>\n               <p>VPC Lattice ARN:\n                        <code>arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-1234567890123456</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the ARN of a target group for a Application Load Balancer, Gateway Load Balancer, or Network Load Balancer, or the name of a\n            Classic Load Balancer, use the Elastic Load Balancing <a href=\"https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeTargetGroups.html\">DescribeTargetGroups</a> and <a href=\"https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html\">DescribeLoadBalancers</a> API operations.</p>\n         <p>To get the ARN of a target group for VPC Lattice, use the VPC Lattice <a href=\"https://docs.aws.amazon.com/vpc-lattice/latest/APIReference/API_GetTargetGroup.html\">GetTargetGroup</a> API operation.</p>",
+          "type": "string"
+        },
+        "Type": {
+          "description": "<p>Provides additional context for the value of <code>Identifier</code>.</p>\n         <p>The following lists the valid values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>elb</code> if <code>Identifier</code> is the name of a Classic Load Balancer.</p>\n            </li>\n            <li>\n               <p>\n                  <code>elbv2</code> if <code>Identifier</code> is the ARN of an Application Load Balancer, Gateway Load Balancer,\n                    or Network Load Balancer target group.</p>\n            </li>\n            <li>\n               <p>\n                  <code>vpc-lattice</code> if <code>Identifier</code> is the ARN of a VPC Lattice\n                    target group.</p>\n            </li>\n         </ul>\n         <p>Required if the identifier is the name of a Classic Load Balancer.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Identifier"
+      ]
+    },
+    "InstanceMaintenancePolicy": {
+      "description": "<p>Describes an instance maintenance policy.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-instance-maintenance-policy.html\">Set instance maintenance policy</a> in the\n            <i>Amazon EC2 Auto Scaling User Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "MinHealthyPercentage": {
+          "description": "<p>Specifies the lower threshold as a percentage of the desired capacity of the Auto Scaling\n            group. It represents the minimum percentage of the group to keep in service, healthy,\n            and ready to use to support your workload when replacing instances. Value range is 0 to\n            100. To clear a previously set value, specify a value of <code>-1</code>.</p>",
+          "type": "number"
+        },
+        "MaxHealthyPercentage": {
+          "description": "<p>Specifies the upper threshold as a percentage of the desired capacity of the Auto Scaling\n            group. It represents the maximum percentage of the group that can be in service and\n            healthy, or pending, to support your workload when replacing instances. Value range is\n            100 to 200. To clear a previously set value, specify a value of <code>-1</code>.</p>\n         <p>Both <code>MinHealthyPercentage</code> and <code>MaxHealthyPercentage</code> must be\n            specified, and the difference between them cannot be greater than 100. A large range\n            increases the number of instances that can be replaced at the same time.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "AvailabilityZoneDistribution": {
+      "description": "<p>\n            Describes an Availability Zone distribution.\n        </p>",
+      "type": "object",
+      "properties": {
+        "CapacityDistributionStrategy": {
+          "enum": [
+            "balanced-best-effort",
+            "balanced-only"
+          ],
+          "description": "<p>\n            If launches fail in an Availability Zone, the following strategies are available. The default is <code>balanced-best-effort</code>. </p>\n         <ul>\n            <li>\n               <p>\n                  <code>balanced-only</code> - If launches fail in an Availability Zone, Auto Scaling will continue to attempt to launch in the unhealthy zone to preserve a balanced distribution.</p>\n            </li>\n            <li>\n               <p>\n                  <code>balanced-best-effort</code> - If launches fail in an Availability Zone, Auto Scaling will attempt to launch in another healthy Availability Zone instead.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        }
+      }
+    },
+    "TrailInfo": {
+      "description": "<p>Information about a CloudTrail trail, including the trail's name, home Region,\n         and Amazon Resource Name (ARN).</p>",
+      "type": "object",
+      "properties": {
+        "TrailARN": {
+          "description": "<p>The ARN of a trail.</p>",
+          "type": "string"
+        },
+        "Name": {
+          "description": "<p>The name of a trail.</p>",
+          "type": "string"
+        },
+        "HomeRegion": {
+          "description": "<p>The Amazon Web Services Region in which a trail was created.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "TableDescription": {
+      "description": "<p>Represents the properties of a table.</p>",
+      "type": "object",
+      "properties": {
+        "AttributeDefinitions": {
+          "description": "<p>An array of <code>AttributeDefinition</code> objects. Each of these objects describes\n            one attribute in the table and index key schema.</p>\n         <p>Each <code>AttributeDefinition</code> object in this array is composed of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>AttributeName</code> - The name of the attribute.</p>\n            </li>\n            <li>\n               <p>\n                  <code>AttributeType</code> - The data type for the attribute.</p>\n            </li>\n         </ul>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AttributeDefinition"
+          }
+        },
+        "TableName": {
+          "description": "<p>The name of the table.</p>",
+          "type": "string"
+        },
+        "KeySchema": {
+          "description": "<p>The primary key structure for the table. Each <code>KeySchemaElement</code> consists\n            of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>AttributeName</code> - The name of the attribute.</p>\n            </li>\n            <li>\n               <p>\n                  <code>KeyType</code> - The role of the attribute:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>HASH</code> - partition key</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>RANGE</code> - sort key</p>\n                  </li>\n               </ul>\n               <note>\n                  <p>The partition key of an item is also known as its <i>hash\n                            attribute</i>. The term \"hash attribute\" derives from DynamoDB's\n                        usage of an internal hash function to evenly distribute data items across\n                        partitions, based on their partition key values.</p>\n                  <p>The sort key of an item is also known as its <i>range\n                            attribute</i>. The term \"range attribute\" derives from the way\n                        DynamoDB stores items with the same partition key physically close together,\n                        in sorted order by the sort key value.</p>\n               </note>\n            </li>\n         </ul>\n         <p>For more information about primary keys, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataModel.html#DataModelPrimaryKey\">Primary Key</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeySchemaElement"
+          }
+        },
+        "TableStatus": {
+          "enum": [
+            "ACTIVE",
+            "ARCHIVED",
+            "ARCHIVING",
+            "CREATING",
+            "DELETING",
+            "INACCESSIBLE_ENCRYPTION_CREDENTIALS",
+            "UPDATING"
+          ],
+          "description": "<p>The current state of the table:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> - The table is being created.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATING</code> - The table/index configuration is being updated. The\n                    table/index remains available for data operations when\n                    <code>UPDATING</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETING</code> - The table is being deleted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - The table is ready for use.</p>\n            </li>\n            <li>\n               <p>\n                  <code>INACCESSIBLE_ENCRYPTION_CREDENTIALS</code> - The KMS key\n                    used to encrypt the table in inaccessible. Table operations may fail due to\n                    failure to use the KMS key. DynamoDB will initiate the\n                    table archival process when a table's KMS key remains\n                    inaccessible for more than seven days. </p>\n            </li>\n            <li>\n               <p>\n                  <code>ARCHIVING</code> - The table is being archived. Operations are not allowed\n                    until archival is complete. </p>\n            </li>\n            <li>\n               <p>\n                  <code>ARCHIVED</code> - The table has been archived. See the ArchivalReason for\n                    more information. </p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "CreationDateTime": {
+          "description": "<p>The date and time when the table was created, in <a href=\"http://www.epochconverter.com/\">UNIX epoch time</a> format.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "ProvisionedThroughput": {
+          "description": "<p>The provisioned throughput settings for the table, consisting of read and write\n            capacity units, along with data about increases and decreases.</p>",
+          "$ref": "#/definitions/ProvisionedThroughputDescription"
+        },
+        "TableSizeBytes": {
+          "description": "<p>The total size of the specified table, in bytes. DynamoDB updates this value\n            approximately every six hours. Recent changes might not be reflected in this\n            value.</p>",
+          "type": "number"
+        },
+        "ItemCount": {
+          "description": "<p>The number of items in the specified table. DynamoDB updates this value approximately\n            every six hours. Recent changes might not be reflected in this value.</p>",
+          "type": "number"
+        },
+        "TableArn": {
+          "description": "<p>The Amazon Resource Name (ARN) that uniquely identifies the table.</p>",
+          "type": "string"
+        },
+        "TableId": {
+          "description": "<p>Unique identifier for the table for which the backup was created. </p>",
+          "type": "string"
+        },
+        "BillingModeSummary": {
+          "description": "<p>Contains the details for the read/write capacity mode.</p>",
+          "$ref": "#/definitions/BillingModeSummary"
+        },
+        "LocalSecondaryIndexes": {
+          "description": "<p>Represents one or more local secondary indexes on the table. Each index is scoped to a\n            given partition key value. Tables with one or more local secondary indexes are subject\n            to an item collection size limit, where the amount of data within a given item\n            collection cannot exceed 10 GB. Each element is composed of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>IndexName</code> - The name of the local secondary index.</p>\n            </li>\n            <li>\n               <p>\n                  <code>KeySchema</code> - Specifies the complete index key schema. The attribute\n                    names in the key schema must be between 1 and 255 characters (inclusive). The\n                    key schema must begin with the same partition key as the table.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ProjectionType</code> - One of the following:</p>\n                     <ul>\n                        <li>\n                           <p>\n                              <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>INCLUDE</code> - Only the specified table attributes are\n                                    projected into the index. The list of projected attributes is in\n                                        <code>NonKeyAttributes</code>.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>\n                        <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>IndexSizeBytes</code> - Represents the total size of the index, in bytes.\n                    DynamoDB updates this value approximately every six hours. Recent changes might\n                    not be reflected in this value.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ItemCount</code> - Represents the number of items in the index. DynamoDB\n                    updates this value approximately every six hours. Recent changes might not be\n                    reflected in this value.</p>\n            </li>\n         </ul>\n         <p>If the table is in the <code>DELETING</code> state, no information about indexes will\n            be returned.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LocalSecondaryIndexDescription"
+          }
+        },
+        "GlobalSecondaryIndexes": {
+          "description": "<p>The global secondary indexes, if any, on the table. Each index is scoped to a given\n            partition key value. Each element is composed of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Backfilling</code> - If true, then the index is currently in the\n                    backfilling phase. Backfilling occurs only when a new global secondary index is\n                    added to the table. It is the process by which DynamoDB populates the new index\n                    with data from the table. (This attribute does not appear for indexes that were\n                    created during a <code>CreateTable</code> operation.) </p>\n               <p> You can delete an index that is being created during the\n                        <code>Backfilling</code> phase when <code>IndexStatus</code> is set to\n                    CREATING and <code>Backfilling</code> is true. You can't delete the index that\n                    is being created when <code>IndexStatus</code> is set to CREATING and\n                        <code>Backfilling</code> is false. (This attribute does not appear for\n                    indexes that were created during a <code>CreateTable</code> operation.)</p>\n            </li>\n            <li>\n               <p>\n                  <code>IndexName</code> - The name of the global secondary index.</p>\n            </li>\n            <li>\n               <p>\n                  <code>IndexSizeBytes</code> - The total size of the global secondary index, in\n                    bytes. DynamoDB updates this value approximately every six hours. Recent changes\n                    might not be reflected in this value. </p>\n            </li>\n            <li>\n               <p>\n                  <code>IndexStatus</code> - The current status of the global secondary\n                    index:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>CREATING</code> - The index is being created.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>UPDATING</code> - The index is being updated.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>DELETING</code> - The index is being deleted.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>ACTIVE</code> - The index is ready for use.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>ItemCount</code> - The number of items in the global secondary index.\n                    DynamoDB updates this value approximately every six hours. Recent changes might\n                    not be reflected in this value. </p>\n            </li>\n            <li>\n               <p>\n                  <code>KeySchema</code> - Specifies the complete index key schema. The attribute\n                    names in the key schema must be between 1 and 255 characters (inclusive). The\n                    key schema must begin with the same partition key as the table.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ProjectionType</code> - One of the following:</p>\n                     <ul>\n                        <li>\n                           <p>\n                              <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>INCLUDE</code> - In addition to the attributes described\n                                    in <code>KEYS_ONLY</code>, the secondary index will include\n                                    other non-key attributes that you specify.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>\n                        <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>ProvisionedThroughput</code> - The provisioned throughput settings for the\n                    global secondary index, consisting of read and write capacity units, along with\n                    data about increases and decreases. </p>\n            </li>\n         </ul>\n         <p>If the table is in the <code>DELETING</code> state, no information about indexes will\n            be returned.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GlobalSecondaryIndexDescription"
+          }
+        },
+        "StreamSpecification": {
+          "description": "<p>The current DynamoDB Streams configuration for the table.</p>",
+          "$ref": "#/definitions/StreamSpecification"
+        },
+        "LatestStreamLabel": {
+          "description": "<p>A timestamp, in ISO 8601 format, for this stream.</p>\n         <p>Note that <code>LatestStreamLabel</code> is not a unique identifier for the stream,\n            because it is possible that a stream from another table might have the same timestamp.\n            However, the combination of the following three elements is guaranteed to be\n            unique:</p>\n         <ul>\n            <li>\n               <p>Amazon Web Services customer ID</p>\n            </li>\n            <li>\n               <p>Table name</p>\n            </li>\n            <li>\n               <p>\n                  <code>StreamLabel</code>\n               </p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "LatestStreamArn": {
+          "description": "<p>The Amazon Resource Name (ARN) that uniquely identifies the latest stream for this\n            table.</p>",
+          "type": "string"
+        },
+        "GlobalTableVersion": {
+          "description": "<p>Represents the version of <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GlobalTables.html\">global tables</a>\n            in use, if the table is replicated across Amazon Web Services Regions.</p>",
+          "type": "string"
+        },
+        "Replicas": {
+          "description": "<p>Represents replicas of the table.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ReplicaDescription"
+          }
+        },
+        "RestoreSummary": {
+          "description": "<p>Contains details for the restore.</p>",
+          "$ref": "#/definitions/RestoreSummary"
+        },
+        "SSEDescription": {
+          "description": "<p>The description of the server-side encryption status on the specified table.</p>",
+          "$ref": "#/definitions/SSEDescription"
+        },
+        "ArchivalSummary": {
+          "description": "<p>Contains information about the table archive.</p>",
+          "$ref": "#/definitions/ArchivalSummary"
+        },
+        "TableClassSummary": {
+          "description": "<p>Contains details of the table class.</p>",
+          "$ref": "#/definitions/TableClassSummary"
+        },
+        "DeletionProtectionEnabled": {
+          "description": "<p>Indicates whether deletion protection is enabled (true) or disabled (false) on the table.</p>",
+          "type": "boolean"
+        },
+        "OnDemandThroughput": {
+          "description": "<p>The maximum number of read and write units for the specified on-demand table. If you use this parameter, you must specify <code>MaxReadRequestUnits</code>, <code>MaxWriteRequestUnits</code>, or both.</p>",
+          "$ref": "#/definitions/OnDemandThroughput"
+        }
+      }
+    },
+    "AttributeDefinition": {
+      "description": "<p>Represents an attribute for describing the schema for the table and\n            indexes.</p>",
+      "type": "object",
+      "properties": {
+        "AttributeName": {
+          "description": "<p>A name for the attribute.</p>",
+          "type": "string"
+        },
+        "AttributeType": {
+          "description": "<p>The data type for the attribute, where:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>S</code> - the attribute is of type String</p>\n            </li>\n            <li>\n               <p>\n                  <code>N</code> - the attribute is of type Number</p>\n            </li>\n            <li>\n               <p>\n                  <code>B</code> - the attribute is of type Binary</p>\n            </li>\n         </ul>",
+          "enum": [
+            "B",
+            "N",
+            "S"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "AttributeName",
+        "AttributeType"
+      ]
+    },
+    "KeySchemaElement": {
+      "description": "<p>Represents <i>a single element</i> of a key schema. A key schema\n            specifies the attributes that make up the primary key of a table, or the key attributes\n            of an index.</p>\n         <p>A <code>KeySchemaElement</code> represents exactly one attribute of the primary key.\n            For example, a simple primary key would be represented by one\n                <code>KeySchemaElement</code> (for the partition key). A composite primary key would\n            require one <code>KeySchemaElement</code> for the partition key, and another\n                <code>KeySchemaElement</code> for the sort key.</p>\n         <p>A <code>KeySchemaElement</code> must be a scalar, top-level attribute (not a nested\n            attribute). The data type must be one of String, Number, or Binary. The attribute cannot\n            be nested within a List or a Map.</p>",
+      "type": "object",
+      "properties": {
+        "AttributeName": {
+          "description": "<p>The name of a key attribute.</p>",
+          "type": "string"
+        },
+        "KeyType": {
+          "description": "<p>The role that this key attribute will assume:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>HASH</code> - partition key</p>\n            </li>\n            <li>\n               <p>\n                  <code>RANGE</code> - sort key</p>\n            </li>\n         </ul>\n         <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across\n                partitions, based on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with\n                the same partition key physically close together, in sorted order by the sort key\n                value.</p>\n         </note>",
+          "enum": [
+            "HASH",
+            "RANGE"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "AttributeName",
+        "KeyType"
+      ]
+    },
+    "ProvisionedThroughputDescription": {
+      "description": "<p>Represents the provisioned throughput settings for the table, consisting of read and\n            write capacity units, along with data about increases and decreases.</p>",
+      "type": "object",
+      "properties": {
+        "LastIncreaseDateTime": {
+          "description": "<p>The date and time of the last provisioned throughput increase for this table.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "LastDecreaseDateTime": {
+          "description": "<p>The date and time of the last provisioned throughput decrease for this table.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "NumberOfDecreasesToday": {
+          "description": "<p>The number of provisioned throughput decreases for this table during this UTC calendar\n            day. For current maximums on provisioned throughput decreases, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>",
+          "type": "number"
+        },
+        "ReadCapacityUnits": {
+          "description": "<p>The maximum number of strongly consistent reads consumed per second before DynamoDB\n            returns a <code>ThrottlingException</code>. Eventually consistent reads require less\n            effort than strongly consistent reads, so a setting of 50 <code>ReadCapacityUnits</code>\n            per second provides 100 eventually consistent <code>ReadCapacityUnits</code> per\n            second.</p>",
+          "type": "number"
+        },
+        "WriteCapacityUnits": {
+          "description": "<p>The maximum number of writes consumed per second before DynamoDB returns a\n                <code>ThrottlingException</code>.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "BillingModeSummary": {
+      "description": "<p>Contains the details for the read/write capacity mode. This page talks about\n                <code>PROVISIONED</code> and <code>PAY_PER_REQUEST</code> billing modes. For more\n            information about these modes, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html\">Read/write capacity mode</a>.</p>\n         <note>\n            <p>You may need to switch to on-demand mode at least once in order to return a\n                    <code>BillingModeSummary</code> response.</p>\n         </note>",
+      "type": "object",
+      "properties": {
+        "BillingMode": {
+          "enum": [
+            "PAY_PER_REQUEST",
+            "PROVISIONED"
+          ],
+          "description": "<p>Controls how you are charged for read and write throughput and how you manage\n            capacity. This setting can be changed later.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PROVISIONED</code> - Sets the read/write capacity mode to\n                        <code>PROVISIONED</code>. We recommend using <code>PROVISIONED</code> for\n                    predictable workloads.</p>\n            </li>\n            <li>\n               <p>\n                  <code>PAY_PER_REQUEST</code> - Sets the read/write capacity mode to\n                        <code>PAY_PER_REQUEST</code>. We recommend using\n                        <code>PAY_PER_REQUEST</code> for unpredictable workloads. </p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "LastUpdateToPayPerRequestDateTime": {
+          "description": "<p>Represents the time when <code>PAY_PER_REQUEST</code> was last set as the read/write\n            capacity mode.</p>",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "LocalSecondaryIndexDescription": {
+      "description": "<p>Represents the properties of a local secondary index.</p>",
+      "type": "object",
+      "properties": {
+        "IndexName": {
+          "description": "<p>Represents the name of the local secondary index.</p>",
+          "type": "string"
+        },
+        "KeySchema": {
+          "description": "<p>The complete key schema for the local secondary index, consisting of one or more pairs\n            of attribute names and key types:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>HASH</code> - partition key</p>\n            </li>\n            <li>\n               <p>\n                  <code>RANGE</code> - sort key</p>\n            </li>\n         </ul>\n         <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of\n                an internal hash function to evenly distribute data items across partitions, based\n                on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with the same\n                partition key physically close together, in sorted order by the sort key\n                value.</p>\n         </note>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeySchemaElement"
+          }
+        },
+        "Projection": {
+          "description": "<p>Represents attributes that are copied (projected) from the table into the global\n            secondary index. These are in addition to the primary key attributes and index key\n            attributes, which are automatically projected. </p>",
+          "$ref": "#/definitions/Projection"
+        },
+        "IndexSizeBytes": {
+          "description": "<p>The total size of the specified index, in bytes. DynamoDB updates this value\n            approximately every six hours. Recent changes might not be reflected in this\n            value.</p>",
+          "type": "number"
+        },
+        "ItemCount": {
+          "description": "<p>The number of items in the specified index. DynamoDB updates this value\n            approximately every six hours. Recent changes might not be reflected in this\n            value.</p>",
+          "type": "number"
+        },
+        "IndexArn": {
+          "description": "<p>The Amazon Resource Name (ARN) that uniquely identifies the index.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Projection": {
+      "description": "<p>Represents attributes that are copied (projected) from the table into an index. These\n            are in addition to the primary key attributes and index key attributes, which are\n            automatically projected.</p>",
+      "type": "object",
+      "properties": {
+        "ProjectionType": {
+          "enum": [
+            "ALL",
+            "INCLUDE",
+            "KEYS_ONLY"
+          ],
+          "description": "<p>The set of attributes that are projected into the index:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>KEYS_ONLY</code> - Only the index and primary keys are projected into the\n                    index.</p>\n            </li>\n            <li>\n               <p>\n                  <code>INCLUDE</code> - In addition to the attributes described in\n                        <code>KEYS_ONLY</code>, the secondary index will include other non-key\n                    attributes that you specify.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ALL</code> - All of the table attributes are projected into the\n                    index.</p>\n            </li>\n         </ul>\n         <p>When using the DynamoDB console, <code>ALL</code> is selected by default.</p>",
+          "type": "string"
+        },
+        "NonKeyAttributes": {
+          "description": "<p>Represents the non-key attribute names which will be projected into the index.</p>\n         <p>For local secondary indexes, the total count of <code>NonKeyAttributes</code> summed\n            across all of the local secondary indexes, must not exceed 100. If you project the same\n            attribute into two different indexes, this counts as two distinct attributes when\n            determining the total.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "GlobalSecondaryIndexDescription": {
+      "description": "<p>Represents the properties of a global secondary index.</p>",
+      "type": "object",
+      "properties": {
+        "IndexName": {
+          "description": "<p>The name of the global secondary index.</p>",
+          "type": "string"
+        },
+        "KeySchema": {
+          "description": "<p>The complete key schema for a global secondary index, which consists of one or more\n            pairs of attribute names and key types:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>HASH</code> - partition key</p>\n            </li>\n            <li>\n               <p>\n                  <code>RANGE</code> - sort key</p>\n            </li>\n         </ul>\n         <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across\n                partitions, based on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with\n                the same partition key physically close together, in sorted order by the sort key\n                value.</p>\n         </note>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeySchemaElement"
+          }
+        },
+        "Projection": {
+          "description": "<p>Represents attributes that are copied (projected) from the table into the global\n            secondary index. These are in addition to the primary key attributes and index key\n            attributes, which are automatically projected. </p>",
+          "$ref": "#/definitions/Projection"
+        },
+        "IndexStatus": {
+          "enum": [
+            "ACTIVE",
+            "CREATING",
+            "DELETING",
+            "UPDATING"
+          ],
+          "description": "<p>The current state of the global secondary index:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> - The index is being created.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATING</code> - The index is being updated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETING</code> - The index is being deleted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - The index is ready for use.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "Backfilling": {
+          "description": "<p>Indicates whether the index is currently backfilling. <i>Backfilling</i>\n            is the process of reading items from the table and determining whether they can be added\n            to the index. (Not all items will qualify: For example, a partition key cannot have any\n            duplicate values.) If an item can be added to the index, DynamoDB will do so. After all\n            items have been processed, the backfilling operation is complete and\n                <code>Backfilling</code> is false.</p>\n         <p>You can delete an index that is being created during the <code>Backfilling</code>\n            phase when <code>IndexStatus</code> is set to CREATING and <code>Backfilling</code> is\n            true. You can't delete the index that is being created when <code>IndexStatus</code> is\n            set to CREATING and <code>Backfilling</code> is false. </p>\n         <note>\n            <p>For indexes that were created during a <code>CreateTable</code> operation, the\n                    <code>Backfilling</code> attribute does not appear in the\n                    <code>DescribeTable</code> output.</p>\n         </note>",
+          "type": "boolean"
+        },
+        "ProvisionedThroughput": {
+          "description": "<p>Represents the provisioned throughput settings for the specified global secondary\n            index.</p>\n         <p>For current minimum and maximum provisioned throughput values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>",
+          "$ref": "#/definitions/ProvisionedThroughputDescription"
+        },
+        "IndexSizeBytes": {
+          "description": "<p>The total size of the specified index, in bytes. DynamoDB updates this value\n            approximately every six hours. Recent changes might not be reflected in this\n            value.</p>",
+          "type": "number"
+        },
+        "ItemCount": {
+          "description": "<p>The number of items in the specified index. DynamoDB updates this value approximately\n            every six hours. Recent changes might not be reflected in this value.</p>",
+          "type": "number"
+        },
+        "IndexArn": {
+          "description": "<p>The Amazon Resource Name (ARN) that uniquely identifies the index.</p>",
+          "type": "string"
+        },
+        "OnDemandThroughput": {
+          "description": "<p>The maximum number of read and write units for the specified global secondary index. If you use this parameter, you must specify <code>MaxReadRequestUnits</code>, <code>MaxWriteRequestUnits</code>, or both.</p>",
+          "$ref": "#/definitions/OnDemandThroughput"
+        }
+      }
+    },
+    "OnDemandThroughput": {
+      "description": "<p>Sets the maximum number of read and write units for the specified on-demand table. If you use this parameter, you must specify <code>MaxReadRequestUnits</code>, <code>MaxWriteRequestUnits</code>, or both.</p>",
+      "type": "object",
+      "properties": {
+        "MaxReadRequestUnits": {
+          "description": "<p>Maximum number of read request units for the specified table.</p>\n         <p>To specify a maximum <code>OnDemandThroughput</code> on your table, set the value of <code>MaxReadRequestUnits</code> as greater than or equal to 1. To remove the maximum <code>OnDemandThroughput</code> that is currently set on your table, set the value of <code>MaxReadRequestUnits</code> to -1.</p>",
+          "type": "number"
+        },
+        "MaxWriteRequestUnits": {
+          "description": "<p>Maximum number of write request units for the specified table.</p>\n         <p>To specify a maximum <code>OnDemandThroughput</code> on your table, set the value of <code>MaxWriteRequestUnits</code> as greater than or equal to 1. To remove the maximum <code>OnDemandThroughput</code> that is currently set on your table, set the value of <code>MaxWriteRequestUnits</code> to -1.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "StreamSpecification": {
+      "description": "<p>Represents the DynamoDB Streams configuration for a table in DynamoDB.</p>",
+      "type": "object",
+      "properties": {
+        "StreamEnabled": {
+          "description": "<p>Indicates whether DynamoDB Streams is enabled (true) or disabled (false) on the\n            table.</p>",
+          "type": "boolean"
+        },
+        "StreamViewType": {
+          "enum": [
+            "KEYS_ONLY",
+            "NEW_AND_OLD_IMAGES",
+            "NEW_IMAGE",
+            "OLD_IMAGE"
+          ],
+          "description": "<p> When an item in the table is modified, <code>StreamViewType</code> determines what\n            information is written to the stream for this table. Valid values for\n                <code>StreamViewType</code> are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>KEYS_ONLY</code> - Only the key attributes of the modified item are\n                    written to the stream.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NEW_IMAGE</code> - The entire item, as it appears after it was modified,\n                    is written to the stream.</p>\n            </li>\n            <li>\n               <p>\n                  <code>OLD_IMAGE</code> - The entire item, as it appeared before it was modified,\n                    is written to the stream.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NEW_AND_OLD_IMAGES</code> - Both the new and the old item images of the\n                    item are written to the stream.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "StreamEnabled"
+      ]
+    },
+    "ReplicaDescription": {
+      "description": "<p>Contains the details of the replica.</p>",
+      "type": "object",
+      "properties": {
+        "RegionName": {
+          "description": "<p>The name of the Region.</p>",
+          "type": "string"
+        },
+        "ReplicaStatus": {
+          "enum": [
+            "ACTIVE",
+            "CREATING",
+            "CREATION_FAILED",
+            "DELETING",
+            "INACCESSIBLE_ENCRYPTION_CREDENTIALS",
+            "REGION_DISABLED",
+            "UPDATING"
+          ],
+          "description": "<p>The current state of the replica:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> - The replica is being created.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATING</code> - The replica is being updated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETING</code> - The replica is being deleted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - The replica is ready for use.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REGION_DISABLED</code> - The replica is inaccessible because the Amazon Web Services Region has been disabled.</p>\n               <note>\n                  <p>If the Amazon Web Services Region remains inaccessible for more than 20\n                        hours, DynamoDB will remove this replica from the replication\n                        group. The replica will not be deleted and replication will stop from and to\n                        this region.</p>\n               </note>\n            </li>\n            <li>\n               <p>\n                  <code>INACCESSIBLE_ENCRYPTION_CREDENTIALS </code> - The KMS key\n                    used to encrypt the table is inaccessible.</p>\n               <note>\n                  <p>If the KMS key remains inaccessible for more than 20 hours,\n                            DynamoDB will remove this replica from the replication group.\n                        The replica will not be deleted and replication will stop from and to this\n                        region.</p>\n               </note>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "ReplicaStatusDescription": {
+          "description": "<p>Detailed information about the replica status.</p>",
+          "type": "string"
+        },
+        "ReplicaStatusPercentProgress": {
+          "description": "<p>Specifies the progress of a Create, Update, or Delete action on the replica as a\n            percentage.</p>",
+          "type": "string"
+        },
+        "KMSMasterKeyId": {
+          "description": "<p>The KMS key of the replica that will be used for KMS\n            encryption.</p>",
+          "type": "string"
+        },
+        "ProvisionedThroughputOverride": {
+          "description": "<p>Replica-specific provisioned throughput. If not described, uses the source table's\n            provisioned throughput settings.</p>",
+          "$ref": "#/definitions/ProvisionedThroughputOverride"
+        },
+        "OnDemandThroughputOverride": {
+          "description": "<p>Overrides the maximum on-demand throughput settings for the specified replica table.</p>",
+          "$ref": "#/definitions/OnDemandThroughputOverride"
+        },
+        "GlobalSecondaryIndexes": {
+          "description": "<p>Replica-specific global secondary index settings.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ReplicaGlobalSecondaryIndexDescription"
+          }
+        },
+        "ReplicaInaccessibleDateTime": {
+          "description": "<p>The time at which the replica was first detected as inaccessible. To determine cause\n            of inaccessibility check the <code>ReplicaStatus</code> property.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "ReplicaTableClassSummary": {
+          "description": "<p>Contains details of the table class.</p>",
+          "$ref": "#/definitions/TableClassSummary"
+        }
+      }
+    },
+    "ProvisionedThroughputOverride": {
+      "description": "<p>Replica-specific provisioned throughput settings. If not specified, uses the source\n            table's provisioned throughput settings.</p>",
+      "type": "object",
+      "properties": {
+        "ReadCapacityUnits": {
+          "description": "<p>Replica-specific read capacity units. If not specified, uses the source table's read\n            capacity settings.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "OnDemandThroughputOverride": {
+      "description": "<p>Overrides the on-demand throughput settings for this replica table. If you don't specify a value for this parameter, it uses the source table's on-demand throughput settings.</p>",
+      "type": "object",
+      "properties": {
+        "MaxReadRequestUnits": {
+          "description": "<p>Maximum number of read request units for the specified replica table.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "ReplicaGlobalSecondaryIndexDescription": {
+      "description": "<p>Represents the properties of a replica global secondary index.</p>",
+      "type": "object",
+      "properties": {
+        "IndexName": {
+          "description": "<p>The name of the global secondary index.</p>",
+          "type": "string"
+        },
+        "ProvisionedThroughputOverride": {
+          "description": "<p>If not described, uses the source table GSI's read capacity settings.</p>",
+          "$ref": "#/definitions/ProvisionedThroughputOverride"
+        },
+        "OnDemandThroughputOverride": {
+          "description": "<p>Overrides the maximum on-demand throughput for the specified global secondary index in the specified replica table.</p>",
+          "$ref": "#/definitions/OnDemandThroughputOverride"
+        }
+      }
+    },
+    "TableClassSummary": {
+      "description": "<p>Contains details of the table class.</p>",
+      "type": "object",
+      "properties": {
+        "TableClass": {
+          "enum": [
+            "STANDARD",
+            "STANDARD_INFREQUENT_ACCESS"
+          ],
+          "description": "<p>The table class of the specified table. Valid values are <code>STANDARD</code> and\n                <code>STANDARD_INFREQUENT_ACCESS</code>.</p>",
+          "type": "string"
+        },
+        "LastUpdateDateTime": {
+          "description": "<p>The date and time at which the table class was last updated.</p>",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "RestoreSummary": {
+      "description": "<p>Contains details for the restore.</p>",
+      "type": "object",
+      "properties": {
+        "SourceBackupArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the backup from which the table was restored.</p>",
+          "type": "string"
+        },
+        "SourceTableArn": {
+          "description": "<p>The ARN of the source table of the backup that is being restored.</p>",
+          "type": "string"
+        },
+        "RestoreDateTime": {
+          "description": "<p>Point in time or source backup time.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "RestoreInProgress": {
+          "description": "<p>Indicates if a restore is in progress or not.</p>",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "RestoreDateTime",
+        "RestoreInProgress"
+      ]
+    },
+    "SSEDescription": {
+      "description": "<p>The description of the server-side encryption status on the specified table.</p>",
+      "type": "object",
+      "properties": {
+        "Status": {
+          "enum": [
+            "DISABLED",
+            "DISABLING",
+            "ENABLED",
+            "ENABLING",
+            "UPDATING"
+          ],
+          "description": "<p>Represents the current state of server-side encryption. The only supported values\n            are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ENABLED</code> - Server-side encryption is enabled.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATING</code> - Server-side encryption is being updated.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "SSEType": {
+          "enum": [
+            "AES256",
+            "KMS"
+          ],
+          "description": "<p>Server-side encryption type. The only supported value is:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>KMS</code> - Server-side encryption that uses Key Management Service. The\n                    key is stored in your account and is managed by KMS (KMS charges apply).</p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "KMSMasterKeyArn": {
+          "description": "<p>The KMS key ARN used for the KMS encryption.</p>",
+          "type": "string"
+        },
+        "InaccessibleEncryptionDateTime": {
+          "description": "<p>Indicates the time, in UNIX epoch date format, when DynamoDB detected that\n            the table's KMS key was inaccessible. This attribute will automatically\n            be cleared when DynamoDB detects that the table's KMS key is accessible\n            again. DynamoDB will initiate the table archival process when table's KMS key remains inaccessible for more than seven days from this date.</p>",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "ArchivalSummary": {
+      "description": "<p>Contains details of a table archival operation.</p>",
+      "type": "object",
+      "properties": {
+        "ArchivalDateTime": {
+          "description": "<p>The date and time when table archival was initiated by DynamoDB, in UNIX epoch time\n            format.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "ArchivalReason": {
+          "description": "<p>The reason DynamoDB archived the table. Currently, the only possible value is:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>INACCESSIBLE_ENCRYPTION_CREDENTIALS</code> - The table was archived due\n                    to the table's KMS key being inaccessible for more than seven\n                    days. An On-Demand backup was created at the archival time.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "ArchivalBackupArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the backup the table was archived to, when\n            applicable in the archival reason. If you wish to restore this backup to the same table\n            name, you will need to delete the original table.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Volume": {
+      "description": "<p>Describes a volume.</p>",
+      "type": "object",
+      "properties": {
+        "OutpostArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the Outpost.</p>",
+          "type": "string"
+        },
+        "Iops": {
+          "description": "<p>The number of I/O operations per second (IOPS). For <code>gp3</code>, <code>io1</code>, and <code>io2</code> volumes, this represents\n      the number of IOPS that are provisioned for the volume. For <code>gp2</code> volumes, this represents the baseline\n      performance of the volume and the rate at which the volume accumulates I/O credits for bursting.</p>",
+          "type": "number"
+        },
+        "Tags": {
+          "description": "<p>Any tags assigned to the volume.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "VolumeType": {
+          "enum": [
+            "gp2",
+            "gp3",
+            "io1",
+            "io2",
+            "sc1",
+            "st1",
+            "standard"
+          ],
+          "description": "<p>The volume type.</p>",
+          "type": "string"
+        },
+        "FastRestored": {
+          "description": "<note>\n            <p>This parameter is not returned by CreateVolume.</p>\n         </note>\n         <p>Indicates whether the volume was created using fast snapshot restore.</p>",
+          "type": "boolean"
+        },
+        "MultiAttachEnabled": {
+          "description": "<p>Indicates whether Amazon EBS Multi-Attach is enabled.</p>",
+          "type": "boolean"
+        },
+        "Throughput": {
+          "description": "<p>The throughput that the volume supports, in MiB/s.</p>",
+          "type": "number"
+        },
+        "SseType": {
+          "enum": [
+            "none",
+            "sse-ebs",
+            "sse-kms"
+          ],
+          "description": "<note>\n            <p>This parameter is not returned by CreateVolume.</p>\n         </note>\n         <p>Reserved for future use.</p>",
+          "type": "string"
+        },
+        "VolumeId": {
+          "description": "<p>The ID of the volume.</p>",
+          "type": "string"
+        },
+        "Size": {
+          "description": "<p>The size of the volume, in GiBs.</p>",
+          "type": "number"
+        },
+        "SnapshotId": {
+          "description": "<p>The snapshot from which the volume was created, if applicable.</p>",
+          "type": "string"
+        },
+        "AvailabilityZone": {
+          "description": "<p>The Availability Zone for the volume.</p>",
+          "type": "string"
+        },
+        "State": {
+          "enum": [
+            "available",
+            "creating",
+            "deleted",
+            "deleting",
+            "error",
+            "in-use"
+          ],
+          "description": "<p>The volume state.</p>",
+          "type": "string"
+        },
+        "CreateTime": {
+          "description": "<p>The time stamp when volume creation was initiated.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "Attachments": {
+          "description": "<note>\n            <p>This parameter is not returned by CreateVolume.</p>\n         </note>\n         <p>Information about the volume attachments.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VolumeAttachment"
+          }
+        },
+        "Encrypted": {
+          "description": "<p>Indicates whether the volume is encrypted.</p>",
+          "type": "boolean"
+        },
+        "KmsKeyId": {
+          "description": "<p>The Amazon Resource Name (ARN) of the KMS key that was used to protect the\n      volume encryption key for the volume.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Tag": {
+      "description": "<p>Describes a tag.</p>",
+      "type": "object",
+      "properties": {
+        "Key": {
+          "description": "<p>The key of the tag.</p>\n         <p>Constraints: Tag keys are case-sensitive and accept a maximum of 127 Unicode characters.\n         May not begin with <code>aws:</code>.</p>",
+          "type": "string"
+        },
+        "Value": {
+          "description": "<p>The value of the tag.</p>\n         <p>Constraints: Tag values are case-sensitive and accept a maximum of 256 Unicode characters.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "VolumeAttachment": {
+      "description": "<p>Describes volume attachment details.</p>",
+      "type": "object",
+      "properties": {
+        "DeleteOnTermination": {
+          "description": "<p>Indicates whether the EBS volume is deleted on instance termination.</p>",
+          "type": "boolean"
+        },
+        "AssociatedResource": {
+          "description": "<p>The ARN of the Amazon ECS or Fargate task\n      to which the volume is attached.</p>",
+          "type": "string"
+        },
+        "InstanceOwningService": {
+          "description": "<p>The service principal of Amazon Web Services service that owns the underlying\n      instance to which the volume is attached.</p>\n         <p>This parameter is returned only for volumes that are attached to\n      Fargate tasks.</p>",
+          "type": "string"
+        },
+        "VolumeId": {
+          "description": "<p>The ID of the volume.</p>",
+          "type": "string"
+        },
+        "InstanceId": {
+          "description": "<p>The ID of the instance.</p>\n         <p>If the volume is attached to a Fargate task, this parameter\n      returns <code>null</code>.</p>",
+          "type": "string"
+        },
+        "Device": {
+          "description": "<p>The device name.</p>\n         <p>If the volume is attached to a Fargate task, this parameter\n      returns <code>null</code>.</p>",
+          "type": "string"
+        },
+        "State": {
+          "enum": [
+            "attached",
+            "attaching",
+            "busy",
+            "detached",
+            "detaching"
+          ],
+          "description": "<p>The attachment state of the volume.</p>",
+          "type": "string"
+        },
+        "AttachTime": {
+          "description": "<p>The time stamp when the attachment initiated.</p>",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "Subnet": {
+      "description": "<p>Describes a subnet.</p>",
+      "type": "object",
+      "properties": {
+        "AvailabilityZoneId": {
+          "description": "<p>The AZ ID of the subnet.</p>",
+          "type": "string"
+        },
+        "EnableLniAtDeviceIndex": {
+          "description": "<p>\n            Indicates the device position for local network interfaces in this subnet. For example,\n            <code>1</code> indicates local network interfaces in this subnet are the secondary\n            network interface (eth1).\n        </p>",
+          "type": "number"
+        },
+        "MapCustomerOwnedIpOnLaunch": {
+          "description": "<p>Indicates whether a network interface created in this subnet (including a network\n            interface created by <a>RunInstances</a>) receives a customer-owned IPv4 address.</p>",
+          "type": "boolean"
+        },
+        "CustomerOwnedIpv4Pool": {
+          "description": "<p>The customer-owned IPv4 address pool associated with the subnet.</p>",
+          "type": "string"
+        },
+        "OwnerId": {
+          "description": "<p>The ID of the Amazon Web Services account that owns the subnet.</p>",
+          "type": "string"
+        },
+        "AssignIpv6AddressOnCreation": {
+          "description": "<p>Indicates whether a network interface created in this subnet (including a network\n            interface created by <a>RunInstances</a>) receives an IPv6 address.</p>",
+          "type": "boolean"
+        },
+        "Ipv6CidrBlockAssociationSet": {
+          "description": "<p>Information about the IPv6 CIDR blocks associated with the subnet.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SubnetIpv6CidrBlockAssociation"
+          }
+        },
+        "Tags": {
+          "description": "<p>Any tags assigned to the subnet.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "SubnetArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the subnet.</p>",
+          "type": "string"
+        },
+        "OutpostArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the Outpost.</p>",
+          "type": "string"
+        },
+        "EnableDns64": {
+          "description": "<p>Indicates whether DNS queries made to the Amazon-provided DNS Resolver in this subnet\n            should return synthetic IPv6 addresses for IPv4-only destinations.</p>",
+          "type": "boolean"
+        },
+        "Ipv6Native": {
+          "description": "<p>Indicates whether this is an IPv6 only subnet.</p>",
+          "type": "boolean"
+        },
+        "PrivateDnsNameOptionsOnLaunch": {
+          "description": "<p>The type of hostnames to assign to instances in the subnet at launch. An instance hostname\n            is based on the IPv4 address or ID of the instance.</p>",
+          "$ref": "#/definitions/PrivateDnsNameOptionsOnLaunch"
+        },
+        "SubnetId": {
+          "description": "<p>The ID of the subnet.</p>",
+          "type": "string"
+        },
+        "State": {
+          "enum": [
+            "available",
+            "pending",
+            "unavailable"
+          ],
+          "description": "<p>The current state of the subnet.</p>",
+          "type": "string"
+        },
+        "VpcId": {
+          "description": "<p>The ID of the VPC the subnet is in.</p>",
+          "type": "string"
+        },
+        "CidrBlock": {
+          "description": "<p>The IPv4 CIDR block assigned to the subnet.</p>",
+          "type": "string"
+        },
+        "AvailableIpAddressCount": {
+          "description": "<p>The number of unused private IPv4 addresses in the subnet. The IPv4 addresses for any\n\t\t\tstopped instances are considered unavailable.</p>",
+          "type": "number"
+        },
+        "AvailabilityZone": {
+          "description": "<p>The Availability Zone of the subnet.</p>",
+          "type": "string"
+        },
+        "DefaultForAz": {
+          "description": "<p>Indicates whether this is the default subnet for the Availability Zone.</p>",
+          "type": "boolean"
+        },
+        "MapPublicIpOnLaunch": {
+          "description": "<p>Indicates whether instances launched in this subnet receive a public IPv4 address.</p>\n         <p>Amazon Web Services charges for all public IPv4 addresses, including public IPv4 addresses\nassociated with running instances and Elastic IP addresses. For more information, see the <i>Public IPv4 Address</i> tab on the <a href=\"http://aws.amazon.com/vpc/pricing/\">Amazon VPC pricing page</a>.</p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "SubnetIpv6CidrBlockAssociation": {
+      "description": "<p>Describes an association between a subnet and an IPv6 CIDR block.</p>",
+      "type": "object",
+      "properties": {
+        "AssociationId": {
+          "description": "<p>The ID of the association.</p>",
+          "type": "string"
+        },
+        "Ipv6CidrBlock": {
+          "description": "<p>The IPv6 CIDR block.</p>",
+          "type": "string"
+        },
+        "Ipv6CidrBlockState": {
+          "description": "<p>The state of the CIDR block.</p>",
+          "$ref": "#/definitions/SubnetCidrBlockState"
+        },
+        "Ipv6AddressAttribute": {
+          "enum": [
+            "private",
+            "public"
+          ],
+          "description": "<p>Public IPv6 addresses are those advertised on the internet from Amazon Web Services. Private IP addresses are not and cannot be advertised on the internet from Amazon Web Services.</p>",
+          "type": "string"
+        },
+        "IpSource": {
+          "enum": [
+            "amazon",
+            "byoip",
+            "none"
+          ],
+          "description": "<p>The source that allocated the IP address space. <code>byoip</code> or <code>amazon</code> indicates public IP address space allocated by Amazon or space that you have allocated with Bring your own IP (BYOIP). <code>none</code> indicates private space.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "SubnetCidrBlockState": {
+      "description": "<p>Describes the state of a CIDR block.</p>",
+      "type": "object",
+      "properties": {
+        "State": {
+          "enum": [
+            "associated",
+            "associating",
+            "disassociated",
+            "disassociating",
+            "failed",
+            "failing"
+          ],
+          "description": "<p>The state of a CIDR block.</p>",
+          "type": "string"
+        },
+        "StatusMessage": {
+          "description": "<p>A message about the status of the CIDR block, if applicable.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "PrivateDnsNameOptionsOnLaunch": {
+      "description": "<p>Describes the options for instance hostnames.</p>",
+      "type": "object",
+      "properties": {
+        "HostnameType": {
+          "enum": [
+            "ip-name",
+            "resource-name"
+          ],
+          "description": "<p>The type of hostname for EC2 instances. For IPv4 only subnets, an instance DNS name\n            must be based on the instance IPv4 address. For IPv6 only subnets, an instance DNS name\n            must be based on the instance ID. For dual-stack subnets, you can specify whether DNS\n            names use the instance IPv4 address or the instance ID.</p>",
+          "type": "string"
+        },
+        "EnableResourceNameDnsARecord": {
+          "description": "<p>Indicates whether to respond to DNS queries for instance hostnames with DNS A\n            records.</p>",
+          "type": "boolean"
+        },
+        "EnableResourceNameDnsAAAARecord": {
+          "description": "<p>Indicates whether to respond to DNS queries for instance hostname with DNS AAAA\n            records.</p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "Vpc": {
+      "description": "<p>Describes a VPC.</p>",
+      "type": "object",
+      "properties": {
+        "OwnerId": {
+          "description": "<p>The ID of the Amazon Web Services account that owns the VPC.</p>",
+          "type": "string"
+        },
+        "InstanceTenancy": {
+          "enum": [
+            "dedicated",
+            "default",
+            "host"
+          ],
+          "description": "<p>The allowed tenancy of instances launched into the VPC.</p>",
+          "type": "string"
+        },
+        "Ipv6CidrBlockAssociationSet": {
+          "description": "<p>Information about the IPv6 CIDR blocks associated with the VPC.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VpcIpv6CidrBlockAssociation"
+          }
+        },
+        "CidrBlockAssociationSet": {
+          "description": "<p>Information about the IPv4 CIDR blocks associated with the VPC.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VpcCidrBlockAssociation"
+          }
+        },
+        "IsDefault": {
+          "description": "<p>Indicates whether the VPC is the default VPC.</p>",
+          "type": "boolean"
+        },
+        "Tags": {
+          "description": "<p>Any tags assigned to the VPC.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "VpcId": {
+          "description": "<p>The ID of the VPC.</p>",
+          "type": "string"
+        },
+        "State": {
+          "enum": [
+            "available",
+            "pending"
+          ],
+          "description": "<p>The current state of the VPC.</p>",
+          "type": "string"
+        },
+        "CidrBlock": {
+          "description": "<p>The primary IPv4 CIDR block for the VPC.</p>",
+          "type": "string"
+        },
+        "DhcpOptionsId": {
+          "description": "<p>The ID of the set of DHCP options you've associated with the VPC.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "VpcIpv6CidrBlockAssociation": {
+      "description": "<p>Describes an IPv6 CIDR block associated with a VPC.</p>",
+      "type": "object",
+      "properties": {
+        "AssociationId": {
+          "description": "<p>The association ID for the IPv6 CIDR block.</p>",
+          "type": "string"
+        },
+        "Ipv6CidrBlock": {
+          "description": "<p>The IPv6 CIDR block.</p>",
+          "type": "string"
+        },
+        "Ipv6CidrBlockState": {
+          "description": "<p>Information about the state of the CIDR block.</p>",
+          "$ref": "#/definitions/VpcCidrBlockState"
+        },
+        "NetworkBorderGroup": {
+          "description": "<p>The name of the unique set of Availability Zones, Local Zones, or Wavelength Zones from\n      which Amazon Web Services advertises IP addresses, for example, <code>us-east-1-wl1-bos-wlz-1</code>.</p>",
+          "type": "string"
+        },
+        "Ipv6Pool": {
+          "description": "<p>The ID of the IPv6 address pool from which the IPv6 CIDR block is allocated.</p>",
+          "type": "string"
+        },
+        "Ipv6AddressAttribute": {
+          "enum": [
+            "private",
+            "public"
+          ],
+          "description": "<p>Public IPv6 addresses are those advertised on the internet from Amazon Web Services. Private IP addresses are not and cannot be advertised on the internet from Amazon Web Services.</p>",
+          "type": "string"
+        },
+        "IpSource": {
+          "enum": [
+            "amazon",
+            "byoip",
+            "none"
+          ],
+          "description": "<p>The source that allocated the IP address space. <code>byoip</code> or <code>amazon</code> indicates public IP address space allocated by Amazon or space that you have allocated with Bring your own IP (BYOIP). <code>none</code> indicates private space.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "VpcCidrBlockState": {
+      "description": "<p>Describes the state of a CIDR block.</p>",
+      "type": "object",
+      "properties": {
+        "State": {
+          "enum": [
+            "associated",
+            "associating",
+            "disassociated",
+            "disassociating",
+            "failed",
+            "failing"
+          ],
+          "description": "<p>The state of the CIDR block.</p>",
+          "type": "string"
+        },
+        "StatusMessage": {
+          "description": "<p>A message about the status of the CIDR block, if applicable.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "VpcCidrBlockAssociation": {
+      "description": "<p>Describes an IPv4 CIDR block associated with a VPC.</p>",
+      "type": "object",
+      "properties": {
+        "AssociationId": {
+          "description": "<p>The association ID for the IPv4 CIDR block.</p>",
+          "type": "string"
+        },
+        "CidrBlock": {
+          "description": "<p>The IPv4 CIDR block.</p>",
+          "type": "string"
+        },
+        "CidrBlockState": {
+          "description": "<p>Information about the state of the CIDR block.</p>",
+          "$ref": "#/definitions/VpcCidrBlockState"
+        }
+      }
+    },
+    "InternetGateway": {
+      "description": "<p>Describes an internet gateway.</p>",
+      "type": "object",
+      "properties": {
+        "Attachments": {
+          "description": "<p>Any VPCs attached to the internet gateway.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InternetGatewayAttachment"
+          }
+        },
+        "InternetGatewayId": {
+          "description": "<p>The ID of the internet gateway.</p>",
+          "type": "string"
+        },
+        "OwnerId": {
+          "description": "<p>The ID of the Amazon Web Services account that owns the internet gateway.</p>",
+          "type": "string"
+        },
+        "Tags": {
+          "description": "<p>Any tags assigned to the internet gateway.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        }
+      }
+    },
+    "InternetGatewayAttachment": {
+      "description": "<p>Describes the attachment of a VPC to an internet gateway or an egress-only internet gateway.</p>",
+      "type": "object",
+      "properties": {
+        "State": {
+          "enum": [
+            "attached",
+            "attaching",
+            "detached",
+            "detaching"
+          ],
+          "description": "<p>The current state of the attachment. For an internet gateway, the state is\n\t\t\t\t<code>available</code> when attached to a VPC; otherwise, this value is not\n\t\t\treturned.</p>",
+          "type": "string"
+        },
+        "VpcId": {
+          "description": "<p>The ID of the VPC.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "NatGateway": {
+      "description": "<p>Describes a NAT gateway.</p>",
+      "type": "object",
+      "properties": {
+        "CreateTime": {
+          "description": "<p>The date and time the NAT gateway was created.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "DeleteTime": {
+          "description": "<p>The date and time the NAT gateway was deleted, if applicable.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "FailureCode": {
+          "description": "<p>If the NAT gateway could not be created, specifies the error code for the failure.\n        (<code>InsufficientFreeAddressesInSubnet</code> | <code>Gateway.NotAttached</code> |\n         <code>InvalidAllocationID.NotFound</code> | <code>Resource.AlreadyAssociated</code> |\n         <code>InternalError</code> | <code>InvalidSubnetID.NotFound</code>)</p>",
+          "type": "string"
+        },
+        "FailureMessage": {
+          "description": "<p>If the NAT gateway could not be created, specifies the error message for the failure, that corresponds to the error code.</p>\n         <ul>\n            <li>\n               <p>For InsufficientFreeAddressesInSubnet: \"Subnet has insufficient free addresses to create this NAT gateway\"</p>\n            </li>\n            <li>\n               <p>For Gateway.NotAttached: \"Network vpc-xxxxxxxx has no Internet gateway attached\"</p>\n            </li>\n            <li>\n               <p>For InvalidAllocationID.NotFound: \"Elastic IP address eipalloc-xxxxxxxx could not be associated with this NAT gateway\"</p>\n            </li>\n            <li>\n               <p>For Resource.AlreadyAssociated: \"Elastic IP address eipalloc-xxxxxxxx is already associated\"</p>\n            </li>\n            <li>\n               <p>For InternalError: \"Network interface eni-xxxxxxxx, created and used internally by this NAT gateway is in an invalid state. Please try again.\"</p>\n            </li>\n            <li>\n               <p>For InvalidSubnetID.NotFound: \"The specified subnet subnet-xxxxxxxx does not exist or could not be found.\"</p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "NatGatewayAddresses": {
+          "description": "<p>Information about the IP addresses and network interface associated with the NAT gateway.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NatGatewayAddress"
+          }
+        },
+        "NatGatewayId": {
+          "description": "<p>The ID of the NAT gateway.</p>",
+          "type": "string"
+        },
+        "ProvisionedBandwidth": {
+          "description": "<p>Reserved. If you need to sustain traffic greater than the <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/amazon-vpc-limits.html#vpc-limits-gateways\">documented limits</a>,\n          contact Amazon Web Services Support.</p>",
+          "$ref": "#/definitions/ProvisionedBandwidth"
+        },
+        "State": {
+          "enum": [
+            "available",
+            "deleted",
+            "deleting",
+            "failed",
+            "pending"
+          ],
+          "description": "<p>The state of the NAT gateway.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>pending</code>: The NAT gateway is being created and is not ready to process\n          traffic.</p>\n            </li>\n            <li>\n               <p>\n                  <code>failed</code>: The NAT gateway could not be created. Check the\n            <code>failureCode</code> and <code>failureMessage</code> fields for the reason.</p>\n            </li>\n            <li>\n               <p>\n                  <code>available</code>: The NAT gateway is able to process traffic. This status remains\n          until you delete the NAT gateway, and does not indicate the health of the NAT gateway.</p>\n            </li>\n            <li>\n               <p>\n                  <code>deleting</code>: The NAT gateway is in the process of being terminated and may\n          still be processing traffic.</p>\n            </li>\n            <li>\n               <p>\n                  <code>deleted</code>: The NAT gateway has been terminated and is no longer processing\n          traffic.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "SubnetId": {
+          "description": "<p>The ID of the subnet in which the NAT gateway is located.</p>",
+          "type": "string"
+        },
+        "VpcId": {
+          "description": "<p>The ID of the VPC in which the NAT gateway is located.</p>",
+          "type": "string"
+        },
+        "Tags": {
+          "description": "<p>The tags for the NAT gateway.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "ConnectivityType": {
+          "enum": [
+            "private",
+            "public"
+          ],
+          "description": "<p>Indicates whether the NAT gateway supports public or private connectivity.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "NatGatewayAddress": {
+      "description": "<p>Describes the IP addresses and network interface associated with a NAT gateway.</p>",
+      "type": "object",
+      "properties": {
+        "AllocationId": {
+          "description": "<p>[Public NAT gateway only] The allocation ID of the Elastic IP address that's associated with the NAT gateway.</p>",
+          "type": "string"
+        },
+        "NetworkInterfaceId": {
+          "description": "<p>The ID of the network interface associated with the NAT gateway.</p>",
+          "type": "string"
+        },
+        "PrivateIp": {
+          "description": "<p>The private IP address associated with the NAT gateway.</p>",
+          "type": "string"
+        },
+        "PublicIp": {
+          "description": "<p>[Public NAT gateway only] The Elastic IP address associated with the NAT gateway.</p>",
+          "type": "string"
+        },
+        "AssociationId": {
+          "description": "<p>[Public NAT gateway only] The association ID of the Elastic IP address that's associated with the NAT gateway.</p>",
+          "type": "string"
+        },
+        "IsPrimary": {
+          "description": "<p>Defines if the IP address is the primary address.</p>",
+          "type": "boolean"
+        },
+        "FailureMessage": {
+          "description": "<p>The address failure message.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "enum": [
+            "assigning",
+            "associating",
+            "disassociating",
+            "failed",
+            "succeeded",
+            "unassigning"
+          ],
+          "description": "<p>The address status.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ProvisionedBandwidth": {
+      "description": "<p>Reserved. If you need to sustain traffic greater than the <a href=\"https://docs.aws.amazon.com/vpc/latest/userguide/amazon-vpc-limits.html#vpc-limits-gateways\">documented limits</a>,\n          contact Amazon Web Services Support.</p>",
+      "type": "object",
+      "properties": {
+        "ProvisionTime": {
+          "description": "<p>Reserved.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "Provisioned": {
+          "description": "<p>Reserved.</p>",
+          "type": "string"
+        },
+        "RequestTime": {
+          "description": "<p>Reserved.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "Requested": {
+          "description": "<p>Reserved.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "description": "<p>Reserved.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "NetworkAcl": {
+      "description": "<p>Describes a network ACL.</p>",
+      "type": "object",
+      "properties": {
+        "Associations": {
+          "description": "<p>Any associations between the network ACL and your subnets</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkAclAssociation"
+          }
+        },
+        "Entries": {
+          "description": "<p>The entries (rules) in the network ACL.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkAclEntry"
+          }
+        },
+        "IsDefault": {
+          "description": "<p>Indicates whether this is the default network ACL for the VPC.</p>",
+          "type": "boolean"
+        },
+        "NetworkAclId": {
+          "description": "<p>The ID of the network ACL.</p>",
+          "type": "string"
+        },
+        "Tags": {
+          "description": "<p>Any tags assigned to the network ACL.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "VpcId": {
+          "description": "<p>The ID of the VPC for the network ACL.</p>",
+          "type": "string"
+        },
+        "OwnerId": {
+          "description": "<p>The ID of the Amazon Web Services account that owns the network ACL.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "NetworkAclAssociation": {
+      "description": "<p>Describes an association between a network ACL and a subnet.</p>",
+      "type": "object",
+      "properties": {
+        "NetworkAclAssociationId": {
+          "description": "<p>The ID of the association between a network ACL and a subnet.</p>",
+          "type": "string"
+        },
+        "NetworkAclId": {
+          "description": "<p>The ID of the network ACL.</p>",
+          "type": "string"
+        },
+        "SubnetId": {
+          "description": "<p>The ID of the subnet.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "NetworkAclEntry": {
+      "description": "<p>Describes an entry in a network ACL.</p>",
+      "type": "object",
+      "properties": {
+        "CidrBlock": {
+          "description": "<p>The IPv4 network range to allow or deny, in CIDR notation.</p>",
+          "type": "string"
+        },
+        "Egress": {
+          "description": "<p>Indicates whether the rule is an egress rule (applied to traffic leaving the subnet).</p>",
+          "type": "boolean"
+        },
+        "IcmpTypeCode": {
+          "description": "<p>ICMP protocol: The ICMP type and code.</p>",
+          "$ref": "#/definitions/IcmpTypeCode"
+        },
+        "Ipv6CidrBlock": {
+          "description": "<p>The IPv6 network range to allow or deny, in CIDR notation.</p>",
+          "type": "string"
+        },
+        "PortRange": {
+          "description": "<p>TCP or UDP protocols: The range of ports the rule applies to.</p>",
+          "$ref": "#/definitions/PortRange"
+        },
+        "Protocol": {
+          "description": "<p>The protocol number. A value of \"-1\" means all protocols.</p>",
+          "type": "string"
+        },
+        "RuleAction": {
+          "enum": [
+            "allow",
+            "deny"
+          ],
+          "description": "<p>Indicates whether to allow or deny the traffic that matches the rule.</p>",
+          "type": "string"
+        },
+        "RuleNumber": {
+          "description": "<p>The rule number for the entry. ACL entries are processed in ascending order by rule number.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "IcmpTypeCode": {
+      "description": "<p>Describes the ICMP type and code.</p>",
+      "type": "object",
+      "properties": {
+        "Code": {
+          "description": "<p>The ICMP code. A value of -1 means all codes for the specified ICMP type.</p>",
+          "type": "number"
+        },
+        "Type": {
+          "description": "<p>The ICMP type. A value of -1 means all types.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "PortRange": {
+      "description": "<p>Describes a range of ports.</p>",
+      "type": "object",
+      "properties": {
+        "From": {
+          "description": "<p>The first port in the range.</p>",
+          "type": "number"
+        },
+        "To": {
+          "description": "<p>The last port in the range.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "NetworkInterface": {
+      "description": "<p>Describes a network interface.</p>",
+      "type": "object",
+      "properties": {
+        "Association": {
+          "description": "<p>The association information for an Elastic IP address (IPv4) associated with the network interface.</p>",
+          "$ref": "#/definitions/NetworkInterfaceAssociation"
+        },
+        "Attachment": {
+          "description": "<p>The network interface attachment.</p>",
+          "$ref": "#/definitions/NetworkInterfaceAttachment"
+        },
+        "AvailabilityZone": {
+          "description": "<p>The Availability Zone.</p>",
+          "type": "string"
+        },
+        "ConnectionTrackingConfiguration": {
+          "description": "<p>A security group connection tracking configuration that enables you to set the timeout for connection tracking on an Elastic network interface. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-connection-tracking.html#connection-tracking-timeouts\">Connection tracking timeouts</a> in the <i>Amazon EC2 User Guide</i>.</p>",
+          "$ref": "#/definitions/ConnectionTrackingConfiguration"
+        },
+        "Description": {
+          "description": "<p>A description.</p>",
+          "type": "string"
+        },
+        "Groups": {
+          "description": "<p>Any security groups for the network interface.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GroupIdentifier"
+          }
+        },
+        "InterfaceType": {
+          "enum": [
+            "api_gateway_managed",
+            "aws_codestar_connections_managed",
+            "branch",
+            "efa",
+            "efa-only",
+            "gateway_load_balancer",
+            "gateway_load_balancer_endpoint",
+            "global_accelerator_managed",
+            "interface",
+            "iot_rules_managed",
+            "lambda",
+            "load_balancer",
+            "natGateway",
+            "network_load_balancer",
+            "quicksight",
+            "transit_gateway",
+            "trunk",
+            "vpc_endpoint"
+          ],
+          "description": "<p>The type of network interface.</p>",
+          "type": "string"
+        },
+        "Ipv6Addresses": {
+          "description": "<p>The IPv6 addresses associated with the network interface.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkInterfaceIpv6Address"
+          }
+        },
+        "MacAddress": {
+          "description": "<p>The MAC address.</p>",
+          "type": "string"
+        },
+        "NetworkInterfaceId": {
+          "description": "<p>The ID of the network interface.</p>",
+          "type": "string"
+        },
+        "OutpostArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the Outpost.</p>",
+          "type": "string"
+        },
+        "OwnerId": {
+          "description": "<p>The Amazon Web Services account ID of the owner of the network interface.</p>",
+          "type": "string"
+        },
+        "PrivateDnsName": {
+          "description": "<p>The private DNS name.</p>",
+          "type": "string"
+        },
+        "PrivateIpAddress": {
+          "description": "<p>The IPv4 address of the network interface within the subnet.</p>",
+          "type": "string"
+        },
+        "PrivateIpAddresses": {
+          "description": "<p>The private IPv4 addresses associated with the network interface.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkInterfacePrivateIpAddress"
+          }
+        },
+        "Ipv4Prefixes": {
+          "description": "<p>The IPv4 prefixes that are assigned to the network interface.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Ipv4PrefixSpecification"
+          }
+        },
+        "Ipv6Prefixes": {
+          "description": "<p>The IPv6 prefixes that are assigned to the network interface.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Ipv6PrefixSpecification"
+          }
+        },
+        "RequesterId": {
+          "description": "<p>The alias or Amazon Web Services account ID of the principal or service that created the network interface.</p>",
+          "type": "string"
+        },
+        "RequesterManaged": {
+          "description": "<p>Indicates whether the network interface is being managed by Amazon Web Services.</p>",
+          "type": "boolean"
+        },
+        "SourceDestCheck": {
+          "description": "<p>Indicates whether source/destination checking is enabled.</p>",
+          "type": "boolean"
+        },
+        "Status": {
+          "enum": [
+            "associated",
+            "attaching",
+            "available",
+            "detaching",
+            "in-use"
+          ],
+          "description": "<p>The status of the network interface.</p>",
+          "type": "string"
+        },
+        "SubnetId": {
+          "description": "<p>The ID of the subnet.</p>",
+          "type": "string"
+        },
+        "TagSet": {
+          "description": "<p>Any tags assigned to the network interface.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "VpcId": {
+          "description": "<p>The ID of the VPC.</p>",
+          "type": "string"
+        },
+        "DenyAllIgwTraffic": {
+          "description": "<p>Indicates whether a network interface with an IPv6 address is unreachable from the\n            public internet. If the value is <code>true</code>, inbound traffic from the internet\n            is dropped and you cannot assign an elastic IP address to the network interface. The\n            network interface is reachable from peered VPCs and resources connected through a\n            transit gateway, including on-premises networks.</p>",
+          "type": "boolean"
+        },
+        "Ipv6Native": {
+          "description": "<p>Indicates whether this is an IPv6 only network interface.</p>",
+          "type": "boolean"
+        },
+        "Ipv6Address": {
+          "description": "<p>The IPv6 globally unique address associated with the network interface.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "NetworkInterfaceAssociation": {
+      "description": "<p>Describes association information for an Elastic IP address (IPv4 only), or a Carrier\n            IP address (for a network interface which resides in a subnet in a Wavelength\n            Zone).</p>",
+      "type": "object",
+      "properties": {
+        "AllocationId": {
+          "description": "<p>The allocation ID.</p>",
+          "type": "string"
+        },
+        "AssociationId": {
+          "description": "<p>The association ID.</p>",
+          "type": "string"
+        },
+        "IpOwnerId": {
+          "description": "<p>The ID of the Elastic IP address owner.</p>",
+          "type": "string"
+        },
+        "PublicDnsName": {
+          "description": "<p>The public DNS name.</p>",
+          "type": "string"
+        },
+        "PublicIp": {
+          "description": "<p>The address of the Elastic IP address bound to the network\n            interface.</p>",
+          "type": "string"
+        },
+        "CustomerOwnedIp": {
+          "description": "<p>The customer-owned IP address associated with the network interface.</p>",
+          "type": "string"
+        },
+        "CarrierIp": {
+          "description": "<p>The carrier IP address associated with the network interface.</p>\n         <p>This option is only available when the network interface is in a subnet which is associated with a Wavelength Zone.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "NetworkInterfaceAttachment": {
+      "description": "<p>Describes a network interface attachment.</p>",
+      "type": "object",
+      "properties": {
+        "AttachTime": {
+          "description": "<p>The timestamp indicating when the attachment initiated.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "AttachmentId": {
+          "description": "<p>The ID of the network interface attachment.</p>",
+          "type": "string"
+        },
+        "DeleteOnTermination": {
+          "description": "<p>Indicates whether the network interface is deleted when the instance is terminated.</p>",
+          "type": "boolean"
+        },
+        "DeviceIndex": {
+          "description": "<p>The device index of the network interface attachment on the instance.</p>",
+          "type": "number"
+        },
+        "NetworkCardIndex": {
+          "description": "<p>The index of the network card.</p>",
+          "type": "number"
+        },
+        "InstanceId": {
+          "description": "<p>The ID of the instance.</p>",
+          "type": "string"
+        },
+        "InstanceOwnerId": {
+          "description": "<p>The Amazon Web Services account ID of the owner of the instance.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "enum": [
+            "attached",
+            "attaching",
+            "detached",
+            "detaching"
+          ],
+          "description": "<p>The attachment state.</p>",
+          "type": "string"
+        },
+        "EnaSrdSpecification": {
+          "description": "<p>Configures ENA Express for the network interface that this action attaches to the instance.</p>",
+          "$ref": "#/definitions/AttachmentEnaSrdSpecification"
+        }
+      }
+    },
+    "AttachmentEnaSrdSpecification": {
+      "description": "<p>ENA Express uses Amazon Web Services Scalable Reliable Datagram (SRD) technology to increase the\n\t\t\tmaximum bandwidth used per stream and minimize tail latency of network traffic between EC2 instances.\n\t\t\tWith ENA Express, you can communicate between two EC2 instances in the same subnet within the same\n\t\t\taccount, or in different accounts. Both sending and receiving instances must have ENA Express enabled.</p>\n         <p>To improve the reliability of network packet delivery, ENA Express reorders network packets on the\n\t\t\treceiving end by default. However, some UDP-based applications are designed to handle network packets\n\t\t\tthat are out of order to reduce the overhead for packet delivery at the network layer. When ENA Express\n\t\t\tis enabled, you can specify whether UDP network traffic uses it.</p>",
+      "type": "object",
+      "properties": {
+        "EnaSrdEnabled": {
+          "description": "<p>Indicates whether ENA Express is enabled for the network interface.</p>",
+          "type": "boolean"
+        },
+        "EnaSrdUdpSpecification": {
+          "description": "<p>Configures ENA Express for UDP network traffic.</p>",
+          "$ref": "#/definitions/AttachmentEnaSrdUdpSpecification"
+        }
+      }
+    },
+    "AttachmentEnaSrdUdpSpecification": {
+      "description": "<p>ENA Express is compatible with both TCP and UDP transport protocols. When it's enabled, TCP traffic\n\t\t\tautomatically uses it. However, some UDP-based applications are designed to handle network packets that are\n\t\t\tout of order, without a need for retransmission, such as live video broadcasting or other near-real-time\n\t\t\tapplications. For UDP traffic, you can specify whether to use ENA Express, based on your application\n\t\t\tenvironment needs.</p>",
+      "type": "object",
+      "properties": {
+        "EnaSrdUdpEnabled": {
+          "description": "<p>Indicates whether UDP traffic to and from the instance uses ENA Express. To specify this setting,\n\t\t\tyou must first enable ENA Express.</p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "ConnectionTrackingConfiguration": {
+      "description": "<p>A security group connection tracking configuration that enables you to set the idle timeout for connection tracking on an Elastic network interface. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-connection-tracking.html#connection-tracking-timeouts\">Connection tracking timeouts</a> in the <i>Amazon EC2 User Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "TcpEstablishedTimeout": {
+          "description": "<p>Timeout (in seconds) for idle TCP\n\t\t\t\t\t\tconnections in an established state. Min: 60 seconds. Max: 432000 seconds (5\n\t\t\t\t\t\tdays). Default: 432000 seconds. Recommended: Less than 432000 seconds.</p>",
+          "type": "number"
+        },
+        "UdpStreamTimeout": {
+          "description": "<p>Timeout (in seconds) for idle UDP\n\t\t\t\t\t\tflows classified as streams which have seen more than one request-response\n\t\t\t\t\t\ttransaction. Min: 60 seconds. Max: 180 seconds (3 minutes). Default: 180\n\t\t\t\t\t\tseconds.</p>",
+          "type": "number"
+        },
+        "UdpTimeout": {
+          "description": "<p>Timeout (in seconds) for idle UDP flows that\n\t\t\t\t\t\thave seen traffic only in a single direction or a single request-response\n\t\t\t\t\t\ttransaction. Min: 30 seconds. Max: 60 seconds. Default: 30 seconds.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "GroupIdentifier": {
+      "description": "<p>Describes a security group.</p>",
+      "type": "object",
+      "properties": {
+        "GroupId": {
+          "description": "<p>The ID of the security group.</p>",
+          "type": "string"
+        },
+        "GroupName": {
+          "description": "<p>The name of the security group.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "NetworkInterfaceIpv6Address": {
+      "description": "<p>Describes an IPv6 address associated with a network interface.</p>",
+      "type": "object",
+      "properties": {
+        "Ipv6Address": {
+          "description": "<p>The IPv6 address.</p>",
+          "type": "string"
+        },
+        "IsPrimaryIpv6": {
+          "description": "<p>Determines if an IPv6 address associated with a network interface is the primary IPv6 address. When you enable an IPv6 GUA address to be a primary IPv6, the first IPv6 GUA will be made the primary IPv6 address until the instance is terminated or the network interface is detached.\n            For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyNetworkInterfaceAttribute.html\">ModifyNetworkInterfaceAttribute</a>.</p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "NetworkInterfacePrivateIpAddress": {
+      "description": "<p>Describes the private IPv4 address of a network interface.</p>",
+      "type": "object",
+      "properties": {
+        "Association": {
+          "description": "<p>The association information for an Elastic IP address (IPv4) associated with the network interface.</p>",
+          "$ref": "#/definitions/NetworkInterfaceAssociation"
+        },
+        "Primary": {
+          "description": "<p>Indicates whether this IPv4 address is the primary private IPv4 address of the network interface.</p>",
+          "type": "boolean"
+        },
+        "PrivateDnsName": {
+          "description": "<p>The private DNS name.</p>",
+          "type": "string"
+        },
+        "PrivateIpAddress": {
+          "description": "<p>The private IPv4 address.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Ipv4PrefixSpecification": {
+      "description": "<p>Describes an IPv4 prefix.</p>",
+      "type": "object",
+      "properties": {
+        "Ipv4Prefix": {
+          "description": "<p>The IPv4 prefix. For information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-prefix-eni.html\">\n            Assigning prefixes to network interfaces</a> in the\n                <i>Amazon EC2 User Guide</i>.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Ipv6PrefixSpecification": {
+      "description": "<p>Describes the IPv6 prefix.</p>",
+      "type": "object",
+      "properties": {
+        "Ipv6Prefix": {
+          "description": "<p>The IPv6 prefix.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "RouteTable": {
+      "description": "<p>Describes a route table.</p>",
+      "type": "object",
+      "properties": {
+        "Associations": {
+          "description": "<p>The associations between the route table and your subnets or gateways.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RouteTableAssociation"
+          }
+        },
+        "PropagatingVgws": {
+          "description": "<p>Any virtual private gateway (VGW) propagating routes.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PropagatingVgw"
+          }
+        },
+        "RouteTableId": {
+          "description": "<p>The ID of the route table.</p>",
+          "type": "string"
+        },
+        "Routes": {
+          "description": "<p>The routes in the route table.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Route"
+          }
+        },
+        "Tags": {
+          "description": "<p>Any tags assigned to the route table.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "VpcId": {
+          "description": "<p>The ID of the VPC.</p>",
+          "type": "string"
+        },
+        "OwnerId": {
+          "description": "<p>The ID of the Amazon Web Services account that owns the route table.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "RouteTableAssociation": {
+      "description": "<p>Describes an association between a route table and a subnet or gateway.</p>",
+      "type": "object",
+      "properties": {
+        "Main": {
+          "description": "<p>Indicates whether this is the main route table.</p>",
+          "type": "boolean"
+        },
+        "RouteTableAssociationId": {
+          "description": "<p>The ID of the association.</p>",
+          "type": "string"
+        },
+        "RouteTableId": {
+          "description": "<p>The ID of the route table.</p>",
+          "type": "string"
+        },
+        "SubnetId": {
+          "description": "<p>The ID of the subnet. A subnet ID is not returned for an implicit association.</p>",
+          "type": "string"
+        },
+        "GatewayId": {
+          "description": "<p>The ID of the internet gateway or virtual private gateway.</p>",
+          "type": "string"
+        },
+        "AssociationState": {
+          "description": "<p>The state of the association.</p>",
+          "$ref": "#/definitions/RouteTableAssociationState"
+        }
+      }
+    },
+    "RouteTableAssociationState": {
+      "description": "<p>Describes the state of an association between a route table and a subnet or gateway.</p>",
+      "type": "object",
+      "properties": {
+        "State": {
+          "enum": [
+            "associated",
+            "associating",
+            "disassociated",
+            "disassociating",
+            "failed"
+          ],
+          "description": "<p>The state of the association.</p>",
+          "type": "string"
+        },
+        "StatusMessage": {
+          "description": "<p>The status message, if applicable.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "PropagatingVgw": {
+      "description": "<p>Describes a virtual private gateway propagating route.</p>",
+      "type": "object",
+      "properties": {
+        "GatewayId": {
+          "description": "<p>The ID of the virtual private gateway.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Route": {
+      "description": "<p>Describes a route in a route table.</p>",
+      "type": "object",
+      "properties": {
+        "DestinationCidrBlock": {
+          "description": "<p>The IPv4 CIDR block used for the destination match.</p>",
+          "type": "string"
+        },
+        "DestinationIpv6CidrBlock": {
+          "description": "<p>The IPv6 CIDR block used for the destination match.</p>",
+          "type": "string"
+        },
+        "DestinationPrefixListId": {
+          "description": "<p>The prefix of the Amazon Web Services service.</p>",
+          "type": "string"
+        },
+        "EgressOnlyInternetGatewayId": {
+          "description": "<p>The ID of the egress-only internet gateway.</p>",
+          "type": "string"
+        },
+        "GatewayId": {
+          "description": "<p>The ID of a gateway attached to your VPC.</p>",
+          "type": "string"
+        },
+        "InstanceId": {
+          "description": "<p>The ID of a NAT instance in your VPC.</p>",
+          "type": "string"
+        },
+        "InstanceOwnerId": {
+          "description": "<p>The ID of Amazon Web Services account that owns the instance.</p>",
+          "type": "string"
+        },
+        "NatGatewayId": {
+          "description": "<p>The ID of a NAT gateway.</p>",
+          "type": "string"
+        },
+        "TransitGatewayId": {
+          "description": "<p>The ID of a transit gateway.</p>",
+          "type": "string"
+        },
+        "LocalGatewayId": {
+          "description": "<p>The ID of the local gateway.</p>",
+          "type": "string"
+        },
+        "CarrierGatewayId": {
+          "description": "<p>The ID of the carrier gateway.</p>",
+          "type": "string"
+        },
+        "NetworkInterfaceId": {
+          "description": "<p>The ID of the network interface.</p>",
+          "type": "string"
+        },
+        "Origin": {
+          "enum": [
+            "CreateRoute",
+            "CreateRouteTable",
+            "EnableVgwRoutePropagation"
+          ],
+          "description": "<p>Describes how the route was created.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CreateRouteTable</code> - The route was automatically created when the route table was created.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CreateRoute</code> - The route was manually added to the route table.</p>\n            </li>\n            <li>\n               <p>\n                  <code>EnableVgwRoutePropagation</code> - The route was propagated by route propagation.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "State": {
+          "enum": [
+            "active",
+            "blackhole"
+          ],
+          "description": "<p>The state of the route. The <code>blackhole</code> state indicates that the\n\t\t\t\troute's target isn't available (for example, the specified gateway isn't attached to the\n\t\t\t\tVPC, or the specified NAT instance has been terminated).</p>",
+          "type": "string"
+        },
+        "VpcPeeringConnectionId": {
+          "description": "<p>The ID of a VPC peering connection.</p>",
+          "type": "string"
+        },
+        "CoreNetworkArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the core network.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "TransitGateway": {
+      "description": "<p>Describes a transit gateway.</p>",
+      "type": "object",
+      "properties": {
+        "TransitGatewayId": {
+          "description": "<p>The ID of the transit gateway.</p>",
+          "type": "string"
+        },
+        "TransitGatewayArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the transit gateway.</p>",
+          "type": "string"
+        },
+        "State": {
+          "enum": [
+            "available",
+            "deleted",
+            "deleting",
+            "modifying",
+            "pending"
+          ],
+          "description": "<p>The state of the transit gateway.</p>",
+          "type": "string"
+        },
+        "OwnerId": {
+          "description": "<p>The ID of the Amazon Web Services account that owns the transit gateway.</p>",
+          "type": "string"
+        },
+        "Description": {
+          "description": "<p>The description of the transit gateway.</p>",
+          "type": "string"
+        },
+        "CreationTime": {
+          "description": "<p>The creation time.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "Options": {
+          "description": "<p>The transit gateway options.</p>",
+          "$ref": "#/definitions/TransitGatewayOptions"
+        },
+        "Tags": {
+          "description": "<p>The tags for the transit gateway.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        }
+      }
+    },
+    "TransitGatewayOptions": {
+      "description": "<p>Describes the options for a transit gateway.</p>",
+      "type": "object",
+      "properties": {
+        "AmazonSideAsn": {
+          "description": "<p>A private Autonomous System Number (ASN) for the Amazon side of a BGP session.\n         The range is 64512 to 65534 for 16-bit ASNs and 4200000000 to 4294967294 for 32-bit ASNs.</p>",
+          "type": "number"
+        },
+        "TransitGatewayCidrBlocks": {
+          "description": "<p>The transit gateway CIDR blocks.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AutoAcceptSharedAttachments": {
+          "enum": [
+            "disable",
+            "enable"
+          ],
+          "description": "<p>Indicates whether attachment requests are automatically accepted.</p>",
+          "type": "string"
+        },
+        "DefaultRouteTableAssociation": {
+          "enum": [
+            "disable",
+            "enable"
+          ],
+          "description": "<p>Indicates whether resource attachments are automatically associated with the default association route table.</p>",
+          "type": "string"
+        },
+        "AssociationDefaultRouteTableId": {
+          "description": "<p>The ID of the default association route table.</p>",
+          "type": "string"
+        },
+        "DefaultRouteTablePropagation": {
+          "enum": [
+            "disable",
+            "enable"
+          ],
+          "description": "<p>Indicates whether resource attachments automatically propagate routes to the default propagation route table.</p>",
+          "type": "string"
+        },
+        "PropagationDefaultRouteTableId": {
+          "description": "<p>The ID of the default propagation route table.</p>",
+          "type": "string"
+        },
+        "VpnEcmpSupport": {
+          "enum": [
+            "disable",
+            "enable"
+          ],
+          "description": "<p>Indicates whether Equal Cost Multipath Protocol support is enabled.</p>",
+          "type": "string"
+        },
+        "DnsSupport": {
+          "enum": [
+            "disable",
+            "enable"
+          ],
+          "description": "<p>Indicates whether DNS support is enabled.</p>",
+          "type": "string"
+        },
+        "SecurityGroupReferencingSupport": {
+          "enum": [
+            "disable",
+            "enable"
+          ],
+          "description": "<p>Enables you to reference a security group across VPCs attached to a transit gateway to simplify security group management.\n\n</p>\n         <p>This option is disabled by default.</p>",
+          "type": "string"
+        },
+        "MulticastSupport": {
+          "enum": [
+            "disable",
+            "enable"
+          ],
+          "description": "<p>Indicates whether multicast is enabled on the transit gateway</p>",
+          "type": "string"
+        }
+      }
+    },
+    "VpcEndpoint": {
+      "description": "<p>Describes a VPC endpoint.</p>",
+      "type": "object",
+      "properties": {
+        "VpcEndpointId": {
+          "description": "<p>The ID of the endpoint.</p>",
+          "type": "string"
+        },
+        "VpcEndpointType": {
+          "enum": [
+            "Gateway",
+            "GatewayLoadBalancer",
+            "Interface"
+          ],
+          "description": "<p>The type of endpoint.</p>",
+          "type": "string"
+        },
+        "VpcId": {
+          "description": "<p>The ID of the VPC to which the endpoint is associated.</p>",
+          "type": "string"
+        },
+        "ServiceName": {
+          "description": "<p>The name of the service to which the endpoint is associated.</p>",
+          "type": "string"
+        },
+        "State": {
+          "enum": [
+            "Available",
+            "Deleted",
+            "Deleting",
+            "Expired",
+            "Failed",
+            "Pending",
+            "PendingAcceptance",
+            "Rejected"
+          ],
+          "description": "<p>The state of the endpoint.</p>",
+          "type": "string"
+        },
+        "PolicyDocument": {
+          "description": "<p>The policy document associated with the endpoint, if applicable.</p>",
+          "type": "string"
+        },
+        "RouteTableIds": {
+          "description": "<p>(Gateway endpoint) The IDs of the route tables associated with the endpoint.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "SubnetIds": {
+          "description": "<p>(Interface endpoint) The subnets for the endpoint.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Groups": {
+          "description": "<p>(Interface endpoint) Information about the security groups that are associated with\n            the network interface.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecurityGroupIdentifier"
+          }
+        },
+        "IpAddressType": {
+          "enum": [
+            "dualstack",
+            "ipv4",
+            "ipv6"
+          ],
+          "description": "<p>The IP address type for the endpoint.</p>",
+          "type": "string"
+        },
+        "DnsOptions": {
+          "description": "<p>The DNS options for the endpoint.</p>",
+          "$ref": "#/definitions/DnsOptions"
+        },
+        "PrivateDnsEnabled": {
+          "description": "<p>(Interface endpoint) Indicates whether the VPC is associated with a private hosted zone.</p>",
+          "type": "boolean"
+        },
+        "RequesterManaged": {
+          "description": "<p>Indicates whether the endpoint is being managed by its service.</p>",
+          "type": "boolean"
+        },
+        "NetworkInterfaceIds": {
+          "description": "<p>(Interface endpoint) The network interfaces for the endpoint.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "DnsEntries": {
+          "description": "<p>(Interface endpoint) The DNS entries for the endpoint.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DnsEntry"
+          }
+        },
+        "CreationTimestamp": {
+          "description": "<p>The date and time that the endpoint was created.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "Tags": {
+          "description": "<p>The tags assigned to the endpoint.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "OwnerId": {
+          "description": "<p>The ID of the Amazon Web Services account that owns the endpoint.</p>",
+          "type": "string"
+        },
+        "LastError": {
+          "description": "<p>The last error that occurred for endpoint.</p>",
+          "$ref": "#/definitions/LastError"
+        }
+      }
+    },
+    "SecurityGroupIdentifier": {
+      "description": "<p>Describes a security group.</p>",
+      "type": "object",
+      "properties": {
+        "GroupId": {
+          "description": "<p>The ID of the security group.</p>",
+          "type": "string"
+        },
+        "GroupName": {
+          "description": "<p>The name of the security group.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "DnsOptions": {
+      "description": "<p>Describes the DNS options for an endpoint.</p>",
+      "type": "object",
+      "properties": {
+        "DnsRecordIpType": {
+          "enum": [
+            "dualstack",
+            "ipv4",
+            "ipv6",
+            "service-defined"
+          ],
+          "description": "<p>The DNS records created for the endpoint.</p>",
+          "type": "string"
+        },
+        "PrivateDnsOnlyForInboundResolverEndpoint": {
+          "description": "<p>Indicates whether to enable private DNS only for inbound endpoints.</p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "DnsEntry": {
+      "description": "<p>Describes a DNS entry.</p>",
+      "type": "object",
+      "properties": {
+        "DnsName": {
+          "description": "<p>The DNS name.</p>",
+          "type": "string"
+        },
+        "HostedZoneId": {
+          "description": "<p>The ID of the private hosted zone.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "LastError": {
+      "description": "<p>The last error that occurred for a VPC endpoint.</p>",
+      "type": "object",
+      "properties": {
+        "Message": {
+          "description": "<p>The error message for the VPC endpoint error.</p>",
+          "type": "string"
+        },
+        "Code": {
+          "description": "<p>The error code for the VPC endpoint error.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "VpnGateway": {
+      "description": "<p>Describes a virtual private gateway.</p>",
+      "type": "object",
+      "properties": {
+        "AmazonSideAsn": {
+          "description": "<p>The private Autonomous System Number (ASN) for the Amazon side of a BGP\n            session.</p>",
+          "type": "number"
+        },
+        "Tags": {
+          "description": "<p>Any tags assigned to the virtual private gateway.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "VpnGatewayId": {
+          "description": "<p>The ID of the virtual private gateway.</p>",
+          "type": "string"
+        },
+        "State": {
+          "enum": [
+            "available",
+            "deleted",
+            "deleting",
+            "pending"
+          ],
+          "description": "<p>The current state of the virtual private gateway.</p>",
+          "type": "string"
+        },
+        "Type": {
+          "enum": "",
+          "description": "<p>The type of VPN connection the virtual private gateway supports.</p>",
+          "const": "ipsec.1",
+          "type": "string"
+        },
+        "AvailabilityZone": {
+          "description": "<p>The Availability Zone where the virtual private gateway was created, if applicable.\n            This field may be empty or not returned.</p>",
+          "type": "string"
+        },
+        "VpcAttachments": {
+          "description": "<p>Any VPCs attached to the virtual private gateway.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VpcAttachment"
+          }
+        }
+      }
+    },
+    "VpcAttachment": {
+      "description": "<p>Describes an attachment between a virtual private gateway and a VPC.</p>",
+      "type": "object",
+      "properties": {
+        "VpcId": {
+          "description": "<p>The ID of the VPC.</p>",
+          "type": "string"
+        },
+        "State": {
+          "enum": [
+            "attached",
+            "attaching",
+            "detached",
+            "detaching"
+          ],
+          "description": "<p>The current state of the attachment.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Instance_1": {
+      "description": "<p>Describes an instance.</p>",
+      "type": "object",
+      "properties": {
+        "Architecture": {
+          "enum": [
+            "arm64",
+            "arm64_mac",
+            "i386",
+            "x86_64",
+            "x86_64_mac"
+          ],
+          "description": "<p>The architecture of the image.</p>",
+          "type": "string"
+        },
+        "BlockDeviceMappings": {
+          "description": "<p>Any block device mapping entries for the instance.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InstanceBlockDeviceMapping"
+          }
+        },
+        "ClientToken": {
+          "description": "<p>The idempotency token you provided when you launched the instance, if\n            applicable.</p>",
+          "type": "string"
+        },
+        "EbsOptimized": {
+          "description": "<p>Indicates whether the instance is optimized for Amazon EBS I/O. This optimization\n            provides dedicated throughput to Amazon EBS and an optimized configuration stack to\n            provide optimal I/O performance. This optimization isn't available with all instance\n            types. Additional usage charges apply when using an EBS Optimized instance.</p>",
+          "type": "boolean"
+        },
+        "EnaSupport": {
+          "description": "<p>Specifies whether enhanced networking with ENA is enabled.</p>",
+          "type": "boolean"
+        },
+        "Hypervisor": {
+          "enum": [
+            "ovm",
+            "xen"
+          ],
+          "description": "<p>The hypervisor type of the instance. The value <code>xen</code> is used for both Xen\n            and Nitro hypervisors.</p>",
+          "type": "string"
+        },
+        "IamInstanceProfile": {
+          "description": "<p>The IAM instance profile associated with the instance, if\n            applicable.</p>",
+          "$ref": "#/definitions/IamInstanceProfile"
+        },
+        "InstanceLifecycle": {
+          "enum": [
+            "capacity-block",
+            "scheduled",
+            "spot"
+          ],
+          "description": "<p>Indicates whether this is a Spot Instance or a Scheduled Instance.</p>",
+          "type": "string"
+        },
+        "ElasticGpuAssociations": {
+          "description": "<p>Deprecated.</p>\n         <note>\n            <p>Amazon Elastic Graphics reached end of life on January 8, 2024.</p>\n         </note>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ElasticGpuAssociation"
+          }
+        },
+        "ElasticInferenceAcceleratorAssociations": {
+          "description": "<p>Deprecated</p>\n         <note>\n            <p>Amazon Elastic Inference is no longer available.</p>\n         </note>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ElasticInferenceAcceleratorAssociation"
+          }
+        },
+        "NetworkInterfaces": {
+          "description": "<p>The network interfaces for the instance.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InstanceNetworkInterface"
+          }
+        },
+        "OutpostArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the Outpost.</p>",
+          "type": "string"
+        },
+        "RootDeviceName": {
+          "description": "<p>The device name of the root device volume (for example,\n            <code>/dev/sda1</code>).</p>",
+          "type": "string"
+        },
+        "RootDeviceType": {
+          "enum": [
+            "ebs",
+            "instance-store"
+          ],
+          "description": "<p>The root device type used by the AMI. The AMI can use an EBS volume or an instance\n            store volume.</p>",
+          "type": "string"
+        },
+        "SecurityGroups": {
+          "description": "<p>The security groups for the instance.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GroupIdentifier"
+          }
+        },
+        "SourceDestCheck": {
+          "description": "<p>Indicates whether source/destination checking is enabled.</p>",
+          "type": "boolean"
+        },
+        "SpotInstanceRequestId": {
+          "description": "<p>If the request is a Spot Instance request, the ID of the request.</p>",
+          "type": "string"
+        },
+        "SriovNetSupport": {
+          "description": "<p>Specifies whether enhanced networking with the Intel 82599 Virtual Function interface\n            is enabled.</p>",
+          "type": "string"
+        },
+        "StateReason": {
+          "description": "<p>The reason for the most recent state transition.</p>",
+          "$ref": "#/definitions/StateReason"
+        },
+        "Tags": {
+          "description": "<p>Any tags assigned to the instance.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "VirtualizationType": {
+          "enum": [
+            "hvm",
+            "paravirtual"
+          ],
+          "description": "<p>The virtualization type of the instance.</p>",
+          "type": "string"
+        },
+        "CpuOptions": {
+          "description": "<p>The CPU options for the instance.</p>",
+          "$ref": "#/definitions/CpuOptions"
+        },
+        "CapacityReservationId": {
+          "description": "<p>The ID of the Capacity Reservation.</p>",
+          "type": "string"
+        },
+        "CapacityReservationSpecification": {
+          "description": "<p>Information about the Capacity Reservation targeting option.</p>",
+          "$ref": "#/definitions/CapacityReservationSpecificationResponse"
+        },
+        "HibernationOptions": {
+          "description": "<p>Indicates whether the instance is enabled for hibernation.</p>",
+          "$ref": "#/definitions/HibernationOptions"
+        },
+        "Licenses": {
+          "description": "<p>The license configurations for the instance.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LicenseConfiguration"
+          }
+        },
+        "MetadataOptions": {
+          "description": "<p>The metadata options for the instance.</p>",
+          "$ref": "#/definitions/InstanceMetadataOptionsResponse"
+        },
+        "EnclaveOptions": {
+          "description": "<p>Indicates whether the instance is enabled for Amazon Web Services Nitro\n            Enclaves.</p>",
+          "$ref": "#/definitions/EnclaveOptions"
+        },
+        "BootMode": {
+          "enum": [
+            "legacy-bios",
+            "uefi",
+            "uefi-preferred"
+          ],
+          "description": "<p>The boot mode that was specified by the AMI. If the value is <code>uefi-preferred</code>,\n            the AMI supports both UEFI and Legacy BIOS. The <code>currentInstanceBootMode</code> parameter\n            is the boot mode that is used to boot the instance at launch or start.</p>\n         <note>\n            <p>The operating system contained in the AMI must be configured to support the specified boot mode.</p>\n         </note>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ami-boot.html\">Boot modes</a> in the\n                <i>Amazon EC2 User Guide</i>.</p>",
+          "type": "string"
+        },
+        "PlatformDetails": {
+          "description": "<p>The platform details value for the instance. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/billing-info-fields.html\">AMI\n                billing information fields</a> in the\n            <i>Amazon EC2 User Guide</i>.</p>",
+          "type": "string"
+        },
+        "UsageOperation": {
+          "description": "<p>The usage operation value for the instance. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/billing-info-fields.html\">AMI\n                billing information fields</a> in the\n            <i>Amazon EC2 User Guide</i>.</p>",
+          "type": "string"
+        },
+        "UsageOperationUpdateTime": {
+          "description": "<p>The time that the usage operation was last updated.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "PrivateDnsNameOptions": {
+          "description": "<p>The options for the instance hostname.</p>",
+          "$ref": "#/definitions/PrivateDnsNameOptionsResponse"
+        },
+        "Ipv6Address": {
+          "description": "<p>The IPv6 address assigned to the instance.</p>",
+          "type": "string"
+        },
+        "TpmSupport": {
+          "description": "<p>If the instance is configured for NitroTPM support, the value is <code>v2.0</code>.\n            For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nitrotpm.html\">NitroTPM</a> in the\n                <i>Amazon EC2 User Guide</i>.</p>",
+          "type": "string"
+        },
+        "MaintenanceOptions": {
+          "description": "<p>Provides information on the recovery and maintenance options of your instance.</p>",
+          "$ref": "#/definitions/InstanceMaintenanceOptions"
+        },
+        "CurrentInstanceBootMode": {
+          "enum": [
+            "legacy-bios",
+            "uefi"
+          ],
+          "description": "<p>The boot mode that is used to boot the instance at launch or start. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ami-boot.html\">Boot modes</a> in the\n            <i>Amazon EC2 User Guide</i>.</p>",
+          "type": "string"
+        },
+        "InstanceId": {
+          "description": "<p>The ID of the instance.</p>",
+          "type": "string"
+        },
+        "ImageId": {
+          "description": "<p>The ID of the AMI used to launch the instance.</p>",
+          "type": "string"
+        },
+        "State": {
+          "description": "<p>The current state of the instance.</p>",
+          "$ref": "#/definitions/InstanceState"
+        },
+        "PrivateDnsName": {
+          "description": "<p>[IPv4 only] The private DNS hostname name assigned to the instance. This DNS hostname\n            can only be used inside the Amazon EC2 network. This name is not available until the\n            instance enters the <code>running</code> state. </p>\n         <p>The Amazon-provided DNS server resolves Amazon-provided private DNS\n            hostnames if you've enabled DNS resolution and DNS hostnames in your VPC. If you are not\n            using the Amazon-provided DNS server in your VPC, your custom domain name servers must\n            resolve the hostname as appropriate.</p>",
+          "type": "string"
+        },
+        "PublicDnsName": {
+          "description": "<p>[IPv4 only] The public DNS name assigned to the instance. This name is not available\n            until the instance enters the <code>running</code> state. This name is only\n            available if you've enabled DNS hostnames for your VPC.</p>",
+          "type": "string"
+        },
+        "StateTransitionReason": {
+          "description": "<p>The reason for the most recent state transition. This might be an empty string.</p>",
+          "type": "string"
+        },
+        "KeyName": {
+          "description": "<p>The name of the key pair, if this instance was launched with an associated key\n            pair.</p>",
+          "type": "string"
+        },
+        "AmiLaunchIndex": {
+          "description": "<p>The AMI launch index, which can be used to find this instance in the launch\n            group.</p>",
+          "type": "number"
+        },
+        "ProductCodes": {
+          "description": "<p>The product codes attached to this instance, if applicable.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ProductCode"
+          }
+        },
+        "InstanceType": {
+          "enum": [
+            "a1.2xlarge",
+            "a1.4xlarge",
+            "a1.large",
+            "a1.medium",
+            "a1.metal",
+            "a1.xlarge",
+            "c1.medium",
+            "c1.xlarge",
+            "c3.2xlarge",
+            "c3.4xlarge",
+            "c3.8xlarge",
+            "c3.large",
+            "c3.xlarge",
+            "c4.2xlarge",
+            "c4.4xlarge",
+            "c4.8xlarge",
+            "c4.large",
+            "c4.xlarge",
+            "c5.12xlarge",
+            "c5.18xlarge",
+            "c5.24xlarge",
+            "c5.2xlarge",
+            "c5.4xlarge",
+            "c5.9xlarge",
+            "c5.large",
+            "c5.metal",
+            "c5.xlarge",
+            "c5a.12xlarge",
+            "c5a.16xlarge",
+            "c5a.24xlarge",
+            "c5a.2xlarge",
+            "c5a.4xlarge",
+            "c5a.8xlarge",
+            "c5a.large",
+            "c5a.xlarge",
+            "c5ad.12xlarge",
+            "c5ad.16xlarge",
+            "c5ad.24xlarge",
+            "c5ad.2xlarge",
+            "c5ad.4xlarge",
+            "c5ad.8xlarge",
+            "c5ad.large",
+            "c5ad.xlarge",
+            "c5d.12xlarge",
+            "c5d.18xlarge",
+            "c5d.24xlarge",
+            "c5d.2xlarge",
+            "c5d.4xlarge",
+            "c5d.9xlarge",
+            "c5d.large",
+            "c5d.metal",
+            "c5d.xlarge",
+            "c5n.18xlarge",
+            "c5n.2xlarge",
+            "c5n.4xlarge",
+            "c5n.9xlarge",
+            "c5n.large",
+            "c5n.metal",
+            "c5n.xlarge",
+            "c6a.12xlarge",
+            "c6a.16xlarge",
+            "c6a.24xlarge",
+            "c6a.2xlarge",
+            "c6a.32xlarge",
+            "c6a.48xlarge",
+            "c6a.4xlarge",
+            "c6a.8xlarge",
+            "c6a.large",
+            "c6a.metal",
+            "c6a.xlarge",
+            "c6g.12xlarge",
+            "c6g.16xlarge",
+            "c6g.2xlarge",
+            "c6g.4xlarge",
+            "c6g.8xlarge",
+            "c6g.large",
+            "c6g.medium",
+            "c6g.metal",
+            "c6g.xlarge",
+            "c6gd.12xlarge",
+            "c6gd.16xlarge",
+            "c6gd.2xlarge",
+            "c6gd.4xlarge",
+            "c6gd.8xlarge",
+            "c6gd.large",
+            "c6gd.medium",
+            "c6gd.metal",
+            "c6gd.xlarge",
+            "c6gn.12xlarge",
+            "c6gn.16xlarge",
+            "c6gn.2xlarge",
+            "c6gn.4xlarge",
+            "c6gn.8xlarge",
+            "c6gn.large",
+            "c6gn.medium",
+            "c6gn.xlarge",
+            "c6i.12xlarge",
+            "c6i.16xlarge",
+            "c6i.24xlarge",
+            "c6i.2xlarge",
+            "c6i.32xlarge",
+            "c6i.4xlarge",
+            "c6i.8xlarge",
+            "c6i.large",
+            "c6i.metal",
+            "c6i.xlarge",
+            "c6id.12xlarge",
+            "c6id.16xlarge",
+            "c6id.24xlarge",
+            "c6id.2xlarge",
+            "c6id.32xlarge",
+            "c6id.4xlarge",
+            "c6id.8xlarge",
+            "c6id.large",
+            "c6id.metal",
+            "c6id.xlarge",
+            "c6in.12xlarge",
+            "c6in.16xlarge",
+            "c6in.24xlarge",
+            "c6in.2xlarge",
+            "c6in.32xlarge",
+            "c6in.4xlarge",
+            "c6in.8xlarge",
+            "c6in.large",
+            "c6in.metal",
+            "c6in.xlarge",
+            "c7a.12xlarge",
+            "c7a.16xlarge",
+            "c7a.24xlarge",
+            "c7a.2xlarge",
+            "c7a.32xlarge",
+            "c7a.48xlarge",
+            "c7a.4xlarge",
+            "c7a.8xlarge",
+            "c7a.large",
+            "c7a.medium",
+            "c7a.metal-48xl",
+            "c7a.xlarge",
+            "c7g.12xlarge",
+            "c7g.16xlarge",
+            "c7g.2xlarge",
+            "c7g.4xlarge",
+            "c7g.8xlarge",
+            "c7g.large",
+            "c7g.medium",
+            "c7g.metal",
+            "c7g.xlarge",
+            "c7gd.12xlarge",
+            "c7gd.16xlarge",
+            "c7gd.2xlarge",
+            "c7gd.4xlarge",
+            "c7gd.8xlarge",
+            "c7gd.large",
+            "c7gd.medium",
+            "c7gd.metal",
+            "c7gd.xlarge",
+            "c7gn.12xlarge",
+            "c7gn.16xlarge",
+            "c7gn.2xlarge",
+            "c7gn.4xlarge",
+            "c7gn.8xlarge",
+            "c7gn.large",
+            "c7gn.medium",
+            "c7gn.metal",
+            "c7gn.xlarge",
+            "c7i-flex.2xlarge",
+            "c7i-flex.4xlarge",
+            "c7i-flex.8xlarge",
+            "c7i-flex.large",
+            "c7i-flex.xlarge",
+            "c7i.12xlarge",
+            "c7i.16xlarge",
+            "c7i.24xlarge",
+            "c7i.2xlarge",
+            "c7i.48xlarge",
+            "c7i.4xlarge",
+            "c7i.8xlarge",
+            "c7i.large",
+            "c7i.metal-24xl",
+            "c7i.metal-48xl",
+            "c7i.xlarge",
+            "c8g.12xlarge",
+            "c8g.16xlarge",
+            "c8g.24xlarge",
+            "c8g.2xlarge",
+            "c8g.48xlarge",
+            "c8g.4xlarge",
+            "c8g.8xlarge",
+            "c8g.large",
+            "c8g.medium",
+            "c8g.metal-24xl",
+            "c8g.metal-48xl",
+            "c8g.xlarge",
+            "cc1.4xlarge",
+            "cc2.8xlarge",
+            "cg1.4xlarge",
+            "cr1.8xlarge",
+            "d2.2xlarge",
+            "d2.4xlarge",
+            "d2.8xlarge",
+            "d2.xlarge",
+            "d3.2xlarge",
+            "d3.4xlarge",
+            "d3.8xlarge",
+            "d3.xlarge",
+            "d3en.12xlarge",
+            "d3en.2xlarge",
+            "d3en.4xlarge",
+            "d3en.6xlarge",
+            "d3en.8xlarge",
+            "d3en.xlarge",
+            "dl1.24xlarge",
+            "dl2q.24xlarge",
+            "f1.16xlarge",
+            "f1.2xlarge",
+            "f1.4xlarge",
+            "g2.2xlarge",
+            "g2.8xlarge",
+            "g3.16xlarge",
+            "g3.4xlarge",
+            "g3.8xlarge",
+            "g3s.xlarge",
+            "g4ad.16xlarge",
+            "g4ad.2xlarge",
+            "g4ad.4xlarge",
+            "g4ad.8xlarge",
+            "g4ad.xlarge",
+            "g4dn.12xlarge",
+            "g4dn.16xlarge",
+            "g4dn.2xlarge",
+            "g4dn.4xlarge",
+            "g4dn.8xlarge",
+            "g4dn.metal",
+            "g4dn.xlarge",
+            "g5.12xlarge",
+            "g5.16xlarge",
+            "g5.24xlarge",
+            "g5.2xlarge",
+            "g5.48xlarge",
+            "g5.4xlarge",
+            "g5.8xlarge",
+            "g5.xlarge",
+            "g5g.16xlarge",
+            "g5g.2xlarge",
+            "g5g.4xlarge",
+            "g5g.8xlarge",
+            "g5g.metal",
+            "g5g.xlarge",
+            "g6.12xlarge",
+            "g6.16xlarge",
+            "g6.24xlarge",
+            "g6.2xlarge",
+            "g6.48xlarge",
+            "g6.4xlarge",
+            "g6.8xlarge",
+            "g6.xlarge",
+            "g6e.12xlarge",
+            "g6e.16xlarge",
+            "g6e.24xlarge",
+            "g6e.2xlarge",
+            "g6e.48xlarge",
+            "g6e.4xlarge",
+            "g6e.8xlarge",
+            "g6e.xlarge",
+            "gr6.4xlarge",
+            "gr6.8xlarge",
+            "h1.16xlarge",
+            "h1.2xlarge",
+            "h1.4xlarge",
+            "h1.8xlarge",
+            "hi1.4xlarge",
+            "hpc6a.48xlarge",
+            "hpc6id.32xlarge",
+            "hpc7a.12xlarge",
+            "hpc7a.24xlarge",
+            "hpc7a.48xlarge",
+            "hpc7a.96xlarge",
+            "hpc7g.16xlarge",
+            "hpc7g.4xlarge",
+            "hpc7g.8xlarge",
+            "hs1.8xlarge",
+            "i2.2xlarge",
+            "i2.4xlarge",
+            "i2.8xlarge",
+            "i2.xlarge",
+            "i3.16xlarge",
+            "i3.2xlarge",
+            "i3.4xlarge",
+            "i3.8xlarge",
+            "i3.large",
+            "i3.metal",
+            "i3.xlarge",
+            "i3en.12xlarge",
+            "i3en.24xlarge",
+            "i3en.2xlarge",
+            "i3en.3xlarge",
+            "i3en.6xlarge",
+            "i3en.large",
+            "i3en.metal",
+            "i3en.xlarge",
+            "i4g.16xlarge",
+            "i4g.2xlarge",
+            "i4g.4xlarge",
+            "i4g.8xlarge",
+            "i4g.large",
+            "i4g.xlarge",
+            "i4i.12xlarge",
+            "i4i.16xlarge",
+            "i4i.24xlarge",
+            "i4i.2xlarge",
+            "i4i.32xlarge",
+            "i4i.4xlarge",
+            "i4i.8xlarge",
+            "i4i.large",
+            "i4i.metal",
+            "i4i.xlarge",
+            "im4gn.16xlarge",
+            "im4gn.2xlarge",
+            "im4gn.4xlarge",
+            "im4gn.8xlarge",
+            "im4gn.large",
+            "im4gn.xlarge",
+            "inf1.24xlarge",
+            "inf1.2xlarge",
+            "inf1.6xlarge",
+            "inf1.xlarge",
+            "inf2.24xlarge",
+            "inf2.48xlarge",
+            "inf2.8xlarge",
+            "inf2.xlarge",
+            "is4gen.2xlarge",
+            "is4gen.4xlarge",
+            "is4gen.8xlarge",
+            "is4gen.large",
+            "is4gen.medium",
+            "is4gen.xlarge",
+            "m1.large",
+            "m1.medium",
+            "m1.small",
+            "m1.xlarge",
+            "m2.2xlarge",
+            "m2.4xlarge",
+            "m2.xlarge",
+            "m3.2xlarge",
+            "m3.large",
+            "m3.medium",
+            "m3.xlarge",
+            "m4.10xlarge",
+            "m4.16xlarge",
+            "m4.2xlarge",
+            "m4.4xlarge",
+            "m4.large",
+            "m4.xlarge",
+            "m5.12xlarge",
+            "m5.16xlarge",
+            "m5.24xlarge",
+            "m5.2xlarge",
+            "m5.4xlarge",
+            "m5.8xlarge",
+            "m5.large",
+            "m5.metal",
+            "m5.xlarge",
+            "m5a.12xlarge",
+            "m5a.16xlarge",
+            "m5a.24xlarge",
+            "m5a.2xlarge",
+            "m5a.4xlarge",
+            "m5a.8xlarge",
+            "m5a.large",
+            "m5a.xlarge",
+            "m5ad.12xlarge",
+            "m5ad.16xlarge",
+            "m5ad.24xlarge",
+            "m5ad.2xlarge",
+            "m5ad.4xlarge",
+            "m5ad.8xlarge",
+            "m5ad.large",
+            "m5ad.xlarge",
+            "m5d.12xlarge",
+            "m5d.16xlarge",
+            "m5d.24xlarge",
+            "m5d.2xlarge",
+            "m5d.4xlarge",
+            "m5d.8xlarge",
+            "m5d.large",
+            "m5d.metal",
+            "m5d.xlarge",
+            "m5dn.12xlarge",
+            "m5dn.16xlarge",
+            "m5dn.24xlarge",
+            "m5dn.2xlarge",
+            "m5dn.4xlarge",
+            "m5dn.8xlarge",
+            "m5dn.large",
+            "m5dn.metal",
+            "m5dn.xlarge",
+            "m5n.12xlarge",
+            "m5n.16xlarge",
+            "m5n.24xlarge",
+            "m5n.2xlarge",
+            "m5n.4xlarge",
+            "m5n.8xlarge",
+            "m5n.large",
+            "m5n.metal",
+            "m5n.xlarge",
+            "m5zn.12xlarge",
+            "m5zn.2xlarge",
+            "m5zn.3xlarge",
+            "m5zn.6xlarge",
+            "m5zn.large",
+            "m5zn.metal",
+            "m5zn.xlarge",
+            "m6a.12xlarge",
+            "m6a.16xlarge",
+            "m6a.24xlarge",
+            "m6a.2xlarge",
+            "m6a.32xlarge",
+            "m6a.48xlarge",
+            "m6a.4xlarge",
+            "m6a.8xlarge",
+            "m6a.large",
+            "m6a.metal",
+            "m6a.xlarge",
+            "m6g.12xlarge",
+            "m6g.16xlarge",
+            "m6g.2xlarge",
+            "m6g.4xlarge",
+            "m6g.8xlarge",
+            "m6g.large",
+            "m6g.medium",
+            "m6g.metal",
+            "m6g.xlarge",
+            "m6gd.12xlarge",
+            "m6gd.16xlarge",
+            "m6gd.2xlarge",
+            "m6gd.4xlarge",
+            "m6gd.8xlarge",
+            "m6gd.large",
+            "m6gd.medium",
+            "m6gd.metal",
+            "m6gd.xlarge",
+            "m6i.12xlarge",
+            "m6i.16xlarge",
+            "m6i.24xlarge",
+            "m6i.2xlarge",
+            "m6i.32xlarge",
+            "m6i.4xlarge",
+            "m6i.8xlarge",
+            "m6i.large",
+            "m6i.metal",
+            "m6i.xlarge",
+            "m6id.12xlarge",
+            "m6id.16xlarge",
+            "m6id.24xlarge",
+            "m6id.2xlarge",
+            "m6id.32xlarge",
+            "m6id.4xlarge",
+            "m6id.8xlarge",
+            "m6id.large",
+            "m6id.metal",
+            "m6id.xlarge",
+            "m6idn.12xlarge",
+            "m6idn.16xlarge",
+            "m6idn.24xlarge",
+            "m6idn.2xlarge",
+            "m6idn.32xlarge",
+            "m6idn.4xlarge",
+            "m6idn.8xlarge",
+            "m6idn.large",
+            "m6idn.metal",
+            "m6idn.xlarge",
+            "m6in.12xlarge",
+            "m6in.16xlarge",
+            "m6in.24xlarge",
+            "m6in.2xlarge",
+            "m6in.32xlarge",
+            "m6in.4xlarge",
+            "m6in.8xlarge",
+            "m6in.large",
+            "m6in.metal",
+            "m6in.xlarge",
+            "m7a.12xlarge",
+            "m7a.16xlarge",
+            "m7a.24xlarge",
+            "m7a.2xlarge",
+            "m7a.32xlarge",
+            "m7a.48xlarge",
+            "m7a.4xlarge",
+            "m7a.8xlarge",
+            "m7a.large",
+            "m7a.medium",
+            "m7a.metal-48xl",
+            "m7a.xlarge",
+            "m7g.12xlarge",
+            "m7g.16xlarge",
+            "m7g.2xlarge",
+            "m7g.4xlarge",
+            "m7g.8xlarge",
+            "m7g.large",
+            "m7g.medium",
+            "m7g.metal",
+            "m7g.xlarge",
+            "m7gd.12xlarge",
+            "m7gd.16xlarge",
+            "m7gd.2xlarge",
+            "m7gd.4xlarge",
+            "m7gd.8xlarge",
+            "m7gd.large",
+            "m7gd.medium",
+            "m7gd.metal",
+            "m7gd.xlarge",
+            "m7i-flex.2xlarge",
+            "m7i-flex.4xlarge",
+            "m7i-flex.8xlarge",
+            "m7i-flex.large",
+            "m7i-flex.xlarge",
+            "m7i.12xlarge",
+            "m7i.16xlarge",
+            "m7i.24xlarge",
+            "m7i.2xlarge",
+            "m7i.48xlarge",
+            "m7i.4xlarge",
+            "m7i.8xlarge",
+            "m7i.large",
+            "m7i.metal-24xl",
+            "m7i.metal-48xl",
+            "m7i.xlarge",
+            "m8g.12xlarge",
+            "m8g.16xlarge",
+            "m8g.24xlarge",
+            "m8g.2xlarge",
+            "m8g.48xlarge",
+            "m8g.4xlarge",
+            "m8g.8xlarge",
+            "m8g.large",
+            "m8g.medium",
+            "m8g.metal-24xl",
+            "m8g.metal-48xl",
+            "m8g.xlarge",
+            "mac1.metal",
+            "mac2-m1ultra.metal",
+            "mac2-m2.metal",
+            "mac2-m2pro.metal",
+            "mac2.metal",
+            "p2.16xlarge",
+            "p2.8xlarge",
+            "p2.xlarge",
+            "p3.16xlarge",
+            "p3.2xlarge",
+            "p3.8xlarge",
+            "p3dn.24xlarge",
+            "p4d.24xlarge",
+            "p4de.24xlarge",
+            "p5.48xlarge",
+            "r3.2xlarge",
+            "r3.4xlarge",
+            "r3.8xlarge",
+            "r3.large",
+            "r3.xlarge",
+            "r4.16xlarge",
+            "r4.2xlarge",
+            "r4.4xlarge",
+            "r4.8xlarge",
+            "r4.large",
+            "r4.xlarge",
+            "r5.12xlarge",
+            "r5.16xlarge",
+            "r5.24xlarge",
+            "r5.2xlarge",
+            "r5.4xlarge",
+            "r5.8xlarge",
+            "r5.large",
+            "r5.metal",
+            "r5.xlarge",
+            "r5a.12xlarge",
+            "r5a.16xlarge",
+            "r5a.24xlarge",
+            "r5a.2xlarge",
+            "r5a.4xlarge",
+            "r5a.8xlarge",
+            "r5a.large",
+            "r5a.xlarge",
+            "r5ad.12xlarge",
+            "r5ad.16xlarge",
+            "r5ad.24xlarge",
+            "r5ad.2xlarge",
+            "r5ad.4xlarge",
+            "r5ad.8xlarge",
+            "r5ad.large",
+            "r5ad.xlarge",
+            "r5b.12xlarge",
+            "r5b.16xlarge",
+            "r5b.24xlarge",
+            "r5b.2xlarge",
+            "r5b.4xlarge",
+            "r5b.8xlarge",
+            "r5b.large",
+            "r5b.metal",
+            "r5b.xlarge",
+            "r5d.12xlarge",
+            "r5d.16xlarge",
+            "r5d.24xlarge",
+            "r5d.2xlarge",
+            "r5d.4xlarge",
+            "r5d.8xlarge",
+            "r5d.large",
+            "r5d.metal",
+            "r5d.xlarge",
+            "r5dn.12xlarge",
+            "r5dn.16xlarge",
+            "r5dn.24xlarge",
+            "r5dn.2xlarge",
+            "r5dn.4xlarge",
+            "r5dn.8xlarge",
+            "r5dn.large",
+            "r5dn.metal",
+            "r5dn.xlarge",
+            "r5n.12xlarge",
+            "r5n.16xlarge",
+            "r5n.24xlarge",
+            "r5n.2xlarge",
+            "r5n.4xlarge",
+            "r5n.8xlarge",
+            "r5n.large",
+            "r5n.metal",
+            "r5n.xlarge",
+            "r6a.12xlarge",
+            "r6a.16xlarge",
+            "r6a.24xlarge",
+            "r6a.2xlarge",
+            "r6a.32xlarge",
+            "r6a.48xlarge",
+            "r6a.4xlarge",
+            "r6a.8xlarge",
+            "r6a.large",
+            "r6a.metal",
+            "r6a.xlarge",
+            "r6g.12xlarge",
+            "r6g.16xlarge",
+            "r6g.2xlarge",
+            "r6g.4xlarge",
+            "r6g.8xlarge",
+            "r6g.large",
+            "r6g.medium",
+            "r6g.metal",
+            "r6g.xlarge",
+            "r6gd.12xlarge",
+            "r6gd.16xlarge",
+            "r6gd.2xlarge",
+            "r6gd.4xlarge",
+            "r6gd.8xlarge",
+            "r6gd.large",
+            "r6gd.medium",
+            "r6gd.metal",
+            "r6gd.xlarge",
+            "r6i.12xlarge",
+            "r6i.16xlarge",
+            "r6i.24xlarge",
+            "r6i.2xlarge",
+            "r6i.32xlarge",
+            "r6i.4xlarge",
+            "r6i.8xlarge",
+            "r6i.large",
+            "r6i.metal",
+            "r6i.xlarge",
+            "r6id.12xlarge",
+            "r6id.16xlarge",
+            "r6id.24xlarge",
+            "r6id.2xlarge",
+            "r6id.32xlarge",
+            "r6id.4xlarge",
+            "r6id.8xlarge",
+            "r6id.large",
+            "r6id.metal",
+            "r6id.xlarge",
+            "r6idn.12xlarge",
+            "r6idn.16xlarge",
+            "r6idn.24xlarge",
+            "r6idn.2xlarge",
+            "r6idn.32xlarge",
+            "r6idn.4xlarge",
+            "r6idn.8xlarge",
+            "r6idn.large",
+            "r6idn.metal",
+            "r6idn.xlarge",
+            "r6in.12xlarge",
+            "r6in.16xlarge",
+            "r6in.24xlarge",
+            "r6in.2xlarge",
+            "r6in.32xlarge",
+            "r6in.4xlarge",
+            "r6in.8xlarge",
+            "r6in.large",
+            "r6in.metal",
+            "r6in.xlarge",
+            "r7a.12xlarge",
+            "r7a.16xlarge",
+            "r7a.24xlarge",
+            "r7a.2xlarge",
+            "r7a.32xlarge",
+            "r7a.48xlarge",
+            "r7a.4xlarge",
+            "r7a.8xlarge",
+            "r7a.large",
+            "r7a.medium",
+            "r7a.metal-48xl",
+            "r7a.xlarge",
+            "r7g.12xlarge",
+            "r7g.16xlarge",
+            "r7g.2xlarge",
+            "r7g.4xlarge",
+            "r7g.8xlarge",
+            "r7g.large",
+            "r7g.medium",
+            "r7g.metal",
+            "r7g.xlarge",
+            "r7gd.12xlarge",
+            "r7gd.16xlarge",
+            "r7gd.2xlarge",
+            "r7gd.4xlarge",
+            "r7gd.8xlarge",
+            "r7gd.large",
+            "r7gd.medium",
+            "r7gd.metal",
+            "r7gd.xlarge",
+            "r7i.12xlarge",
+            "r7i.16xlarge",
+            "r7i.24xlarge",
+            "r7i.2xlarge",
+            "r7i.48xlarge",
+            "r7i.4xlarge",
+            "r7i.8xlarge",
+            "r7i.large",
+            "r7i.metal-24xl",
+            "r7i.metal-48xl",
+            "r7i.xlarge",
+            "r7iz.12xlarge",
+            "r7iz.16xlarge",
+            "r7iz.2xlarge",
+            "r7iz.32xlarge",
+            "r7iz.4xlarge",
+            "r7iz.8xlarge",
+            "r7iz.large",
+            "r7iz.metal-16xl",
+            "r7iz.metal-32xl",
+            "r7iz.xlarge",
+            "r8g.12xlarge",
+            "r8g.16xlarge",
+            "r8g.24xlarge",
+            "r8g.2xlarge",
+            "r8g.48xlarge",
+            "r8g.4xlarge",
+            "r8g.8xlarge",
+            "r8g.large",
+            "r8g.medium",
+            "r8g.metal-24xl",
+            "r8g.metal-48xl",
+            "r8g.xlarge",
+            "t1.micro",
+            "t2.2xlarge",
+            "t2.large",
+            "t2.medium",
+            "t2.micro",
+            "t2.nano",
+            "t2.small",
+            "t2.xlarge",
+            "t3.2xlarge",
+            "t3.large",
+            "t3.medium",
+            "t3.micro",
+            "t3.nano",
+            "t3.small",
+            "t3.xlarge",
+            "t3a.2xlarge",
+            "t3a.large",
+            "t3a.medium",
+            "t3a.micro",
+            "t3a.nano",
+            "t3a.small",
+            "t3a.xlarge",
+            "t4g.2xlarge",
+            "t4g.large",
+            "t4g.medium",
+            "t4g.micro",
+            "t4g.nano",
+            "t4g.small",
+            "t4g.xlarge",
+            "trn1.2xlarge",
+            "trn1.32xlarge",
+            "trn1n.32xlarge",
+            "u-12tb1.112xlarge",
+            "u-12tb1.metal",
+            "u-18tb1.112xlarge",
+            "u-18tb1.metal",
+            "u-24tb1.112xlarge",
+            "u-24tb1.metal",
+            "u-3tb1.56xlarge",
+            "u-6tb1.112xlarge",
+            "u-6tb1.56xlarge",
+            "u-6tb1.metal",
+            "u-9tb1.112xlarge",
+            "u-9tb1.metal",
+            "u7i-12tb.224xlarge",
+            "u7ib-12tb.224xlarge",
+            "u7in-16tb.224xlarge",
+            "u7in-24tb.224xlarge",
+            "u7in-32tb.224xlarge",
+            "vt1.24xlarge",
+            "vt1.3xlarge",
+            "vt1.6xlarge",
+            "x1.16xlarge",
+            "x1.32xlarge",
+            "x1e.16xlarge",
+            "x1e.2xlarge",
+            "x1e.32xlarge",
+            "x1e.4xlarge",
+            "x1e.8xlarge",
+            "x1e.xlarge",
+            "x2gd.12xlarge",
+            "x2gd.16xlarge",
+            "x2gd.2xlarge",
+            "x2gd.4xlarge",
+            "x2gd.8xlarge",
+            "x2gd.large",
+            "x2gd.medium",
+            "x2gd.metal",
+            "x2gd.xlarge",
+            "x2idn.16xlarge",
+            "x2idn.24xlarge",
+            "x2idn.32xlarge",
+            "x2idn.metal",
+            "x2iedn.16xlarge",
+            "x2iedn.24xlarge",
+            "x2iedn.2xlarge",
+            "x2iedn.32xlarge",
+            "x2iedn.4xlarge",
+            "x2iedn.8xlarge",
+            "x2iedn.metal",
+            "x2iedn.xlarge",
+            "x2iezn.12xlarge",
+            "x2iezn.2xlarge",
+            "x2iezn.4xlarge",
+            "x2iezn.6xlarge",
+            "x2iezn.8xlarge",
+            "x2iezn.metal",
+            "x8g.12xlarge",
+            "x8g.16xlarge",
+            "x8g.24xlarge",
+            "x8g.2xlarge",
+            "x8g.48xlarge",
+            "x8g.4xlarge",
+            "x8g.8xlarge",
+            "x8g.large",
+            "x8g.medium",
+            "x8g.metal-24xl",
+            "x8g.metal-48xl",
+            "x8g.xlarge",
+            "z1d.12xlarge",
+            "z1d.2xlarge",
+            "z1d.3xlarge",
+            "z1d.6xlarge",
+            "z1d.large",
+            "z1d.metal",
+            "z1d.xlarge"
+          ],
+          "description": "<p>The instance type.</p>",
+          "type": "string"
+        },
+        "LaunchTime": {
+          "description": "<p>The time the instance was launched.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "Placement": {
+          "description": "<p>The location where the instance launched, if applicable.</p>",
+          "$ref": "#/definitions/Placement"
+        },
+        "KernelId": {
+          "description": "<p>The kernel associated with this instance, if applicable.</p>",
+          "type": "string"
+        },
+        "RamdiskId": {
+          "description": "<p>The RAM disk associated with this instance, if applicable.</p>",
+          "type": "string"
+        },
+        "Platform": {
+          "enum": "",
+          "description": "<p>The platform. This value is <code>windows</code> for Windows instances; otherwise, it is empty.</p>",
+          "const": "Windows",
+          "type": "string"
+        },
+        "Monitoring": {
+          "description": "<p>The monitoring for the instance.</p>",
+          "$ref": "#/definitions/Monitoring"
+        },
+        "SubnetId": {
+          "description": "<p>The ID of the subnet in which the instance is running.</p>",
+          "type": "string"
+        },
+        "VpcId": {
+          "description": "<p>The ID of the VPC in which the instance is running.</p>",
+          "type": "string"
+        },
+        "PrivateIpAddress": {
+          "description": "<p>The private IPv4 address assigned to the instance.</p>",
+          "type": "string"
+        },
+        "PublicIpAddress": {
+          "description": "<p>The public IPv4 address, or the Carrier IP address assigned to the instance, if\n            applicable.</p>\n         <p>A Carrier IP address only applies to an instance launched in a subnet associated with\n            a Wavelength Zone.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "InstanceBlockDeviceMapping": {
+      "description": "<p>Describes a block device mapping.</p>",
+      "type": "object",
+      "properties": {
+        "DeviceName": {
+          "description": "<p>The device name (for example, <code>/dev/sdh</code> or <code>xvdh</code>).</p>",
+          "type": "string"
+        },
+        "Ebs": {
+          "description": "<p>Parameters used to automatically set up EBS volumes when the instance is\n            launched.</p>",
+          "$ref": "#/definitions/EbsInstanceBlockDevice"
+        }
+      }
+    },
+    "EbsInstanceBlockDevice": {
+      "description": "<p>Describes a parameter used to set up an EBS volume in a block device mapping.</p>",
+      "type": "object",
+      "properties": {
+        "AttachTime": {
+          "description": "<p>The time stamp when the attachment initiated.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "DeleteOnTermination": {
+          "description": "<p>Indicates whether the volume is deleted on instance termination.</p>",
+          "type": "boolean"
+        },
+        "Status": {
+          "enum": [
+            "attached",
+            "attaching",
+            "detached",
+            "detaching"
+          ],
+          "description": "<p>The attachment state.</p>",
+          "type": "string"
+        },
+        "VolumeId": {
+          "description": "<p>The ID of the EBS volume.</p>",
+          "type": "string"
+        },
+        "AssociatedResource": {
+          "description": "<p>The ARN of the Amazon ECS or Fargate task\n            to which the volume is attached.</p>",
+          "type": "string"
+        },
+        "VolumeOwnerId": {
+          "description": "<p>The ID of the Amazon Web Services account that owns the volume.</p>\n         <p>This parameter is returned only for volumes that are attached to\n            Fargate tasks.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "IamInstanceProfile": {
+      "description": "<p>Describes an IAM instance profile.</p>",
+      "type": "object",
+      "properties": {
+        "Arn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the instance profile.</p>",
+          "type": "string"
+        },
+        "Id": {
+          "description": "<p>The ID of the instance profile.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ElasticGpuAssociation": {
+      "description": "<note>\n            <p>Amazon Elastic Graphics reached end of life on January 8, 2024.</p>\n         </note>\n         <p>Describes the association between an instance and an Elastic Graphics accelerator.</p>",
+      "type": "object",
+      "properties": {
+        "ElasticGpuId": {
+          "description": "<p>The ID of the Elastic Graphics accelerator.</p>",
+          "type": "string"
+        },
+        "ElasticGpuAssociationId": {
+          "description": "<p>The ID of the association.</p>",
+          "type": "string"
+        },
+        "ElasticGpuAssociationState": {
+          "description": "<p>The state of the association between the instance and the\n            Elastic Graphics accelerator.</p>",
+          "type": "string"
+        },
+        "ElasticGpuAssociationTime": {
+          "description": "<p>The time the Elastic Graphics accelerator was associated with the instance.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ElasticInferenceAcceleratorAssociation": {
+      "description": "<note>\n            <p>Amazon Elastic Inference is no longer available.</p>\n         </note>\n         <p>\n            Describes the association between an instance and an elastic inference accelerator.\n        </p>",
+      "type": "object",
+      "properties": {
+        "ElasticInferenceAcceleratorArn": {
+          "description": "<p>\n            The Amazon Resource Name (ARN) of the elastic inference accelerator.\n        </p>",
+          "type": "string"
+        },
+        "ElasticInferenceAcceleratorAssociationId": {
+          "description": "<p>\n            The ID of the association.\n        </p>",
+          "type": "string"
+        },
+        "ElasticInferenceAcceleratorAssociationState": {
+          "description": "<p>\n            The state of the elastic inference accelerator.\n        </p>",
+          "type": "string"
+        },
+        "ElasticInferenceAcceleratorAssociationTime": {
+          "description": "<p>\n            The time at which the elastic inference accelerator is associated with an instance.\n        </p>",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "InstanceNetworkInterface": {
+      "description": "<p>Describes a network interface.</p>",
+      "type": "object",
+      "properties": {
+        "Association": {
+          "description": "<p>The association information for an Elastic IPv4 associated with the network\n            interface.</p>",
+          "$ref": "#/definitions/InstanceNetworkInterfaceAssociation"
+        },
+        "Attachment": {
+          "description": "<p>The network interface attachment.</p>",
+          "$ref": "#/definitions/InstanceNetworkInterfaceAttachment"
+        },
+        "Description": {
+          "description": "<p>The description.</p>",
+          "type": "string"
+        },
+        "Groups": {
+          "description": "<p>The security groups.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GroupIdentifier"
+          }
+        },
+        "Ipv6Addresses": {
+          "description": "<p>The IPv6 addresses associated with the network interface.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InstanceIpv6Address"
+          }
+        },
+        "MacAddress": {
+          "description": "<p>The MAC address.</p>",
+          "type": "string"
+        },
+        "NetworkInterfaceId": {
+          "description": "<p>The ID of the network interface.</p>",
+          "type": "string"
+        },
+        "OwnerId": {
+          "description": "<p>The ID of the Amazon Web Services account that created the network interface.</p>",
+          "type": "string"
+        },
+        "PrivateDnsName": {
+          "description": "<p>The private DNS name.</p>",
+          "type": "string"
+        },
+        "PrivateIpAddress": {
+          "description": "<p>The IPv4 address of the network interface within the subnet.</p>",
+          "type": "string"
+        },
+        "PrivateIpAddresses": {
+          "description": "<p>The private IPv4 addresses associated with the network interface.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InstancePrivateIpAddress"
+          }
+        },
+        "SourceDestCheck": {
+          "description": "<p>Indicates whether source/destination checking is enabled.</p>",
+          "type": "boolean"
+        },
+        "Status": {
+          "enum": [
+            "associated",
+            "attaching",
+            "available",
+            "detaching",
+            "in-use"
+          ],
+          "description": "<p>The status of the network interface.</p>",
+          "type": "string"
+        },
+        "SubnetId": {
+          "description": "<p>The ID of the subnet.</p>",
+          "type": "string"
+        },
+        "VpcId": {
+          "description": "<p>The ID of the VPC.</p>",
+          "type": "string"
+        },
+        "InterfaceType": {
+          "description": "<p>The type of network interface.</p>\n         <p>Valid values: <code>interface</code> | <code>efa</code> | <code>efa-only</code> | <code>trunk</code>\n         </p>",
+          "type": "string"
+        },
+        "Ipv4Prefixes": {
+          "description": "<p>The IPv4 delegated prefixes that are assigned to the network interface.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InstanceIpv4Prefix"
+          }
+        },
+        "Ipv6Prefixes": {
+          "description": "<p>The IPv6 delegated prefixes that are assigned to the network interface.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InstanceIpv6Prefix"
+          }
+        },
+        "ConnectionTrackingConfiguration": {
+          "description": "<p>A security group connection tracking configuration that enables you to set the timeout for connection tracking on an Elastic network interface. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-connection-tracking.html#connection-tracking-timeouts\">Connection tracking timeouts</a> in the <i>Amazon EC2 User Guide</i>.</p>",
+          "$ref": "#/definitions/ConnectionTrackingSpecificationResponse"
+        }
+      }
+    },
+    "InstanceNetworkInterfaceAssociation": {
+      "description": "<p>Describes association information for an Elastic IP address (IPv4).</p>",
+      "type": "object",
+      "properties": {
+        "CarrierIp": {
+          "description": "<p>The carrier IP address associated with the network interface.</p>",
+          "type": "string"
+        },
+        "CustomerOwnedIp": {
+          "description": "<p>The customer-owned IP address associated with the network interface.</p>",
+          "type": "string"
+        },
+        "IpOwnerId": {
+          "description": "<p>The ID of the owner of the Elastic IP address.</p>",
+          "type": "string"
+        },
+        "PublicDnsName": {
+          "description": "<p>The public DNS name.</p>",
+          "type": "string"
+        },
+        "PublicIp": {
+          "description": "<p>The public IP address or Elastic IP address bound to the network interface.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "InstanceNetworkInterfaceAttachment": {
+      "description": "<p>Describes a network interface attachment.</p>",
+      "type": "object",
+      "properties": {
+        "AttachTime": {
+          "description": "<p>The time stamp when the attachment initiated.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "AttachmentId": {
+          "description": "<p>The ID of the network interface attachment.</p>",
+          "type": "string"
+        },
+        "DeleteOnTermination": {
+          "description": "<p>Indicates whether the network interface is deleted when the instance is terminated.</p>",
+          "type": "boolean"
+        },
+        "DeviceIndex": {
+          "description": "<p>The index of the device on the instance for the network interface attachment.</p>",
+          "type": "number"
+        },
+        "Status": {
+          "enum": [
+            "attached",
+            "attaching",
+            "detached",
+            "detaching"
+          ],
+          "description": "<p>The attachment state.</p>",
+          "type": "string"
+        },
+        "NetworkCardIndex": {
+          "description": "<p>The index of the network card.</p>",
+          "type": "number"
+        },
+        "EnaSrdSpecification": {
+          "description": "<p>Contains the ENA Express settings for the network interface that's attached\n\t\t\tto the instance.</p>",
+          "$ref": "#/definitions/InstanceAttachmentEnaSrdSpecification"
+        }
+      }
+    },
+    "InstanceAttachmentEnaSrdSpecification": {
+      "description": "<p>ENA Express uses Amazon Web Services Scalable Reliable Datagram (SRD) technology to increase the\n\t\t\tmaximum bandwidth used per stream and minimize tail latency of network traffic between EC2 instances.\n\t\t\tWith ENA Express, you can communicate between two EC2 instances in the same subnet within the same\n\t\t\taccount, or in different accounts. Both sending and receiving instances must have ENA Express enabled.</p>\n         <p>To improve the reliability of network packet delivery, ENA Express reorders network packets on the\n\t\t\treceiving end by default. However, some UDP-based applications are designed to handle network packets\n\t\t\tthat are out of order to reduce the overhead for packet delivery at the network layer. When ENA Express\n\t\t\tis enabled, you can specify whether UDP network traffic uses it.</p>",
+      "type": "object",
+      "properties": {
+        "EnaSrdEnabled": {
+          "description": "<p>Indicates whether ENA Express is enabled for the network interface.</p>",
+          "type": "boolean"
+        },
+        "EnaSrdUdpSpecification": {
+          "description": "<p>Configures ENA Express for UDP network traffic.</p>",
+          "$ref": "#/definitions/InstanceAttachmentEnaSrdUdpSpecification"
+        }
+      }
+    },
+    "InstanceAttachmentEnaSrdUdpSpecification": {
+      "description": "<p>ENA Express is compatible with both TCP and UDP transport protocols. When it's enabled, TCP traffic\n\t\t\tautomatically uses it. However, some UDP-based applications are designed to handle network packets that are\n\t\t\tout of order, without a need for retransmission, such as live video broadcasting or other near-real-time\n\t\t\tapplications. For UDP traffic, you can specify whether to use ENA Express, based on your application\n\t\t\tenvironment needs.</p>",
+      "type": "object",
+      "properties": {
+        "EnaSrdUdpEnabled": {
+          "description": "<p>Indicates whether UDP traffic to and from the instance uses ENA Express. To specify this setting,\n\t\t\tyou must first enable ENA Express.</p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "InstanceIpv6Address": {
+      "description": "<p>Describes an IPv6 address.</p>",
+      "type": "object",
+      "properties": {
+        "Ipv6Address": {
+          "description": "<p>The IPv6 address.</p>",
+          "type": "string"
+        },
+        "IsPrimaryIpv6": {
+          "description": "<p>Determines if an IPv6 address associated with a network interface is the primary IPv6 address. When you enable an IPv6 GUA address to be a primary IPv6, the first IPv6 GUA will be made the primary IPv6 address until the instance is terminated or the network interface is detached.\n            For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html\">RunInstances</a>.</p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "InstancePrivateIpAddress": {
+      "description": "<p>Describes a private IPv4 address.</p>",
+      "type": "object",
+      "properties": {
+        "Association": {
+          "description": "<p>The association information for an Elastic IP address for the network interface.</p>",
+          "$ref": "#/definitions/InstanceNetworkInterfaceAssociation"
+        },
+        "Primary": {
+          "description": "<p>Indicates whether this IPv4 address is the primary private IP address of the network interface.</p>",
+          "type": "boolean"
+        },
+        "PrivateDnsName": {
+          "description": "<p>The private IPv4 DNS name.</p>",
+          "type": "string"
+        },
+        "PrivateIpAddress": {
+          "description": "<p>The private IPv4 address of the network interface.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "InstanceIpv4Prefix": {
+      "description": "<p>Information about an IPv4 prefix.</p>",
+      "type": "object",
+      "properties": {
+        "Ipv4Prefix": {
+          "description": "<p>One or more IPv4 prefixes assigned to the network interface.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "InstanceIpv6Prefix": {
+      "description": "<p>Information about an IPv6 prefix.</p>",
+      "type": "object",
+      "properties": {
+        "Ipv6Prefix": {
+          "description": "<p>One or more IPv6 prefixes assigned to the network interface.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ConnectionTrackingSpecificationResponse": {
+      "description": "<p>A security group connection tracking specification response that enables you to set the idle timeout for connection tracking on an Elastic network interface. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-connection-tracking.html#connection-tracking-timeouts\">Connection tracking timeouts</a> in the <i>Amazon EC2 User Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "TcpEstablishedTimeout": {
+          "description": "<p>Timeout (in seconds) for idle TCP\n\t\t\t\t\t\tconnections in an established state. Min: 60 seconds. Max: 432000 seconds (5\n\t\t\t\t\t\tdays). Default: 432000 seconds. Recommended: Less than 432000 seconds.</p>",
+          "type": "number"
+        },
+        "UdpStreamTimeout": {
+          "description": "<p>Timeout (in seconds) for idle UDP\n\t\t\t\t\t\tflows classified as streams which have seen more than one request-response\n\t\t\t\t\t\ttransaction. Min: 60 seconds. Max: 180 seconds (3 minutes). Default: 180\n\t\t\t\t\t\tseconds.</p>",
+          "type": "number"
+        },
+        "UdpTimeout": {
+          "description": "<p>Timeout (in seconds) for idle UDP flows that\n\t\t\t\t\t\thave seen traffic only in a single direction or a single request-response\n\t\t\t\t\t\ttransaction. Min: 30 seconds. Max: 60 seconds. Default: 30 seconds.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "StateReason": {
+      "description": "<p>Describes a state change.</p>",
+      "type": "object",
+      "properties": {
+        "Code": {
+          "description": "<p>The reason code for the state change.</p>",
+          "type": "string"
+        },
+        "Message": {
+          "description": "<p>The message for the state change.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Server.InsufficientInstanceCapacity</code>: There was insufficient\n                    capacity available to satisfy the launch request.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Server.InternalError</code>: An internal error caused the instance to\n                    terminate during launch.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Server.ScheduledStop</code>: The instance was stopped due to a scheduled\n                    retirement.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Server.SpotInstanceShutdown</code>: The instance was stopped because the\n                    number of Spot requests with a maximum price equal to or higher than the Spot\n                    price exceeded available capacity or because of an increase in the Spot\n                    price.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Server.SpotInstanceTermination</code>: The instance was terminated\n                    because the number of Spot requests with a maximum price equal to or higher than\n                    the Spot price exceeded available capacity or because of an increase in the Spot\n                    price.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Client.InstanceInitiatedShutdown</code>: The instance was shut down\n                    from the operating system of the instance.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Client.InstanceTerminated</code>: The instance was terminated or\n                    rebooted during AMI creation.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Client.InternalError</code>: A client error caused the instance to\n                    terminate during launch.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Client.InvalidSnapshot.NotFound</code>: The specified snapshot was not\n                    found.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Client.UserInitiatedHibernate</code>: Hibernation was initiated on the\n                    instance.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Client.UserInitiatedShutdown</code>: The instance was shut down using\n                    the Amazon EC2 API.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Client.VolumeLimitExceeded</code>: The limit on the number of EBS\n                    volumes or total storage was exceeded. Decrease usage or request an increase in\n                    your account limits.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        }
+      }
+    },
+    "CpuOptions": {
+      "description": "<p>The CPU options for the instance.</p>",
+      "type": "object",
+      "properties": {
+        "CoreCount": {
+          "description": "<p>The number of CPU cores for the instance.</p>",
+          "type": "number"
+        },
+        "ThreadsPerCore": {
+          "description": "<p>The number of threads per CPU core.</p>",
+          "type": "number"
+        },
+        "AmdSevSnp": {
+          "enum": [
+            "disabled",
+            "enabled"
+          ],
+          "description": "<p>Indicates whether the instance is enabled for AMD SEV-SNP. For more information, see\n            <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sev-snp.html\">AMD SEV-SNP</a>.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "CapacityReservationSpecificationResponse": {
+      "description": "<p>Describes the instance's Capacity Reservation targeting preferences. The action returns the\n                <code>capacityReservationPreference</code> response element if the instance is\n            configured to run in On-Demand capacity, or if it is configured in run in any\n                <code>open</code> Capacity Reservation that has matching attributes (instance type, platform,\n            Availability Zone). The action returns the <code>capacityReservationTarget</code>\n            response element if the instance explicily targets a specific Capacity Reservation or Capacity Reservation group.</p>",
+      "type": "object",
+      "properties": {
+        "CapacityReservationPreference": {
+          "enum": [
+            "none",
+            "open"
+          ],
+          "description": "<p>Describes the instance's Capacity Reservation preferences. Possible preferences include:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>open</code> - The instance can run in any <code>open</code> Capacity Reservation that\n                    has matching attributes (instance type, platform, Availability Zone).</p>\n            </li>\n            <li>\n               <p>\n                  <code>none</code> - The instance avoids running in a Capacity Reservation even if one is\n                    available. The instance runs in On-Demand capacity.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "CapacityReservationTarget": {
+          "description": "<p>Information about the targeted Capacity Reservation or Capacity Reservation group.</p>",
+          "$ref": "#/definitions/CapacityReservationTargetResponse"
+        }
+      }
+    },
+    "CapacityReservationTargetResponse": {
+      "description": "<p>Describes a target Capacity Reservation or Capacity Reservation group.</p>",
+      "type": "object",
+      "properties": {
+        "CapacityReservationId": {
+          "description": "<p>The ID of the targeted Capacity Reservation.</p>",
+          "type": "string"
+        },
+        "CapacityReservationResourceGroupArn": {
+          "description": "<p>The ARN of the targeted Capacity Reservation group.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "HibernationOptions": {
+      "description": "<p>Indicates whether your instance is configured for hibernation. This parameter is valid\n            only if the instance meets the <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/hibernating-prerequisites.html\">hibernation\n                prerequisites</a>. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Hibernate.html\">Hibernate your Amazon EC2\n                instance</a> in the <i>Amazon EC2 User Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "Configured": {
+          "description": "<p>If <code>true</code>, your instance is enabled for hibernation; otherwise, it is not\n            enabled for hibernation.</p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "LicenseConfiguration": {
+      "description": "<p>Describes a license configuration.</p>",
+      "type": "object",
+      "properties": {
+        "LicenseConfigurationArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the license configuration.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "InstanceMetadataOptionsResponse": {
+      "description": "<p>The metadata options for the instance.</p>",
+      "type": "object",
+      "properties": {
+        "State": {
+          "enum": [
+            "applied",
+            "pending"
+          ],
+          "description": "<p>The state of the metadata option changes.</p>\n         <p>\n            <code>pending</code> - The metadata options are being updated and the instance is not\n            ready to process metadata traffic with the new selection.</p>\n         <p>\n            <code>applied</code> - The metadata options have been successfully applied on the\n            instance.</p>",
+          "type": "string"
+        },
+        "HttpTokens": {
+          "enum": [
+            "optional",
+            "required"
+          ],
+          "description": "<p>Indicates whether IMDSv2 is required.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>optional</code> - IMDSv2 is optional, which means that you can use\n                    either IMDSv2 or IMDSv1.</p>\n            </li>\n            <li>\n               <p>\n                  <code>required</code> - IMDSv2 is required, which means that IMDSv1 is\n                    disabled, and you must use IMDSv2.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "HttpPutResponseHopLimit": {
+          "description": "<p>The maximum number of hops that the metadata token can travel.</p>\n         <p>Possible values: Integers from <code>1</code> to <code>64</code>\n         </p>",
+          "type": "number"
+        },
+        "HttpEndpoint": {
+          "enum": [
+            "disabled",
+            "enabled"
+          ],
+          "description": "<p>Indicates whether the HTTP metadata endpoint on your instances is enabled or\n            disabled.</p>\n         <p>If the value is <code>disabled</code>, you cannot access your instance\n            metadata.</p>",
+          "type": "string"
+        },
+        "HttpProtocolIpv6": {
+          "enum": [
+            "disabled",
+            "enabled"
+          ],
+          "description": "<p>Indicates whether the IPv6 endpoint for the instance metadata service is enabled or\n            disabled.</p>\n         <p>Default: <code>disabled</code>\n         </p>",
+          "type": "string"
+        },
+        "InstanceMetadataTags": {
+          "enum": [
+            "disabled",
+            "enabled"
+          ],
+          "description": "<p>Indicates whether access to instance tags from the instance metadata is enabled or\n            disabled. For more information, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS\">Work with\n                instance tags using the instance metadata</a>.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "EnclaveOptions": {
+      "description": "<p>Indicates whether the instance is enabled for Amazon Web Services Nitro\n            Enclaves.</p>",
+      "type": "object",
+      "properties": {
+        "Enabled": {
+          "description": "<p>If this parameter is set to <code>true</code>, the instance is enabled for Amazon Web Services Nitro Enclaves; otherwise, it is not enabled for Amazon Web Services Nitro\n            Enclaves.</p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "PrivateDnsNameOptionsResponse": {
+      "description": "<p>Describes the options for instance hostnames.</p>",
+      "type": "object",
+      "properties": {
+        "HostnameType": {
+          "enum": [
+            "ip-name",
+            "resource-name"
+          ],
+          "description": "<p>The type of hostname to assign to an instance.</p>",
+          "type": "string"
+        },
+        "EnableResourceNameDnsARecord": {
+          "description": "<p>Indicates whether to respond to DNS queries for instance hostnames with DNS A\n            records.</p>",
+          "type": "boolean"
+        },
+        "EnableResourceNameDnsAAAARecord": {
+          "description": "<p>Indicates whether to respond to DNS queries for instance hostnames with DNS AAAA\n            records.</p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "InstanceMaintenanceOptions": {
+      "description": "<p>The maintenance options for the instance.</p>",
+      "type": "object",
+      "properties": {
+        "AutoRecovery": {
+          "enum": [
+            "default",
+            "disabled"
+          ],
+          "description": "<p>Provides information on the current automatic recovery behavior of your\n            instance.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "InstanceState": {
+      "description": "<p>Describes the current state of an instance.</p>",
+      "type": "object",
+      "properties": {
+        "Code": {
+          "description": "<p>The state of the instance as a 16-bit unsigned integer. </p>\n         <p>The high byte is all of the bits between 2^8 and (2^16)-1, which equals decimal values\n            between 256 and 65,535. These numerical values are used for internal purposes and should\n            be ignored.</p>\n         <p>The low byte is all of the bits between 2^0 and (2^8)-1, which equals decimal values\n            between 0 and 255. </p>\n         <p>The valid values for instance-state-code will all be in the range of the low byte and\n            they are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>0</code> : <code>pending</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>16</code> : <code>running</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>32</code> : <code>shutting-down</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>48</code> : <code>terminated</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>64</code> : <code>stopping</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>80</code> : <code>stopped</code>\n               </p>\n            </li>\n         </ul>\n         <p>You can ignore the high byte value by zeroing out all of the bits above 2^8 or 256 in\n            decimal.</p>",
+          "type": "number"
+        },
+        "Name": {
+          "enum": [
+            "pending",
+            "running",
+            "shutting-down",
+            "stopped",
+            "stopping",
+            "terminated"
+          ],
+          "description": "<p>The current state of the instance.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ProductCode": {
+      "description": "<p>Describes a product code.</p>",
+      "type": "object",
+      "properties": {
+        "ProductCodeId": {
+          "description": "<p>The product code.</p>",
+          "type": "string"
+        },
+        "ProductCodeType": {
+          "enum": [
+            "devpay",
+            "marketplace"
+          ],
+          "description": "<p>The type of product code.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Placement": {
+      "description": "<p>Describes the placement of an instance.</p>",
+      "type": "object",
+      "properties": {
+        "Affinity": {
+          "description": "<p>The affinity setting for the instance on the Dedicated Host.</p>\n         <p>This parameter is not supported for <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet\">CreateFleet</a> or <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ImportInstance.html\">ImportInstance</a>.</p>",
+          "type": "string"
+        },
+        "GroupName": {
+          "description": "<p>The name of the placement group that the instance is in. If you specify\n                <code>GroupName</code>, you can't specify <code>GroupId</code>.</p>",
+          "type": "string"
+        },
+        "PartitionNumber": {
+          "description": "<p>The number of the partition that the instance is in. Valid only if the placement group\n            strategy is set to <code>partition</code>.</p>\n         <p>This parameter is not supported for <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet\">CreateFleet</a>.</p>",
+          "type": "number"
+        },
+        "HostId": {
+          "description": "<p>The ID of the Dedicated Host on which the instance resides.</p>\n         <p>This parameter is not supported for <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet\">CreateFleet</a> or <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ImportInstance.html\">ImportInstance</a>.</p>",
+          "type": "string"
+        },
+        "Tenancy": {
+          "enum": [
+            "dedicated",
+            "default",
+            "host"
+          ],
+          "description": "<p>The tenancy of the instance. An instance with a\n            tenancy of <code>dedicated</code> runs on single-tenant hardware.</p>\n         <p>This parameter is not supported for <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet\">CreateFleet</a>. The\n                <code>host</code> tenancy is not supported for <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ImportInstance.html\">ImportInstance</a> or\n            for T3 instances that are configured for the <code>unlimited</code> CPU credit\n            option.</p>",
+          "type": "string"
+        },
+        "SpreadDomain": {
+          "description": "<p>Reserved for future use.</p>",
+          "type": "string"
+        },
+        "HostResourceGroupArn": {
+          "description": "<p>The ARN of the host resource group in which to launch the instances.</p>\n         <p>If you specify this parameter, either omit the <b>Tenancy</b> parameter or set it to <code>host</code>.</p>\n         <p>This parameter is not supported for <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet\">CreateFleet</a>.</p>",
+          "type": "string"
+        },
+        "GroupId": {
+          "description": "<p>The ID of the placement group that the instance is in. If you specify\n                <code>GroupId</code>, you can't specify <code>GroupName</code>.</p>",
+          "type": "string"
+        },
+        "AvailabilityZone": {
+          "description": "<p>The Availability Zone of the instance.</p>\n         <p>If not specified, an Availability Zone will be automatically chosen for you based on\n            the load balancing criteria for the Region.</p>\n         <p>This parameter is not supported for <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet\">CreateFleet</a>.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Monitoring": {
+      "description": "<p>Describes the monitoring of an instance.</p>",
+      "type": "object",
+      "properties": {
+        "State": {
+          "enum": [
+            "disabled",
+            "disabling",
+            "enabled",
+            "pending"
+          ],
+          "description": "<p>Indicates whether detailed monitoring is enabled. Otherwise, basic monitoring is\n            enabled.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "FunctionConfiguration": {
+      "description": "<p>Details about a function's configuration.</p>",
+      "type": "object",
+      "properties": {
+        "FunctionName": {
+          "description": "<p>The name of the function.</p>",
+          "type": "string"
+        },
+        "FunctionArn": {
+          "description": "<p>The function's Amazon Resource Name (ARN).</p>",
+          "type": "string"
+        },
+        "Runtime": {
+          "enum": [
+            "dotnet6",
+            "dotnet8",
+            "dotnetcore1.0",
+            "dotnetcore2.0",
+            "dotnetcore2.1",
+            "dotnetcore3.1",
+            "go1.x",
+            "java11",
+            "java17",
+            "java21",
+            "java8",
+            "java8.al2",
+            "nodejs",
+            "nodejs10.x",
+            "nodejs12.x",
+            "nodejs14.x",
+            "nodejs16.x",
+            "nodejs18.x",
+            "nodejs20.x",
+            "nodejs4.3",
+            "nodejs4.3-edge",
+            "nodejs6.10",
+            "nodejs8.10",
+            "provided",
+            "provided.al2",
+            "provided.al2023",
+            "python2.7",
+            "python3.10",
+            "python3.11",
+            "python3.12",
+            "python3.13",
+            "python3.6",
+            "python3.7",
+            "python3.8",
+            "python3.9",
+            "ruby2.5",
+            "ruby2.7",
+            "ruby3.2",
+            "ruby3.3"
+          ],
+          "description": "<p>The identifier of the function's <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html\">\n          runtime</a>. Runtime is required if the deployment package is a .zip file archive. Specifying a runtime results in\n          an error if you're deploying a function using a container image.</p>\n         <p>The following list includes deprecated runtimes. Lambda blocks creating new functions and updating existing\n          functions shortly after each runtime is deprecated. For more information, see\n          <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-deprecation-levels\">Runtime use after deprecation</a>.</p>\n         <p>For a list of all currently supported runtimes, see\n          <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported\">Supported runtimes</a>.</p>",
+          "type": "string"
+        },
+        "Role": {
+          "description": "<p>The function's execution role.</p>",
+          "type": "string"
+        },
+        "Handler": {
+          "description": "<p>The function that Lambda calls to begin running your function.</p>",
+          "type": "string"
+        },
+        "CodeSize": {
+          "description": "<p>The size of the function's deployment package, in bytes.</p>",
+          "type": "number"
+        },
+        "Description": {
+          "description": "<p>The function's description.</p>",
+          "type": "string"
+        },
+        "Timeout": {
+          "description": "<p>The amount of time in seconds that Lambda allows a function to run before stopping it.</p>",
+          "type": "number"
+        },
+        "MemorySize": {
+          "description": "<p>The amount of memory available to the function at runtime.</p>",
+          "type": "number"
+        },
+        "LastModified": {
+          "description": "<p>The date and time that the function was last updated, in <a href=\"https://www.w3.org/TR/NOTE-datetime\">ISO-8601 format</a> (YYYY-MM-DDThh:mm:ss.sTZD).</p>",
+          "type": "string"
+        },
+        "CodeSha256": {
+          "description": "<p>The SHA256 hash of the function's deployment package.</p>",
+          "type": "string"
+        },
+        "Version": {
+          "description": "<p>The version of the Lambda function.</p>",
+          "type": "string"
+        },
+        "VpcConfig": {
+          "description": "<p>The function's networking configuration.</p>",
+          "$ref": "#/definitions/VpcConfigResponse"
+        },
+        "DeadLetterConfig": {
+          "description": "<p>The function's dead letter queue.</p>",
+          "$ref": "#/definitions/DeadLetterConfig"
+        },
+        "Environment": {
+          "description": "<p>The function's <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html\">environment variables</a>. Omitted from CloudTrail logs.</p>",
+          "$ref": "#/definitions/EnvironmentResponse"
+        },
+        "KMSKeyArn": {
+          "description": "<p>The ARN of the Key Management Service (KMS) customer managed key that's used to encrypt the following resources:</p>\n         <ul>\n            <li>\n               <p>The function's <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-encryption\">environment variables</a>.</p>\n            </li>\n            <li>\n               <p>The function's <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/snapstart-security.html\">Lambda SnapStart</a> snapshots.</p>\n            </li>\n            <li>\n               <p>When used with <code>SourceKMSKeyArn</code>, the unzipped version of the .zip deployment package that's used for function invocations. For more information, see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/encrypt-zip-package.html#enable-zip-custom-encryption\">\n          Specifying a customer managed key for Lambda</a>.</p>\n            </li>\n            <li>\n               <p>The optimized version of the container image that's used for function invocations. Note that this is not the same key that's used to protect your container image in the Amazon Elastic Container Registry (Amazon ECR). For more information, see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/images-create.html#images-lifecycle\">Function lifecycle</a>.</p>\n            </li>\n         </ul>\n         <p>If you don't provide a customer managed key, Lambda uses an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-owned-cmk\">Amazon Web Services owned key</a> or an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed key</a>.</p>",
+          "type": "string"
+        },
+        "TracingConfig": {
+          "description": "<p>The function's X-Ray tracing configuration.</p>",
+          "$ref": "#/definitions/TracingConfigResponse"
+        },
+        "MasterArn": {
+          "description": "<p>For Lambda@Edge functions, the ARN of the main function.</p>",
+          "type": "string"
+        },
+        "RevisionId": {
+          "description": "<p>The latest updated revision of the function or alias.</p>",
+          "type": "string"
+        },
+        "Layers": {
+          "description": "<p>The function's <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html\">layers</a>.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Layer"
+          }
+        },
+        "State": {
+          "enum": [
+            "Active",
+            "Failed",
+            "Inactive",
+            "Pending"
+          ],
+          "description": "<p>The current state of the function. When the state is <code>Inactive</code>, you can reactivate the function by\n      invoking it.</p>",
+          "type": "string"
+        },
+        "StateReason": {
+          "description": "<p>The reason for the function's current state.</p>",
+          "type": "string"
+        },
+        "StateReasonCode": {
+          "enum": [
+            "Creating",
+            "DisabledKMSKey",
+            "EFSIOError",
+            "EFSMountConnectivityError",
+            "EFSMountFailure",
+            "EFSMountTimeout",
+            "EniLimitExceeded",
+            "FunctionError",
+            "Idle",
+            "ImageAccessDenied",
+            "ImageDeleted",
+            "InsufficientRolePermissions",
+            "InternalError",
+            "InvalidConfiguration",
+            "InvalidImage",
+            "InvalidRuntime",
+            "InvalidSecurityGroup",
+            "InvalidStateKMSKey",
+            "InvalidSubnet",
+            "InvalidZipFileException",
+            "KMSKeyAccessDenied",
+            "KMSKeyNotFound",
+            "Restoring",
+            "SubnetOutOfIPAddresses"
+          ],
+          "description": "<p>The reason code for the function's current state. When the code is <code>Creating</code>, you can't invoke or\n      modify the function.</p>",
+          "type": "string"
+        },
+        "LastUpdateStatus": {
+          "enum": [
+            "Failed",
+            "InProgress",
+            "Successful"
+          ],
+          "description": "<p>The status of the last update that was performed on the function. This is first set to <code>Successful</code>\n      after function creation completes.</p>",
+          "type": "string"
+        },
+        "LastUpdateStatusReason": {
+          "description": "<p>The reason for the last update that was performed on the function.</p>",
+          "type": "string"
+        },
+        "LastUpdateStatusReasonCode": {
+          "enum": [
+            "DisabledKMSKey",
+            "EFSIOError",
+            "EFSMountConnectivityError",
+            "EFSMountFailure",
+            "EFSMountTimeout",
+            "EniLimitExceeded",
+            "FunctionError",
+            "ImageAccessDenied",
+            "ImageDeleted",
+            "InsufficientRolePermissions",
+            "InternalError",
+            "InvalidConfiguration",
+            "InvalidImage",
+            "InvalidRuntime",
+            "InvalidSecurityGroup",
+            "InvalidStateKMSKey",
+            "InvalidSubnet",
+            "InvalidZipFileException",
+            "KMSKeyAccessDenied",
+            "KMSKeyNotFound",
+            "SubnetOutOfIPAddresses"
+          ],
+          "description": "<p>The reason code for the last update that was performed on the function.</p>",
+          "type": "string"
+        },
+        "FileSystemConfigs": {
+          "description": "<p>Connection settings for an <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/configuration-filesystem.html\">Amazon EFS file system</a>.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FileSystemConfig"
+          }
+        },
+        "PackageType": {
+          "enum": [
+            "Image",
+            "Zip"
+          ],
+          "description": "<p>The type of deployment package. Set to <code>Image</code> for container image and set <code>Zip</code> for .zip file archive.</p>",
+          "type": "string"
+        },
+        "ImageConfigResponse": {
+          "description": "<p>The function's image configuration values.</p>",
+          "$ref": "#/definitions/ImageConfigResponse"
+        },
+        "SigningProfileVersionArn": {
+          "description": "<p>The ARN of the signing profile version.</p>",
+          "type": "string"
+        },
+        "SigningJobArn": {
+          "description": "<p>The ARN of the signing job.</p>",
+          "type": "string"
+        },
+        "Architectures": {
+          "description": "<p>The instruction set architecture that the function supports. Architecture is a string array with one of the\n      valid values. The default architecture value is <code>x86_64</code>.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Architecture"
+          }
+        },
+        "EphemeralStorage": {
+          "description": "<p>The size of the function's <code>/tmp</code> directory in MB. The default value is 512, but can be any whole\n  number between 512 and 10,240 MB. For more information, see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-ephemeral-storage\">Configuring ephemeral storage (console)</a>.</p>",
+          "$ref": "#/definitions/EphemeralStorage"
+        },
+        "SnapStart": {
+          "description": "<p>Set <code>ApplyOn</code> to <code>PublishedVersions</code> to create a snapshot of the initialized execution\n      environment when you publish a function version. For more information, see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html\">Improving startup performance with Lambda SnapStart</a>.</p>",
+          "$ref": "#/definitions/SnapStartResponse"
+        },
+        "RuntimeVersionConfig": {
+          "description": "<p>The ARN of the runtime and any errors that occured.</p>",
+          "$ref": "#/definitions/RuntimeVersionConfig"
+        },
+        "LoggingConfig": {
+          "description": "<p>The function's Amazon CloudWatch Logs configuration settings.</p>",
+          "$ref": "#/definitions/LoggingConfig"
+        }
+      }
+    },
+    "VpcConfigResponse": {
+      "description": "<p>The VPC security groups and subnets that are attached to a Lambda function.</p>",
+      "type": "object",
+      "properties": {
+        "SubnetIds": {
+          "description": "<p>A list of VPC subnet IDs.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "SecurityGroupIds": {
+          "description": "<p>A list of VPC security group IDs.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "VpcId": {
+          "description": "<p>The ID of the VPC.</p>",
+          "type": "string"
+        },
+        "Ipv6AllowedForDualStack": {
+          "description": "<p>Allows outbound IPv6 traffic on VPC functions that are connected to dual-stack subnets.</p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "DeadLetterConfig": {
+      "description": "<p>The <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#dlq\">dead-letter queue</a> for\n      failed asynchronous invocations.</p>",
+      "type": "object",
+      "properties": {
+        "TargetArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of an Amazon SQS queue or Amazon SNS topic.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "EnvironmentResponse": {
+      "description": "<p>The results of an operation to update or read environment variables. If the operation succeeds, the response\n      contains the environment variables. If it fails, the response contains details about the error.</p>",
+      "type": "object",
+      "properties": {
+        "Variables": {
+          "description": "<p>Environment variable key-value pairs. Omitted from CloudTrail logs.</p>",
+          "$ref": "#/definitions/Record<string,string>"
+        },
+        "Error": {
+          "description": "<p>Error messages for environment variables that couldn't be applied.</p>",
+          "$ref": "#/definitions/EnvironmentError"
+        }
+      }
+    },
+    "Record<string,string>": {
+      "type": "object"
+    },
+    "EnvironmentError": {
+      "description": "<p>Error messages for environment variables that couldn't be applied.</p>",
+      "type": "object",
+      "properties": {
+        "ErrorCode": {
+          "description": "<p>The error code.</p>",
+          "type": "string"
+        },
+        "Message": {
+          "description": "<p>The error message.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "TracingConfigResponse": {
+      "description": "<p>The function's X-Ray tracing configuration.</p>",
+      "type": "object",
+      "properties": {
+        "Mode": {
+          "enum": [
+            "Active",
+            "PassThrough"
+          ],
+          "description": "<p>The tracing mode.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Layer": {
+      "description": "<p>An <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html\">Lambda\n        layer</a>.</p>",
+      "type": "object",
+      "properties": {
+        "Arn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the function layer.</p>",
+          "type": "string"
+        },
+        "CodeSize": {
+          "description": "<p>The size of the layer archive in bytes.</p>",
+          "type": "number"
+        },
+        "SigningProfileVersionArn": {
+          "description": "<p>The Amazon Resource Name (ARN) for a signing profile version.</p>",
+          "type": "string"
+        },
+        "SigningJobArn": {
+          "description": "<p>The Amazon Resource Name (ARN)  of a signing job.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "FileSystemConfig": {
+      "description": "<p>Details about the connection between a Lambda function and an <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/configuration-filesystem.html\">Amazon EFS file system</a>.</p>",
+      "type": "object",
+      "properties": {
+        "Arn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the Amazon EFS access point that provides access to the file\n      system.</p>",
+          "type": "string"
+        },
+        "LocalMountPath": {
+          "description": "<p>The path where the function can access the file system, starting with <code>/mnt/</code>.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Arn",
+        "LocalMountPath"
+      ]
+    },
+    "ImageConfigResponse": {
+      "description": "<p>Response to a <code>GetFunctionConfiguration</code> request.</p>",
+      "type": "object",
+      "properties": {
+        "ImageConfig": {
+          "description": "<p>Configuration values that override the container image Dockerfile.</p>",
+          "$ref": "#/definitions/ImageConfig"
+        },
+        "Error": {
+          "description": "<p>Error response to <code>GetFunctionConfiguration</code>.</p>",
+          "$ref": "#/definitions/ImageConfigError"
+        }
+      }
+    },
+    "ImageConfig": {
+      "description": "<p>Configuration values that override the container image Dockerfile settings. For more information, see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/images-create.html#images-parms\">Container image\n      settings</a>.</p>",
+      "type": "object",
+      "properties": {
+        "EntryPoint": {
+          "description": "<p>Specifies the entry point to their application, which is typically the location of the runtime\n      executable.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Command": {
+          "description": "<p>Specifies parameters that you want to pass in with ENTRYPOINT.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "WorkingDirectory": {
+          "description": "<p>Specifies the working directory.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ImageConfigError": {
+      "description": "<p>Error response to <code>GetFunctionConfiguration</code>.</p>",
+      "type": "object",
+      "properties": {
+        "ErrorCode": {
+          "description": "<p>Error code.</p>",
+          "type": "string"
+        },
+        "Message": {
+          "description": "<p>Error message.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Architecture": {
+      "enum": [
+        "arm64",
+        "x86_64"
+      ],
+      "type": "string"
+    },
+    "EphemeralStorage": {
+      "description": "<p>The size of the function's <code>/tmp</code> directory in MB. The default value is 512, but can be any whole\n  number between 512 and 10,240 MB. For more information, see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-ephemeral-storage\">Configuring ephemeral storage (console)</a>.</p>",
+      "type": "object",
+      "properties": {
+        "Size": {
+          "description": "<p>The size of the function's <code>/tmp</code> directory.</p>",
+          "type": "number"
+        }
+      },
+      "required": [
+        "Size"
+      ]
+    },
+    "SnapStartResponse": {
+      "description": "<p>The function's <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html\">SnapStart</a> setting.</p>",
+      "type": "object",
+      "properties": {
+        "ApplyOn": {
+          "enum": [
+            "None",
+            "PublishedVersions"
+          ],
+          "description": "<p>When set to <code>PublishedVersions</code>, Lambda creates a snapshot of the execution environment when you publish a function version.</p>",
+          "type": "string"
+        },
+        "OptimizationStatus": {
+          "enum": [
+            "Off",
+            "On"
+          ],
+          "description": "<p>When you provide a <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html#versioning-versions-using\">qualified Amazon Resource Name (ARN)</a>, this response element indicates whether SnapStart is activated for the specified function version.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "RuntimeVersionConfig": {
+      "description": "<p>The ARN of the runtime and any errors that occured.</p>",
+      "type": "object",
+      "properties": {
+        "RuntimeVersionArn": {
+          "description": "<p>The ARN of the runtime version you want the function to use.</p>",
+          "type": "string"
+        },
+        "Error": {
+          "description": "<p>Error response when Lambda is unable to retrieve the runtime version for a function.</p>",
+          "$ref": "#/definitions/RuntimeVersionError"
+        }
+      }
+    },
+    "RuntimeVersionError": {
+      "description": "<p>Any error returned when the runtime version information for the function could not be retrieved.</p>",
+      "type": "object",
+      "properties": {
+        "ErrorCode": {
+          "description": "<p>The error code.</p>",
+          "type": "string"
+        },
+        "Message": {
+          "description": "<p>The error message.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "LoggingConfig": {
+      "description": "<p>The function's Amazon CloudWatch Logs configuration settings.</p>",
+      "type": "object",
+      "properties": {
+        "LogFormat": {
+          "enum": [
+            "JSON",
+            "Text"
+          ],
+          "description": "<p>The format in which Lambda sends your function's application and system logs to CloudWatch. Select between\n    plain text and structured JSON.</p>",
+          "type": "string"
+        },
+        "ApplicationLogLevel": {
+          "enum": [
+            "DEBUG",
+            "ERROR",
+            "FATAL",
+            "INFO",
+            "TRACE",
+            "WARN"
+          ],
+          "description": "<p>Set this property to filter the application logs for your function that Lambda sends to CloudWatch. Lambda only sends application logs at the\n    selected level of detail and lower, where <code>TRACE</code> is the highest level and <code>FATAL</code> is the lowest.</p>",
+          "type": "string"
+        },
+        "SystemLogLevel": {
+          "enum": [
+            "DEBUG",
+            "INFO",
+            "WARN"
+          ],
+          "description": "<p>Set this property to filter the system logs for your function that Lambda sends to CloudWatch. Lambda only sends system logs at the\n      selected level of detail and lower, where <code>DEBUG</code> is the highest level and <code>WARN</code> is the lowest.</p>",
+          "type": "string"
+        },
+        "LogGroup": {
+          "description": "<p>The name of the Amazon CloudWatch log group the function sends logs to. By default, Lambda functions send logs to a default\n      log group named <code>/aws/lambda/<function name></code>. To use a different log group, enter an existing log group or enter a new log group name.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "DBCluster": {
+      "description": "<p>Contains the details of an Amazon Aurora DB cluster or Multi-AZ DB cluster.</p>\n         <p>For an Amazon Aurora DB cluster, this data type is used as a response element in the operations\n          <code>CreateDBCluster</code>, <code>DeleteDBCluster</code>, <code>DescribeDBClusters</code>,\n          <code>FailoverDBCluster</code>, <code>ModifyDBCluster</code>, <code>PromoteReadReplicaDBCluster</code>,\n          <code>RestoreDBClusterFromS3</code>, <code>RestoreDBClusterFromSnapshot</code>,\n          <code>RestoreDBClusterToPointInTime</code>, <code>StartDBCluster</code>, and <code>StopDBCluster</code>.</p>\n         <p>For a Multi-AZ DB cluster, this data type is used as a response element in the operations\n          <code>CreateDBCluster</code>, <code>DeleteDBCluster</code>, <code>DescribeDBClusters</code>,\n          <code>FailoverDBCluster</code>, <code>ModifyDBCluster</code>, <code>RebootDBCluster</code>,\n          <code>RestoreDBClusterFromSnapshot</code>, and <code>RestoreDBClusterToPointInTime</code>.</p>\n         <p>For more information on Amazon Aurora DB clusters, see\n          <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/CHAP_AuroraOverview.html\">\n              What is Amazon Aurora?</a> in the <i>Amazon Aurora User Guide.</i>\n         </p>\n         <p>For more information on Multi-AZ DB clusters, see\n          <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/multi-az-db-clusters-concepts.html\">\n              Multi-AZ deployments with two readable standby DB instances</a> in the <i>Amazon RDS User Guide.</i>\n         </p>",
+      "type": "object",
+      "properties": {
+        "AllocatedStorage": {
+          "description": "<p>For all database engines except Amazon Aurora, <code>AllocatedStorage</code> specifies the allocated storage size in gibibytes (GiB).\n          For Aurora, <code>AllocatedStorage</code> always returns 1, because Aurora DB cluster storage size isn't fixed, but instead automatically\n      adjusts as needed.</p>",
+          "type": "number"
+        },
+        "AvailabilityZones": {
+          "description": "<p>The list of Availability Zones (AZs) where instances in the DB cluster can be created.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "BackupRetentionPeriod": {
+          "description": "<p>The number of days for which automatic DB snapshots are retained.</p>",
+          "type": "number"
+        },
+        "CharacterSetName": {
+          "description": "<p>If present, specifies the name of the character set that this cluster is associated with.</p>",
+          "type": "string"
+        },
+        "DatabaseName": {
+          "description": "<p>The name of the initial database that was specified for the DB cluster when it was created, if one was provided. This same name is returned for the life of the DB cluster.</p>",
+          "type": "string"
+        },
+        "DBClusterIdentifier": {
+          "description": "<p>The user-supplied identifier for the DB cluster. This identifier is the unique key that identifies a DB cluster.</p>",
+          "type": "string"
+        },
+        "DBClusterParameterGroup": {
+          "description": "<p>The name of the DB cluster parameter group for the DB cluster.</p>",
+          "type": "string"
+        },
+        "DBSubnetGroup": {
+          "description": "<p>Information about the subnet group associated with the DB cluster, including the name, description, and subnets in the subnet group.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "description": "<p>The current state of this DB cluster.</p>",
+          "type": "string"
+        },
+        "AutomaticRestartTime": {
+          "description": "<p>The time when a stopped DB cluster is restarted automatically.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "PercentProgress": {
+          "description": "<p>The progress of the operation as a percentage.</p>",
+          "type": "string"
+        },
+        "EarliestRestorableTime": {
+          "description": "<p>The earliest time to which a database can be restored with point-in-time\n            restore.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "Endpoint": {
+          "description": "<p>The connection endpoint for the primary instance of the DB cluster.</p>",
+          "type": "string"
+        },
+        "ReaderEndpoint": {
+          "description": "<p>The reader endpoint for the DB cluster. The reader endpoint for a DB cluster load-balances\n            connections across the Aurora Replicas that are available in a DB cluster. As clients request new connections\n            to the reader endpoint, Aurora distributes the connection requests among the Aurora Replicas in the DB cluster.\n            This functionality can help balance your read workload across multiple Aurora Replicas in your DB cluster.</p>\n         <p>If a failover occurs, and the Aurora Replica that you are connected to is promoted\n            to be the primary instance, your connection is dropped. To\n            continue sending your read workload to other Aurora Replicas in the cluster,\n            you can then reconnect to the reader endpoint.</p>",
+          "type": "string"
+        },
+        "CustomEndpoints": {
+          "description": "<p>The custom endpoints associated with the DB cluster.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "MultiAZ": {
+          "description": "<p>Indicates whether the DB cluster has instances in multiple Availability Zones.</p>",
+          "type": "boolean"
+        },
+        "Engine": {
+          "description": "<p>The database engine used for this DB cluster.</p>",
+          "type": "string"
+        },
+        "EngineVersion": {
+          "description": "<p>The version of the database engine.</p>",
+          "type": "string"
+        },
+        "LatestRestorableTime": {
+          "description": "<p>The latest time to which a database can be restored with point-in-time restore.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "Port": {
+          "description": "<p>The port that the database engine is listening on.</p>",
+          "type": "number"
+        },
+        "MasterUsername": {
+          "description": "<p>The master username for the DB cluster.</p>",
+          "type": "string"
+        },
+        "DBClusterOptionGroupMemberships": {
+          "description": "<p>The list of option group memberships for this DB cluster.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DBClusterOptionGroupStatus"
+          }
+        },
+        "PreferredBackupWindow": {
+          "description": "<p>The daily time range during which automated backups are\n            created if automated backups are enabled, as determined\n            by the <code>BackupRetentionPeriod</code>.</p>",
+          "type": "string"
+        },
+        "PreferredMaintenanceWindow": {
+          "description": "<p>The weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).</p>",
+          "type": "string"
+        },
+        "ReplicationSourceIdentifier": {
+          "description": "<p>The identifier of the source DB cluster if this DB cluster is a read\n            replica.</p>",
+          "type": "string"
+        },
+        "ReadReplicaIdentifiers": {
+          "description": "<p>Contains one or more identifiers of the read replicas associated with this DB\n            cluster.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "StatusInfos": {
+          "description": "<p>Reserved for future use.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DBClusterStatusInfo"
+          }
+        },
+        "DBClusterMembers": {
+          "description": "<p>The list of DB instances that make up the DB cluster.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DBClusterMember"
+          }
+        },
+        "VpcSecurityGroups": {
+          "description": "<p>The list of VPC security groups that the DB cluster belongs to.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VpcSecurityGroupMembership"
+          }
+        },
+        "HostedZoneId": {
+          "description": "<p>The ID that Amazon Route 53 assigns when you create a hosted zone.</p>",
+          "type": "string"
+        },
+        "StorageEncrypted": {
+          "description": "<p>Indicates whether the DB cluster is encrypted.</p>",
+          "type": "boolean"
+        },
+        "KmsKeyId": {
+          "description": "<p>If <code>StorageEncrypted</code> is enabled, the Amazon Web Services KMS key identifier for the encrypted DB cluster.</p>\n         <p>The Amazon Web Services KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key.</p>",
+          "type": "string"
+        },
+        "DbClusterResourceId": {
+          "description": "<p>The Amazon Web Services Region-unique, immutable identifier for the DB cluster. This identifier is found in Amazon Web Services CloudTrail log entries whenever\n          the KMS key for the DB cluster is accessed.</p>",
+          "type": "string"
+        },
+        "DBClusterArn": {
+          "description": "<p>The Amazon Resource Name (ARN) for the DB cluster.</p>",
+          "type": "string"
+        },
+        "AssociatedRoles": {
+          "description": "<p>A list of the Amazon Web Services Identity and Access Management (IAM) roles that are associated with the DB cluster.\n          IAM roles that are associated with a DB cluster grant permission for the DB cluster to access other Amazon Web Services\n          on your behalf.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DBClusterRole"
+          }
+        },
+        "IAMDatabaseAuthenticationEnabled": {
+          "description": "<p>Indicates whether the mapping of Amazon Web Services Identity and Access Management (IAM) accounts to database accounts is enabled.</p>",
+          "type": "boolean"
+        },
+        "CloneGroupId": {
+          "description": "<p>The ID of the clone group with which the DB cluster is associated.</p>",
+          "type": "string"
+        },
+        "ClusterCreateTime": {
+          "description": "<p>The time when the DB cluster was created, in Universal Coordinated Time (UTC).</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "EarliestBacktrackTime": {
+          "description": "<p>The earliest time to which a DB cluster can be backtracked.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "BacktrackWindow": {
+          "description": "<p>The target backtrack window, in seconds. If this value is set to <code>0</code>, backtracking is\n            disabled for the DB cluster. Otherwise, backtracking is enabled.</p>",
+          "type": "number"
+        },
+        "BacktrackConsumedChangeRecords": {
+          "description": "<p>The number of change records stored for Backtrack.</p>",
+          "type": "number"
+        },
+        "EnabledCloudwatchLogsExports": {
+          "description": "<p>A list of log types that this DB cluster is configured to export to CloudWatch Logs.</p>\n         <p>Log types vary by DB engine. For information about the log types for each DB engine, see\n            <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html\">Amazon RDS Database Log Files</a> in the <i>Amazon Aurora User Guide.</i>\n         </p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Capacity": {
+          "description": "<p>The current capacity of an Aurora Serverless v1 DB cluster. The capacity is <code>0</code> (zero)\n          when the cluster is paused.</p>\n         <p>For more information about Aurora Serverless v1, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html\">Using Amazon Aurora Serverless v1</a> in the\n          <i>Amazon Aurora User Guide</i>.</p>",
+          "type": "number"
+        },
+        "EngineMode": {
+          "description": "<p>The DB engine mode of the DB cluster, either <code>provisioned</code> or <code>serverless</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBCluster.html\">\n            CreateDBCluster</a>.</p>",
+          "type": "string"
+        },
+        "ScalingConfigurationInfo": {
+          "description": "<p>The scaling configuration for an Aurora DB cluster in <code>serverless</code> DB engine mode.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html\">Using Amazon Aurora Serverless v1</a> in the\n            <i>Amazon Aurora User Guide</i>.</p>",
+          "$ref": "#/definitions/ScalingConfigurationInfo"
+        },
+        "RdsCustomClusterConfiguration": {
+          "description": "<p>Reserved for future use.</p>",
+          "$ref": "#/definitions/RdsCustomClusterConfiguration"
+        },
+        "DeletionProtection": {
+          "description": "<p>Indicates whether the DB cluster has deletion protection enabled.\n            The database can't be deleted when deletion protection is enabled.</p>",
+          "type": "boolean"
+        },
+        "HttpEndpointEnabled": {
+          "description": "<p>Indicates whether the HTTP endpoint is enabled for an Aurora DB cluster.</p>\n         <p>When enabled, the HTTP endpoint provides a connectionless web service API (RDS Data API) for running\n          SQL queries on the DB cluster. You can also query your database\n          from inside the RDS console with the RDS query editor.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html\">Using RDS Data API</a> in the\n          <i>Amazon Aurora User Guide</i>.</p>",
+          "type": "boolean"
+        },
+        "ActivityStreamMode": {
+          "enum": [
+            "async",
+            "sync"
+          ],
+          "description": "<p>The mode of the database activity stream.\n           Database events such as a change or access generate an activity stream event.\n           The database session can handle these events either synchronously or asynchronously.</p>",
+          "type": "string"
+        },
+        "ActivityStreamStatus": {
+          "enum": [
+            "started",
+            "starting",
+            "stopped",
+            "stopping"
+          ],
+          "description": "<p>The status of the database activity stream.</p>",
+          "type": "string"
+        },
+        "ActivityStreamKmsKeyId": {
+          "description": "<p>The Amazon Web Services KMS key identifier used for encrypting messages in the database activity stream.</p>\n         <p>The Amazon Web Services KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key.</p>",
+          "type": "string"
+        },
+        "ActivityStreamKinesisStreamName": {
+          "description": "<p>The name of the Amazon Kinesis data stream used for the database activity stream.</p>",
+          "type": "string"
+        },
+        "CopyTagsToSnapshot": {
+          "description": "<p>Indicates whether tags are copied from the DB cluster to snapshots of the DB cluster.</p>",
+          "type": "boolean"
+        },
+        "CrossAccountClone": {
+          "description": "<p>Indicates whether the DB cluster is a clone of a DB cluster owned by a different Amazon Web Services account.</p>",
+          "type": "boolean"
+        },
+        "DomainMemberships": {
+          "description": "<p>The Active Directory Domain membership records associated with the DB cluster.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DomainMembership"
+          }
+        },
+        "TagList": {
+          "description": "<p>A list of tags.</p>\n         <p>For more information, see\n            <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html\">Tagging Amazon RDS resources</a> in the <i>Amazon RDS User Guide</i> or\n            <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_Tagging.html\">Tagging Amazon Aurora and Amazon RDS resources</a> in the <i>Amazon Aurora User Guide</i>.\n            </p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag_1"
+          }
+        },
+        "GlobalWriteForwardingStatus": {
+          "enum": [
+            "disabled",
+            "disabling",
+            "enabled",
+            "enabling",
+            "unknown"
+          ],
+          "description": "<p>The status of write forwarding for a secondary cluster in an Aurora global database.</p>",
+          "type": "string"
+        },
+        "GlobalWriteForwardingRequested": {
+          "description": "<p>Indicates whether write forwarding is enabled for a secondary cluster\n      in an Aurora global database. Because write forwarding takes time to enable, check the\n      value of <code>GlobalWriteForwardingStatus</code> to confirm that the request has completed\n      before using the write forwarding feature for this cluster.</p>",
+          "type": "boolean"
+        },
+        "PendingModifiedValues": {
+          "description": "<p>Information about pending changes to the DB cluster. This information is returned only when there are pending changes. Specific changes are identified by subelements.</p>",
+          "$ref": "#/definitions/ClusterPendingModifiedValues"
+        },
+        "DBClusterInstanceClass": {
+          "description": "<p>The name of the compute and memory capacity class of the DB instance.</p>\n         <p>This setting is only for non-Aurora Multi-AZ DB clusters.</p>",
+          "type": "string"
+        },
+        "StorageType": {
+          "description": "<p>The storage type associated with the DB cluster.</p>",
+          "type": "string"
+        },
+        "Iops": {
+          "description": "<p>The Provisioned IOPS (I/O operations per second) value.</p>\n         <p>This setting is only for non-Aurora Multi-AZ DB clusters.</p>",
+          "type": "number"
+        },
+        "PubliclyAccessible": {
+          "description": "<p>Indicates whether the DB cluster is publicly accessible.</p>\n         <p>When the DB cluster is publicly accessible and you connect from outside of the DB cluster's virtual private cloud (VPC),\n              its Domain Name System (DNS) endpoint resolves to the public IP address. When you connect from within the same VPC as the DB cluster,\n              the endpoint resolves to the private IP address. Access to the DB cluster is ultimately controlled by the security group it uses. That public\n              access isn't permitted if the security group assigned to the DB cluster doesn't permit it.</p>\n         <p>When the DB cluster isn't publicly accessible, it is an internal DB cluster with a DNS name that resolves to a private IP address.</p>\n         <p>For more information, see <a>CreateDBCluster</a>.</p>\n         <p>This setting is only for non-Aurora Multi-AZ DB clusters.</p>",
+          "type": "boolean"
+        },
+        "AutoMinorVersionUpgrade": {
+          "description": "<p>Indicates whether minor version patches are applied automatically.</p>\n         <p>This setting is only for non-Aurora Multi-AZ DB clusters.</p>",
+          "type": "boolean"
+        },
+        "MonitoringInterval": {
+          "description": "<p>The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB cluster.</p>\n         <p>This setting is only for non-Aurora Multi-AZ DB clusters.</p>",
+          "type": "number"
+        },
+        "MonitoringRoleArn": {
+          "description": "<p>The ARN for the IAM role that permits RDS to send Enhanced Monitoring metrics to Amazon CloudWatch Logs.</p>\n         <p>This setting is only for non-Aurora Multi-AZ DB clusters.</p>",
+          "type": "string"
+        },
+        "PerformanceInsightsEnabled": {
+          "description": "<p>Indicates whether Performance Insights is enabled for the DB cluster.</p>\n         <p>This setting is only for non-Aurora Multi-AZ DB clusters.</p>",
+          "type": "boolean"
+        },
+        "PerformanceInsightsKMSKeyId": {
+          "description": "<p>The Amazon Web Services KMS key identifier for encryption of Performance Insights data.</p>\n         <p>The Amazon Web Services KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key.</p>\n         <p>This setting is only for non-Aurora Multi-AZ DB clusters.</p>",
+          "type": "string"
+        },
+        "PerformanceInsightsRetentionPeriod": {
+          "description": "<p>The number of days to retain Performance Insights data.</p>\n         <p>This setting is only for non-Aurora Multi-AZ DB clusters.</p>\n         <p>Valid Values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>7</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <i>month</i> * 31, where <i>month</i> is a number of months from 1-23.\n                Examples: <code>93</code> (3 months * 31), <code>341</code> (11 months * 31), <code>589</code> (19 months * 31)</p>\n            </li>\n            <li>\n               <p>\n                  <code>731</code>\n               </p>\n            </li>\n         </ul>\n         <p>Default: <code>7</code> days</p>",
+          "type": "number"
+        },
+        "ServerlessV2ScalingConfiguration": {
+          "description": "<p>The scaling configuration for an Aurora Serverless v2 DB cluster.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html\">Using Amazon Aurora Serverless v2</a> in the\n            <i>Amazon Aurora User Guide</i>.</p>",
+          "$ref": "#/definitions/ServerlessV2ScalingConfigurationInfo"
+        },
+        "NetworkType": {
+          "description": "<p>The network type of the DB instance.</p>\n         <p>The network type is determined by the <code>DBSubnetGroup</code> specified for the DB cluster.\n            A <code>DBSubnetGroup</code> can support only the IPv4 protocol or the IPv4 and the IPv6\n            protocols (<code>DUAL</code>).</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html\">\n            Working with a DB instance in a VPC</a> in the\n            <i>Amazon Aurora User Guide.</i>\n         </p>\n         <p>This setting is only for Aurora DB clusters.</p>\n         <p>Valid Values: <code>IPV4 | DUAL</code>\n         </p>",
+          "type": "string"
+        },
+        "DBSystemId": {
+          "description": "<p>Reserved for future use.</p>",
+          "type": "string"
+        },
+        "MasterUserSecret": {
+          "description": "<p>The secret managed by RDS in Amazon Web Services Secrets Manager for the master user password.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-secrets-manager.html\">Password management with Amazon Web Services Secrets Manager</a>\n            in the <i>Amazon RDS User Guide</i> and <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/rds-secrets-manager.html\">Password management with Amazon Web Services Secrets Manager</a>\n            in the <i>Amazon Aurora User Guide.</i>\n         </p>",
+          "$ref": "#/definitions/MasterUserSecret"
+        },
+        "IOOptimizedNextAllowedModificationTime": {
+          "description": "<p>The next time you can modify the DB cluster to use the <code>aurora-iopt1</code> storage type.</p>\n         <p>This setting is only for Aurora DB clusters.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "LocalWriteForwardingStatus": {
+          "enum": [
+            "disabled",
+            "disabling",
+            "enabled",
+            "enabling",
+            "requested"
+          ],
+          "description": "<p>Indicates whether an Aurora DB cluster has in-cluster write forwarding enabled, not enabled, requested, or is in the process\n            of enabling it.</p>",
+          "type": "string"
+        },
+        "AwsBackupRecoveryPointArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the recovery point in Amazon Web Services Backup.</p>",
+          "type": "string"
+        },
+        "LimitlessDatabase": {
+          "description": "<p>The details for Aurora Limitless Database.</p>",
+          "$ref": "#/definitions/LimitlessDatabase"
+        },
+        "StorageThroughput": {
+          "description": "<p>The storage throughput for the DB cluster. The throughput is automatically set based on the IOPS that you provision, and is not configurable.</p>\n         <p>This setting is only for non-Aurora Multi-AZ DB clusters.</p>",
+          "type": "number"
+        },
+        "ClusterScalabilityType": {
+          "enum": [
+            "limitless",
+            "standard"
+          ],
+          "description": "<p>The scalability mode of the Aurora DB cluster. When set to <code>limitless</code>, the cluster operates as an Aurora Limitless Database.\n            When set to <code>standard</code> (the default), the cluster uses normal DB instance creation.</p>",
+          "type": "string"
+        },
+        "CertificateDetails": {
+          "description": "<p>The details of the DB instance’s server certificate.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html\">Using SSL/TLS to encrypt a connection to a DB\n            instance</a> in the <i>Amazon RDS User Guide</i> and\n            <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.SSL.html\">\n            Using SSL/TLS to encrypt a connection to a DB cluster</a> in the <i>Amazon Aurora\n            User Guide</i>.</p>",
+          "$ref": "#/definitions/CertificateDetails"
+        },
+        "EngineLifecycleSupport": {
+          "description": "<p>The life cycle type for the DB cluster.</p>\n         <p>For more information, see CreateDBCluster.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "DBClusterOptionGroupStatus": {
+      "description": "<p>Contains status information for a DB cluster option group.</p>",
+      "type": "object",
+      "properties": {
+        "DBClusterOptionGroupName": {
+          "description": "<p>Specifies the name of the DB cluster option group.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "description": "<p>Specifies the status of the DB cluster option group.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "DBClusterStatusInfo": {
+      "description": "<p>Reserved for future use.</p>",
+      "type": "object",
+      "properties": {
+        "StatusType": {
+          "description": "<p>Reserved for future use.</p>",
+          "type": "string"
+        },
+        "Normal": {
+          "description": "<p>Reserved for future use.</p>",
+          "type": "boolean"
+        },
+        "Status": {
+          "description": "<p>Reserved for future use.</p>",
+          "type": "string"
+        },
+        "Message": {
+          "description": "<p>Reserved for future use.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "DBClusterMember": {
+      "description": "<p>Contains information about an instance that is part of a DB cluster.</p>",
+      "type": "object",
+      "properties": {
+        "DBInstanceIdentifier": {
+          "description": "<p>Specifies the instance identifier for this member of the DB cluster.</p>",
+          "type": "string"
+        },
+        "IsClusterWriter": {
+          "description": "<p>Indicates whether the cluster member is the primary DB instance for the DB cluster.</p>",
+          "type": "boolean"
+        },
+        "DBClusterParameterGroupStatus": {
+          "description": "<p>Specifies the status of the DB cluster parameter group for this member of the DB cluster.</p>",
+          "type": "string"
+        },
+        "PromotionTier": {
+          "description": "<p>A value that specifies the order in which an Aurora Replica is promoted to the primary instance\n      after a failure of the existing primary instance. For more information,\n      see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Managing.Backups.html#Aurora.Managing.FaultTolerance\">\n          Fault Tolerance for an Aurora DB Cluster</a> in the <i>Amazon Aurora User Guide</i>.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "VpcSecurityGroupMembership": {
+      "description": "<p>This data type is used as a response element for queries on VPC security group membership.</p>",
+      "type": "object",
+      "properties": {
+        "VpcSecurityGroupId": {
+          "description": "<p>The name of the VPC security group.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "description": "<p>The membership status of the VPC security group.</p>\n         <p>Currently, the only valid status is <code>active</code>.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "DBClusterRole": {
+      "description": "<p>Describes an Amazon Web Services Identity and Access Management (IAM) role that is associated with a DB cluster.</p>",
+      "type": "object",
+      "properties": {
+        "RoleArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the IAM role that is associated with the DB cluster.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "description": "<p>Describes the state of association between the IAM role and the DB cluster. The Status property returns one of the following\n        values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - the IAM role ARN is associated with the DB cluster and can be used to\n            access other Amazon Web Services on your behalf.</p>\n            </li>\n            <li>\n               <p>\n                  <code>PENDING</code> - the IAM role ARN is being associated with the DB cluster.</p>\n            </li>\n            <li>\n               <p>\n                  <code>INVALID</code> - the IAM role ARN is associated with the DB cluster, but the DB cluster is unable\n                to assume the IAM role in order to access other Amazon Web Services on your behalf.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "FeatureName": {
+          "description": "<p>The name of the feature associated with the Amazon Web Services Identity and Access Management (IAM) role.\n            For information about supported feature names, see <a>DBEngineVersion</a>.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ScalingConfigurationInfo": {
+      "description": "<p>The scaling configuration for an Aurora DB cluster in <code>serverless</code> DB engine mode.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html\">Using Amazon Aurora Serverless v1</a> in the\n            <i>Amazon Aurora User Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "MinCapacity": {
+          "description": "<p>The minimum capacity for an Aurora DB cluster in <code>serverless</code> DB engine mode.</p>",
+          "type": "number"
+        },
+        "MaxCapacity": {
+          "description": "<p>The maximum capacity for an Aurora DB cluster in <code>serverless</code> DB engine mode.</p>",
+          "type": "number"
+        },
+        "AutoPause": {
+          "description": "<p>Indicates whether automatic pause is allowed for the Aurora DB cluster\n            in <code>serverless</code> DB engine mode.</p>\n         <p>When the value is set to false for an Aurora Serverless v1 DB cluster, the DB cluster automatically resumes.</p>",
+          "type": "boolean"
+        },
+        "SecondsUntilAutoPause": {
+          "description": "<p>The remaining amount of time, in seconds, before the Aurora DB cluster in\n                <code>serverless</code> mode is paused. A DB cluster can be paused only when\n            it's idle (it has no connections).</p>",
+          "type": "number"
+        },
+        "TimeoutAction": {
+          "description": "<p>The action that occurs when Aurora times out while attempting to change the capacity of an\n            Aurora Serverless v1 cluster. The value is either <code>ForceApplyCapacityChange</code> or\n            <code>RollbackCapacityChange</code>.</p>\n         <p>\n            <code>ForceApplyCapacityChange</code>, the default, sets the capacity to the specified value as soon as possible.</p>\n         <p>\n            <code>RollbackCapacityChange</code> ignores the capacity change if a scaling point isn't found in the timeout period.</p>",
+          "type": "string"
+        },
+        "SecondsBeforeTimeout": {
+          "description": "<p>The number of seconds before scaling times out. What happens when an attempted scaling action times out\n            is determined by the <code>TimeoutAction</code> setting.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "RdsCustomClusterConfiguration": {
+      "description": "<p>Reserved for future use.</p>",
+      "type": "object",
+      "properties": {
+        "InterconnectSubnetId": {
+          "description": "<p>Reserved for future use.</p>",
+          "type": "string"
+        },
+        "TransitGatewayMulticastDomainId": {
+          "description": "<p>Reserved for future use.</p>",
+          "type": "string"
+        },
+        "ReplicaMode": {
+          "enum": [
+            "mounted",
+            "open-read-only"
+          ],
+          "description": "<p>Reserved for future use.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "DomainMembership": {
+      "description": "<p>An Active Directory Domain membership record associated with the DB instance or cluster.</p>",
+      "type": "object",
+      "properties": {
+        "Domain": {
+          "description": "<p>The identifier of the Active Directory Domain.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "description": "<p>The status of the Active Directory Domain membership for the DB instance or cluster. Values include <code>joined</code>, <code>pending-join</code>, <code>failed</code>, and so on.</p>",
+          "type": "string"
+        },
+        "FQDN": {
+          "description": "<p>The fully qualified domain name (FQDN) of the Active Directory Domain.</p>",
+          "type": "string"
+        },
+        "IAMRoleName": {
+          "description": "<p>The name of the IAM role used when making API calls to the Directory Service.</p>",
+          "type": "string"
+        },
+        "OU": {
+          "description": "<p>The Active Directory organizational unit for the DB instance or cluster.</p>",
+          "type": "string"
+        },
+        "AuthSecretArn": {
+          "description": "<p>The ARN for the Secrets Manager secret with the credentials for the user that's a member of the domain.</p>",
+          "type": "string"
+        },
+        "DnsIps": {
+          "description": "<p>The IPv4 DNS IP addresses of the primary and secondary Active Directory domain controllers.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Tag_1": {
+      "description": "<p>Metadata assigned to an Amazon RDS resource consisting of a key-value pair.</p>\n         <p>For more information, see\n            <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html\">Tagging Amazon RDS resources</a> in the <i>Amazon RDS User Guide</i> or\n            <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_Tagging.html\">Tagging Amazon Aurora and Amazon RDS resources</a> in the <i>Amazon Aurora User Guide</i>.\n            </p>",
+      "type": "object",
+      "properties": {
+        "Key": {
+          "description": "<p>A key is the required name of the tag. The string value can be from 1 to 128 Unicode characters in length and can't be prefixed with <code>aws:</code> or <code>rds:</code>. The string can only contain only the set of Unicode letters, digits, white-space, '_', '.', ':', '/', '=', '+', '-', '@' (Java regex: \"^([\\\\p\\{L\\}\\\\p\\{Z\\}\\\\p\\{N\\}_.:/=+\\\\-@]*)$\").</p>",
+          "type": "string"
+        },
+        "Value": {
+          "description": "<p>A value is the optional value of the tag. The string value can be from 1 to 256 Unicode characters in length and can't be prefixed with <code>aws:</code> or <code>rds:</code>. The string can only contain only the set of Unicode letters, digits, white-space, '_', '.', ':', '/', '=', '+', '-', '@' (Java regex: \"^([\\\\p\\{L\\}\\\\p\\{Z\\}\\\\p\\{N\\}_.:/=+\\\\-@]*)$\").</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ClusterPendingModifiedValues": {
+      "description": "<p>This data type is used as a response element in the <code>ModifyDBCluster</code> operation and\n            contains changes that will be applied during the next maintenance window.</p>",
+      "type": "object",
+      "properties": {
+        "PendingCloudwatchLogsExports": {
+          "description": "<p>A list of the log types whose configuration is still pending. In other words, these log types are in the process of being activated or deactivated.</p>",
+          "$ref": "#/definitions/PendingCloudwatchLogsExports"
+        },
+        "DBClusterIdentifier": {
+          "description": "<p>The DBClusterIdentifier value for the DB cluster.</p>",
+          "type": "string"
+        },
+        "MasterUserPassword": {
+          "description": "<p>The master credentials for the DB cluster.</p>",
+          "type": "string"
+        },
+        "IAMDatabaseAuthenticationEnabled": {
+          "description": "<p>Indicates whether mapping of Amazon Web Services Identity and Access Management (IAM) accounts to database accounts is enabled.</p>",
+          "type": "boolean"
+        },
+        "EngineVersion": {
+          "description": "<p>The database engine version.</p>",
+          "type": "string"
+        },
+        "BackupRetentionPeriod": {
+          "description": "<p>The number of days for which automatic DB snapshots are retained.</p>",
+          "type": "number"
+        },
+        "AllocatedStorage": {
+          "description": "<p>The allocated storage size in gibibytes (GiB) for all database engines except Amazon Aurora. For Aurora,\n            <code>AllocatedStorage</code> always returns 1, because Aurora DB cluster storage size isn't fixed, but\n            instead automatically adjusts as needed.</p>",
+          "type": "number"
+        },
+        "RdsCustomClusterConfiguration": {
+          "description": "<p>Reserved for future use.</p>",
+          "$ref": "#/definitions/RdsCustomClusterConfiguration"
+        },
+        "Iops": {
+          "description": "<p>The Provisioned IOPS (I/O operations per second) value. This setting is only for non-Aurora Multi-AZ DB clusters.</p>",
+          "type": "number"
+        },
+        "StorageType": {
+          "description": "<p>The storage type for the DB cluster.</p>",
+          "type": "string"
+        },
+        "CertificateDetails": {
+          "description": "<p>The details of the DB instance’s server certificate.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html\">Using SSL/TLS to encrypt a connection to a DB\n            instance</a> in the <i>Amazon RDS User Guide</i> and\n            <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.SSL.html\">\n            Using SSL/TLS to encrypt a connection to a DB cluster</a> in the <i>Amazon Aurora\n            User Guide</i>.</p>",
+          "$ref": "#/definitions/CertificateDetails"
+        }
+      }
+    },
+    "PendingCloudwatchLogsExports": {
+      "description": "<p>A list of the log types whose configuration is still pending. In other words, these log types are in the process of being activated or deactivated.</p>",
+      "type": "object",
+      "properties": {
+        "LogTypesToEnable": {
+          "description": "<p>Log types that are in the process of being deactivated. After they are deactivated, these log types aren't exported to CloudWatch Logs.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "LogTypesToDisable": {
+          "description": "<p>Log types that are in the process of being enabled. After they are enabled, these log types are exported to CloudWatch Logs.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "CertificateDetails": {
+      "description": "<p>The details of the DB instance’s server certificate.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html\">Using SSL/TLS to encrypt a connection to a DB\n            instance</a> in the <i>Amazon RDS User Guide</i> and\n            <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.SSL.html\">\n            Using SSL/TLS to encrypt a connection to a DB cluster</a> in the <i>Amazon Aurora\n            User Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "CAIdentifier": {
+          "description": "<p>The CA identifier of the CA certificate used for the DB instance's server certificate.</p>",
+          "type": "string"
+        },
+        "ValidTill": {
+          "description": "<p>The expiration date of the DB instance’s server certificate.</p>",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "ServerlessV2ScalingConfigurationInfo": {
+      "description": "<p>The scaling configuration for an Aurora Serverless v2 DB cluster.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html\">Using Amazon Aurora Serverless v2</a> in the\n            <i>Amazon Aurora User Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "MinCapacity": {
+          "description": "<p>The minimum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster.\n            You can specify ACU values in half-step increments, such as 8, 8.5, 9, and so on. The smallest value\n            that you can use is 0.5.</p>",
+          "type": "number"
+        },
+        "MaxCapacity": {
+          "description": "<p>The maximum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster.\n            You can specify ACU values in half-step increments, such as 40, 40.5, 41, and so on. The largest value\n            that you can use is 128.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "MasterUserSecret": {
+      "description": "<p>Contains the secret managed by RDS in Amazon Web Services Secrets Manager for the master user password.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-secrets-manager.html\">Password management with Amazon Web Services Secrets Manager</a>\n            in the <i>Amazon RDS User Guide</i> and <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/rds-secrets-manager.html\">Password management with Amazon Web Services Secrets Manager</a>\n            in the <i>Amazon Aurora User Guide.</i>\n         </p>",
+      "type": "object",
+      "properties": {
+        "SecretArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the secret.</p>",
+          "type": "string"
+        },
+        "SecretStatus": {
+          "description": "<p>The status of the secret.</p>\n         <p>The possible status values include the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>creating</code> - The secret is being created.</p>\n            </li>\n            <li>\n               <p>\n                  <code>active</code> - The secret is available for normal use and rotation.</p>\n            </li>\n            <li>\n               <p>\n                  <code>rotating</code> - The secret is being rotated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>impaired</code> - The secret can be used to access database credentials,\n                    but it can't be rotated. A secret might have this status if, for example,\n                    permissions are changed so that RDS can no longer access either the secret or\n                    the KMS key for the secret.</p>\n               <p>When a secret has this status, you can correct the condition that caused the\n                    status. Alternatively, modify the DB instance to turn off automatic management\n                    of database credentials, and then modify the DB instance again to turn on\n                    automatic management of database credentials.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "KmsKeyId": {
+          "description": "<p>The Amazon Web Services KMS key identifier that is used to encrypt the secret.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "LimitlessDatabase": {
+      "description": "<p>Contains details for Aurora Limitless Database.</p>",
+      "type": "object",
+      "properties": {
+        "Status": {
+          "enum": [
+            "active",
+            "disabled",
+            "disabling",
+            "enabled",
+            "enabling",
+            "error",
+            "modifying-max-capacity",
+            "not-in-use"
+          ],
+          "description": "<p>The status of Aurora Limitless Database.</p>",
+          "type": "string"
+        },
+        "MinRequiredACU": {
+          "description": "<p>The minimum required capacity for Aurora Limitless Database in Aurora capacity units (ACUs).</p>",
+          "type": "number"
+        }
+      }
+    },
+    "DBInstance": {
+      "description": "<p>Contains the details of an Amazon RDS DB instance.</p>\n         <p>This data type is used as a response element in the operations <code>CreateDBInstance</code>,\n          <code>CreateDBInstanceReadReplica</code>, <code>DeleteDBInstance</code>, <code>DescribeDBInstances</code>,\n          <code>ModifyDBInstance</code>, <code>PromoteReadReplica</code>, <code>RebootDBInstance</code>,\n          <code>RestoreDBInstanceFromDBSnapshot</code>, <code>RestoreDBInstanceFromS3</code>, <code>RestoreDBInstanceToPointInTime</code>,\n          <code>StartDBInstance</code>, and <code>StopDBInstance</code>.</p>",
+      "type": "object",
+      "properties": {
+        "DBInstanceIdentifier": {
+          "description": "<p>The user-supplied database identifier. This identifier is the unique key that identifies a DB instance.</p>",
+          "type": "string"
+        },
+        "DBInstanceClass": {
+          "description": "<p>The name of the compute and memory capacity class of the DB instance.</p>",
+          "type": "string"
+        },
+        "Engine": {
+          "description": "<p>The database engine used for this DB instance.</p>",
+          "type": "string"
+        },
+        "DBInstanceStatus": {
+          "description": "<p>The current state of this database.</p>\n         <p>For information about DB instance statuses, see\n          <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/accessing-monitoring.html#Overview.DBInstance.Status\">Viewing DB instance status</a>\n          in the <i>Amazon RDS User Guide.</i>\n         </p>",
+          "type": "string"
+        },
+        "AutomaticRestartTime": {
+          "description": "<p>The time when a stopped DB instance is restarted automatically.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "MasterUsername": {
+          "description": "<p>The master username for the DB instance.</p>",
+          "type": "string"
+        },
+        "DBName": {
+          "description": "<p>The initial database name that you provided (if required) when you created\n            the DB instance. This name is returned for the life of your DB instance. For an RDS for\n            Oracle CDB instance, the name identifies the PDB rather than the CDB.</p>",
+          "type": "string"
+        },
+        "Endpoint": {
+          "description": "<p>The connection endpoint for the DB instance.</p>\n         <note>\n            <p>The endpoint might not be shown for instances with the status of <code>creating</code>.</p>\n         </note>",
+          "$ref": "#/definitions/Endpoint"
+        },
+        "AllocatedStorage": {
+          "description": "<p>The amount of storage in gibibytes (GiB) allocated for the DB instance.</p>",
+          "type": "number"
+        },
+        "InstanceCreateTime": {
+          "description": "<p>The date and time when the DB instance was created.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "PreferredBackupWindow": {
+          "description": "<p>The daily time range during which automated backups are\n        created if automated backups are enabled, as determined\n        by the <code>BackupRetentionPeriod</code>.</p>",
+          "type": "string"
+        },
+        "BackupRetentionPeriod": {
+          "description": "<p>The number of days for which automatic DB snapshots are retained.</p>",
+          "type": "number"
+        },
+        "DBSecurityGroups": {
+          "description": "<p>A list of DB security group elements containing\n        <code>DBSecurityGroup.Name</code> and <code>DBSecurityGroup.Status</code> subelements.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DBSecurityGroupMembership"
+          }
+        },
+        "VpcSecurityGroups": {
+          "description": "<p>The list of Amazon EC2 VPC security groups that the DB instance belongs to.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VpcSecurityGroupMembership"
+          }
+        },
+        "DBParameterGroups": {
+          "description": "<p>The list of DB parameter groups applied to this DB instance.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DBParameterGroupStatus"
+          }
+        },
+        "AvailabilityZone": {
+          "description": "<p>The name of the Availability Zone where the DB instance is located.</p>",
+          "type": "string"
+        },
+        "DBSubnetGroup": {
+          "description": "<p>Information about the subnet group associated with the DB instance, including the name, description, and subnets in the subnet group.</p>",
+          "$ref": "#/definitions/DBSubnetGroup"
+        },
+        "PreferredMaintenanceWindow": {
+          "description": "<p>The weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).</p>",
+          "type": "string"
+        },
+        "PendingModifiedValues": {
+          "description": "<p>Information about pending changes to the DB instance. This information is returned only when there are pending changes. Specific changes are identified by subelements.</p>",
+          "$ref": "#/definitions/PendingModifiedValues"
+        },
+        "LatestRestorableTime": {
+          "description": "<p>The latest time to which a database in this DB instance can be restored with point-in-time restore.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "MultiAZ": {
+          "description": "<p>Indicates whether the DB instance is a Multi-AZ deployment. This setting doesn't apply to RDS Custom DB instances.</p>",
+          "type": "boolean"
+        },
+        "EngineVersion": {
+          "description": "<p>The version of the database engine.</p>",
+          "type": "string"
+        },
+        "AutoMinorVersionUpgrade": {
+          "description": "<p>Indicates whether minor version patches are applied automatically.</p>",
+          "type": "boolean"
+        },
+        "ReadReplicaSourceDBInstanceIdentifier": {
+          "description": "<p>The identifier of the source DB instance if this DB instance is a read\n            replica.</p>",
+          "type": "string"
+        },
+        "ReadReplicaDBInstanceIdentifiers": {
+          "description": "<p>The identifiers of the read replicas associated with this DB\n            instance.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ReadReplicaDBClusterIdentifiers": {
+          "description": "<p>The identifiers of Aurora DB clusters to which the RDS DB instance\n            is replicated as a read replica. For example, when you create an Aurora read replica of\n            an RDS for MySQL DB instance, the Aurora MySQL DB cluster for the Aurora read replica is\n            shown. This output doesn't contain information about cross-Region Aurora read\n            replicas.</p>\n         <note>\n            <p>Currently, each RDS DB instance can have only one Aurora read replica.</p>\n         </note>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ReplicaMode": {
+          "enum": [
+            "mounted",
+            "open-read-only"
+          ],
+          "description": "<p>The open mode of an Oracle read replica. The default is <code>open-read-only</code>.\n            For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/oracle-read-replicas.html\">Working with Oracle Read Replicas for Amazon RDS</a>\n            in the <i>Amazon RDS User Guide</i>.</p>\n         <note>\n            <p>This attribute is only supported in RDS for Oracle.</p>\n         </note>",
+          "type": "string"
+        },
+        "LicenseModel": {
+          "description": "<p>The license model information for this DB instance. This setting doesn't apply to\n            Amazon Aurora or RDS Custom DB instances.</p>",
+          "type": "string"
+        },
+        "Iops": {
+          "description": "<p>The Provisioned IOPS (I/O operations per second) value for the DB instance.</p>",
+          "type": "number"
+        },
+        "OptionGroupMemberships": {
+          "description": "<p>The list of option group memberships for this DB instance.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OptionGroupMembership"
+          }
+        },
+        "CharacterSetName": {
+          "description": "<p>If present, specifies the name of the character set that this instance is associated with.</p>",
+          "type": "string"
+        },
+        "NcharCharacterSetName": {
+          "description": "<p>The name of the NCHAR character set for the Oracle DB instance. This character set specifies the\n            Unicode encoding for data stored in table columns of type NCHAR, NCLOB, or NVARCHAR2.</p>",
+          "type": "string"
+        },
+        "SecondaryAvailabilityZone": {
+          "description": "<p>If present, specifies the name of the secondary Availability Zone for a DB instance with multi-AZ support.</p>",
+          "type": "string"
+        },
+        "PubliclyAccessible": {
+          "description": "<p>Indicates whether the DB instance is publicly accessible.</p>\n         <p>When the DB instance is publicly accessible and you connect from outside of the DB instance's virtual private cloud (VPC),\n              its Domain Name System (DNS) endpoint resolves to the public IP address. When you connect from within the same VPC as the DB instance,\n              the endpoint resolves to the private IP address. Access to the DB cluster is ultimately controlled by the security group it uses. That public\n              access isn't permitted if the security group assigned to the DB cluster doesn't permit it.</p>\n         <p>When the DB instance isn't publicly accessible, it is an internal DB instance with a DNS name that resolves to a private IP address.</p>\n         <p>For more information, see <a>CreateDBInstance</a>.</p>",
+          "type": "boolean"
+        },
+        "StatusInfos": {
+          "description": "<p>The status of a read replica. If the DB instance isn't a read replica, the value is\n            blank.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DBInstanceStatusInfo"
+          }
+        },
+        "StorageType": {
+          "description": "<p>The storage type associated with the DB instance.</p>",
+          "type": "string"
+        },
+        "TdeCredentialArn": {
+          "description": "<p>The ARN from the key store with which the instance is associated for TDE encryption.</p>",
+          "type": "string"
+        },
+        "DbInstancePort": {
+          "description": "<p>The port that the DB instance listens on. If the DB instance is part of a DB cluster, this can be a different port than the DB cluster port.</p>",
+          "type": "number"
+        },
+        "DBClusterIdentifier": {
+          "description": "<p>If the DB instance is a member of a DB cluster, indicates the name of the DB cluster that the DB instance is a member of.</p>",
+          "type": "string"
+        },
+        "StorageEncrypted": {
+          "description": "<p>Indicates whether the DB instance is encrypted.</p>",
+          "type": "boolean"
+        },
+        "KmsKeyId": {
+          "description": "<p>If <code>StorageEncrypted</code> is enabled, the Amazon Web Services KMS key identifier\n            for the encrypted DB instance.</p>\n         <p>The Amazon Web Services KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key.</p>",
+          "type": "string"
+        },
+        "DbiResourceId": {
+          "description": "<p>The Amazon Web Services Region-unique, immutable identifier for the DB instance. This identifier is found in Amazon Web Services CloudTrail log\n          entries whenever the Amazon Web Services KMS key for the DB instance is accessed.</p>",
+          "type": "string"
+        },
+        "CACertificateIdentifier": {
+          "description": "<p>The identifier of the CA certificate for this DB instance.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html\">Using SSL/TLS to encrypt a connection to a DB\n            instance</a> in the <i>Amazon RDS User Guide</i> and\n            <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.SSL.html\">\n            Using SSL/TLS to encrypt a connection to a DB cluster</a> in the <i>Amazon Aurora\n            User Guide</i>.</p>",
+          "type": "string"
+        },
+        "DomainMemberships": {
+          "description": "<p>The Active Directory Domain membership records associated with the DB instance.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DomainMembership"
+          }
+        },
+        "CopyTagsToSnapshot": {
+          "description": "<p>Indicates whether tags are copied from the DB instance to snapshots of the DB instance.</p>\n         <p>This setting doesn't apply to Amazon Aurora DB instances. Copying tags to snapshots is managed by the DB cluster. Setting this\n            value for an Aurora DB instance has no effect on the DB cluster setting. For more\n            information, see <code>DBCluster</code>.</p>",
+          "type": "boolean"
+        },
+        "MonitoringInterval": {
+          "description": "<p>The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance.</p>",
+          "type": "number"
+        },
+        "EnhancedMonitoringResourceArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the Amazon CloudWatch Logs log stream that receives the Enhanced Monitoring metrics data for the DB instance.</p>",
+          "type": "string"
+        },
+        "MonitoringRoleArn": {
+          "description": "<p>The ARN for the IAM role that permits RDS to send Enhanced Monitoring metrics to Amazon CloudWatch Logs.</p>",
+          "type": "string"
+        },
+        "PromotionTier": {
+          "description": "<p>The order of priority in which an Aurora Replica is promoted to the primary instance\n          after a failure of the existing primary instance. For more information,\n      see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.AuroraHighAvailability.html#Aurora.Managing.FaultTolerance\">\n          Fault Tolerance for an Aurora DB Cluster</a> in the <i>Amazon Aurora User Guide</i>.</p>",
+          "type": "number"
+        },
+        "DBInstanceArn": {
+          "description": "<p>The Amazon Resource Name (ARN) for the DB instance.</p>",
+          "type": "string"
+        },
+        "Timezone": {
+          "description": "<p>The time zone of the DB instance.\n            In most cases, the <code>Timezone</code> element is empty.\n            <code>Timezone</code> content appears only for\n            RDS for Db2 and RDS for SQL Server DB instances\n            that were created with a time zone specified.</p>",
+          "type": "string"
+        },
+        "IAMDatabaseAuthenticationEnabled": {
+          "description": "<p>Indicates whether mapping of Amazon Web Services Identity and Access Management (IAM) accounts to database accounts is enabled for the DB instance.</p>\n         <p>For a list of engine versions that support IAM database authentication, see\n              <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RDS_Fea_Regions_DB-eng.Feature.IamDatabaseAuthentication.html\">IAM database authentication</a>\n              in the <i>Amazon RDS User Guide</i> and <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.Aurora_Fea_Regions_DB-eng.Feature.IAMdbauth.html\">IAM\n              database authentication in Aurora</a> in the <i>Amazon Aurora User Guide</i>.</p>",
+          "type": "boolean"
+        },
+        "PerformanceInsightsEnabled": {
+          "description": "<p>Indicates whether Performance Insights is enabled for the DB instance.</p>",
+          "type": "boolean"
+        },
+        "PerformanceInsightsKMSKeyId": {
+          "description": "<p>The Amazon Web Services KMS key identifier for encryption of Performance Insights data.</p>\n         <p>The Amazon Web Services KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key.</p>",
+          "type": "string"
+        },
+        "PerformanceInsightsRetentionPeriod": {
+          "description": "<p>The number of days to retain Performance Insights data.</p>\n         <p>Valid Values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>7</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <i>month</i> * 31, where <i>month</i> is a number of months from 1-23.\n                Examples: <code>93</code> (3 months * 31), <code>341</code> (11 months * 31), <code>589</code> (19 months * 31)</p>\n            </li>\n            <li>\n               <p>\n                  <code>731</code>\n               </p>\n            </li>\n         </ul>\n         <p>Default: <code>7</code> days</p>",
+          "type": "number"
+        },
+        "EnabledCloudwatchLogsExports": {
+          "description": "<p>A list of log types that this DB instance is configured to export to CloudWatch Logs.</p>\n         <p>Log types vary by DB engine. For information about the log types for each DB engine, see\n            <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html\">Monitoring Amazon RDS log files</a> in the <i>Amazon RDS User Guide.</i>\n         </p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ProcessorFeatures": {
+          "description": "<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ProcessorFeature"
+          }
+        },
+        "DeletionProtection": {
+          "description": "<p>Indicates whether the DB instance has deletion protection enabled.\n            The database can't be deleted when deletion protection is enabled.\n            For more information, see\n            <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_DeleteInstance.html\">\n                Deleting a DB Instance</a>.</p>",
+          "type": "boolean"
+        },
+        "AssociatedRoles": {
+          "description": "<p>The Amazon Web Services Identity and Access Management (IAM) roles associated with the DB instance.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DBInstanceRole"
+          }
+        },
+        "ListenerEndpoint": {
+          "description": "<p>The listener connection endpoint for SQL Server Always On.</p>",
+          "$ref": "#/definitions/Endpoint"
+        },
+        "MaxAllocatedStorage": {
+          "description": "<p>The upper limit in gibibytes (GiB) to which Amazon RDS can automatically scale the storage of the DB instance.</p>",
+          "type": "number"
+        },
+        "TagList": {
+          "description": "<p>A list of tags.</p>\n         <p>For more information, see\n            <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html\">Tagging Amazon RDS resources</a> in the <i>Amazon RDS User Guide</i> or\n            <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_Tagging.html\">Tagging Amazon Aurora and Amazon RDS resources</a> in the <i>Amazon Aurora User Guide</i>.\n            </p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag_1"
+          }
+        },
+        "DBInstanceAutomatedBackupsReplications": {
+          "description": "<p>The list of replicated automated backups associated with the DB instance.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DBInstanceAutomatedBackupsReplication"
+          }
+        },
+        "CustomerOwnedIpEnabled": {
+          "description": "<p>Indicates whether a customer-owned IP address (CoIP) is enabled for an RDS on Outposts DB instance.</p>\n         <p>A <i>CoIP </i>provides local or external connectivity to resources in\n            your Outpost subnets through your on-premises network. For some use cases, a CoIP can\n            provide lower latency for connections to the DB instance from outside of its virtual\n            private cloud (VPC) on your local network.</p>\n         <p>For more information about RDS on Outposts, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-on-outposts.html\">Working with Amazon RDS on Amazon Web Services Outposts</a>\n            in the <i>Amazon RDS User Guide</i>.</p>\n         <p>For more information about CoIPs, see <a href=\"https://docs.aws.amazon.com/outposts/latest/userguide/routing.html#ip-addressing\">Customer-owned IP addresses</a>\n            in the <i>Amazon Web Services Outposts User Guide</i>.</p>",
+          "type": "boolean"
+        },
+        "AwsBackupRecoveryPointArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the recovery point in Amazon Web Services Backup.</p>",
+          "type": "string"
+        },
+        "ActivityStreamStatus": {
+          "enum": [
+            "started",
+            "starting",
+            "stopped",
+            "stopping"
+          ],
+          "description": "<p>The status of the database activity stream.</p>",
+          "type": "string"
+        },
+        "ActivityStreamKmsKeyId": {
+          "description": "<p>The Amazon Web Services KMS key identifier used for encrypting messages in the database activity stream.\n            The Amazon Web Services KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key.</p>",
+          "type": "string"
+        },
+        "ActivityStreamKinesisStreamName": {
+          "description": "<p>The name of the Amazon Kinesis data stream used for the database activity stream.</p>",
+          "type": "string"
+        },
+        "ActivityStreamMode": {
+          "enum": [
+            "async",
+            "sync"
+          ],
+          "description": "<p>The mode of the database activity stream. Database events such as a change or access generate\n            an activity stream event. RDS for Oracle always handles these events asynchronously.</p>",
+          "type": "string"
+        },
+        "ActivityStreamEngineNativeAuditFieldsIncluded": {
+          "description": "<p>Indicates whether engine-native audit fields are included in the database activity stream.</p>",
+          "type": "boolean"
+        },
+        "AutomationMode": {
+          "enum": [
+            "all-paused",
+            "full"
+          ],
+          "description": "<p>The automation mode of the RDS Custom DB instance: <code>full</code> or <code>all paused</code>.\n            If <code>full</code>, the DB instance automates monitoring and instance recovery. If\n            <code>all paused</code>, the instance pauses automation for the duration set by\n            <code>--resume-full-automation-mode-minutes</code>.</p>",
+          "type": "string"
+        },
+        "ResumeFullAutomationModeTime": {
+          "description": "<p>The number of minutes to pause the automation. When the time period ends, RDS Custom resumes full automation.\n            The minimum value is 60 (default). The maximum value is 1,440.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "CustomIamInstanceProfile": {
+          "description": "<p>The instance profile associated with the underlying Amazon EC2 instance of an\n            RDS Custom DB instance. The instance profile must meet the following requirements:</p>\n         <ul>\n            <li>\n               <p>The profile must exist in your account.</p>\n            </li>\n            <li>\n               <p>The profile must have an IAM role that Amazon EC2 has permissions to assume.</p>\n            </li>\n            <li>\n               <p>The instance profile name and the associated IAM role name must start with the prefix <code>AWSRDSCustom</code>.</p>\n            </li>\n         </ul>\n         <p>For the list of permissions required for the IAM role, see\n            <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/custom-setup-orcl.html#custom-setup-orcl.iam-vpc\">\n                Configure IAM and your VPC</a> in the <i>Amazon RDS User Guide</i>.</p>",
+          "type": "string"
+        },
+        "BackupTarget": {
+          "description": "<p>The location where automated backups and manual snapshots are stored: Amazon Web Services Outposts or the Amazon Web Services Region.</p>",
+          "type": "string"
+        },
+        "NetworkType": {
+          "description": "<p>The network type of the DB instance.</p>\n         <p>The network type is determined by the <code>DBSubnetGroup</code> specified for the DB instance.\n            A <code>DBSubnetGroup</code> can support only the IPv4 protocol or the IPv4 and the IPv6\n            protocols (<code>DUAL</code>).</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html\">\n            Working with a DB instance in a VPC</a> in the\n            <i>Amazon RDS User Guide</i> and\n            <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html\">\n                Working with a DB instance in a VPC</a> in the\n            <i>Amazon Aurora User Guide.</i>\n         </p>\n         <p>Valid Values: <code>IPV4 | DUAL</code>\n         </p>",
+          "type": "string"
+        },
+        "ActivityStreamPolicyStatus": {
+          "enum": [
+            "locked",
+            "locking-policy",
+            "unlocked",
+            "unlocking-policy"
+          ],
+          "description": "<p>The status of the policy state of the activity stream.</p>",
+          "type": "string"
+        },
+        "StorageThroughput": {
+          "description": "<p>The storage throughput for the DB instance.</p>\n         <p>This setting applies only to the <code>gp3</code> storage type.</p>",
+          "type": "number"
+        },
+        "DBSystemId": {
+          "description": "<p>The Oracle system ID (Oracle SID) for a container database (CDB). The Oracle SID is also\n            the name of the CDB. This setting is only valid for RDS Custom DB instances.</p>",
+          "type": "string"
+        },
+        "MasterUserSecret": {
+          "description": "<p>The secret managed by RDS in Amazon Web Services Secrets Manager for the master user password.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-secrets-manager.html\">Password management with Amazon Web Services Secrets Manager</a>\n            in the <i>Amazon RDS User Guide.</i>\n         </p>",
+          "$ref": "#/definitions/MasterUserSecret"
+        },
+        "CertificateDetails": {
+          "description": "<p>The details of the DB instance's server certificate.</p>",
+          "$ref": "#/definitions/CertificateDetails"
+        },
+        "ReadReplicaSourceDBClusterIdentifier": {
+          "description": "<p>The identifier of the source DB cluster if this DB instance is a read\n            replica.</p>",
+          "type": "string"
+        },
+        "PercentProgress": {
+          "description": "<p>The progress of the storage optimization operation as a percentage.</p>",
+          "type": "string"
+        },
+        "DedicatedLogVolume": {
+          "description": "<p>Indicates whether the DB instance has a dedicated log volume (DLV) enabled.</p>",
+          "type": "boolean"
+        },
+        "IsStorageConfigUpgradeAvailable": {
+          "description": "<p>Indicates whether an upgrade is recommended for the storage file system configuration\n            on the DB instance. To migrate to the preferred configuration, you can either create a\n            blue/green deployment, or create a read replica from the DB instance. For more\n            information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PIOPS.StorageTypes.html#USER_PIOPS.UpgradeFileSystem\">Upgrading the storage file system for a DB instance</a>.</p>",
+          "type": "boolean"
+        },
+        "MultiTenant": {
+          "description": "<p>Specifies whether the DB instance is in the multi-tenant configuration (TRUE) or the\n            single-tenant configuration (FALSE).</p>",
+          "type": "boolean"
+        },
+        "EngineLifecycleSupport": {
+          "description": "<p>The life cycle type for the DB instance.</p>\n         <p>For more information, see CreateDBInstance.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Endpoint": {
+      "description": "<p>This data type represents the information you need to connect to an Amazon RDS DB instance.\n      This data type is used as a response element in the following actions:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CreateDBInstance</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>DescribeDBInstances</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>DeleteDBInstance</code>\n               </p>\n            </li>\n         </ul>\n         <p>For the data structure that represents Amazon Aurora DB cluster endpoints,\n        see <code>DBClusterEndpoint</code>.</p>",
+      "type": "object",
+      "properties": {
+        "Address": {
+          "description": "<p>Specifies the DNS address of the DB instance.</p>",
+          "type": "string"
+        },
+        "Port": {
+          "description": "<p>Specifies the port that the database engine is listening on.</p>",
+          "type": "number"
+        },
+        "HostedZoneId": {
+          "description": "<p>Specifies the ID that Amazon Route 53 assigns when you create a hosted zone.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "DBSecurityGroupMembership": {
+      "description": "<p>This data type is used as a response element in the following actions:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ModifyDBInstance</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>RebootDBInstance</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>RestoreDBInstanceFromDBSnapshot</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>RestoreDBInstanceToPointInTime</code>\n               </p>\n            </li>\n         </ul>",
+      "type": "object",
+      "properties": {
+        "DBSecurityGroupName": {
+          "description": "<p>The name of the DB security group.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "description": "<p>The status of the DB security group.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "DBParameterGroupStatus": {
+      "description": "<p>The status of the DB parameter group.</p>\n         <p>This data type is used as a response element in the following actions:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CreateDBInstance</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>CreateDBInstanceReadReplica</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>DeleteDBInstance</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ModifyDBInstance</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>RebootDBInstance</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>RestoreDBInstanceFromDBSnapshot</code>\n               </p>\n            </li>\n         </ul>",
+      "type": "object",
+      "properties": {
+        "DBParameterGroupName": {
+          "description": "<p>The name of the DB parameter group.</p>",
+          "type": "string"
+        },
+        "ParameterApplyStatus": {
+          "description": "<p>The status of parameter updates. Valid values are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>applying</code>: The parameter group change is being applied to the\n                    database.</p>\n            </li>\n            <li>\n               <p>\n                  <code>failed-to-apply</code>: The parameter group is in an invalid\n                    state.</p>\n            </li>\n            <li>\n               <p>\n                  <code>in-sync</code>: The parameter group change is synchronized with the\n                    database.</p>\n            </li>\n            <li>\n               <p>\n                  <code>pending-database-upgrade</code>: The parameter group change will be\n                    applied after the DB instance is upgraded.</p>\n            </li>\n            <li>\n               <p>\n                  <code>pending-reboot</code>: The parameter group change will be applied after\n                    the DB instance reboots.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        }
+      }
+    },
+    "DBSubnetGroup": {
+      "description": "<p>Contains the details of an Amazon RDS DB subnet group.</p>\n         <p>This data type is used as a response element\n          in the <code>DescribeDBSubnetGroups</code> action.</p>",
+      "type": "object",
+      "properties": {
+        "DBSubnetGroupName": {
+          "description": "<p>The name of the DB subnet group.</p>",
+          "type": "string"
+        },
+        "DBSubnetGroupDescription": {
+          "description": "<p>Provides the description of the DB subnet group.</p>",
+          "type": "string"
+        },
+        "VpcId": {
+          "description": "<p>Provides the VpcId of the DB subnet group.</p>",
+          "type": "string"
+        },
+        "SubnetGroupStatus": {
+          "description": "<p>Provides the status of the DB subnet group.</p>",
+          "type": "string"
+        },
+        "Subnets": {
+          "description": "<p>Contains a list of <code>Subnet</code> elements.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Subnet_1"
+          }
+        },
+        "DBSubnetGroupArn": {
+          "description": "<p>The Amazon Resource Name (ARN) for the DB subnet group.</p>",
+          "type": "string"
+        },
+        "SupportedNetworkTypes": {
+          "description": "<p>The network type of the DB subnet group.</p>\n         <p>Valid values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>IPV4</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>DUAL</code>\n               </p>\n            </li>\n         </ul>\n         <p>A <code>DBSubnetGroup</code> can support only the IPv4 protocol or the IPv4 and the IPv6\n            protocols (<code>DUAL</code>).</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html\">\n            Working with a DB instance in a VPC</a> in the\n            <i>Amazon RDS User Guide.</i>\n         </p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Subnet_1": {
+      "description": "<p>This data type is used as a response element for the <code>DescribeDBSubnetGroups</code> operation.</p>",
+      "type": "object",
+      "properties": {
+        "SubnetIdentifier": {
+          "description": "<p>The identifier of the subnet.</p>",
+          "type": "string"
+        },
+        "SubnetAvailabilityZone": {
+          "description": "<p>Contains Availability Zone information.</p>\n         <p>This data type is used as an element in the <code>OrderableDBInstanceOption</code>\n            data type.</p>",
+          "$ref": "#/definitions/AvailabilityZone"
+        },
+        "SubnetOutpost": {
+          "description": "<p>If the subnet is associated with an Outpost, this value specifies the Outpost.</p>\n         <p>For more information about RDS on Outposts, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-on-outposts.html\">Amazon RDS on Amazon Web Services Outposts</a>\n            in the <i>Amazon RDS User Guide.</i>\n         </p>",
+          "$ref": "#/definitions/Outpost"
+        },
+        "SubnetStatus": {
+          "description": "<p>The status of the subnet.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "AvailabilityZone": {
+      "description": "<p>Contains Availability Zone information.</p>\n         <p>This data type is used as an element in the <code>OrderableDBInstanceOption</code>\n            data type.</p>",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "<p>The name of the Availability Zone.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Outpost": {
+      "description": "<p>A data type that represents an Outpost.</p>\n         <p>For more information about RDS on Outposts, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-on-outposts.html\">Amazon RDS on Amazon Web Services Outposts</a>\n          in the <i>Amazon RDS User Guide.</i>\n         </p>",
+      "type": "object",
+      "properties": {
+        "Arn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the Outpost.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "PendingModifiedValues": {
+      "description": "<p>This data type is used as a response element in the <code>ModifyDBInstance</code> operation and\n          contains changes that will be applied during the next maintenance window.</p>",
+      "type": "object",
+      "properties": {
+        "DBInstanceClass": {
+          "description": "<p>The name of the compute and memory capacity class for the DB instance.</p>",
+          "type": "string"
+        },
+        "AllocatedStorage": {
+          "description": "<p>The allocated storage size for the DB instance specified in gibibytes (GiB).</p>",
+          "type": "number"
+        },
+        "MasterUserPassword": {
+          "description": "<p>The master credentials for the DB instance.</p>",
+          "type": "string"
+        },
+        "Port": {
+          "description": "<p>The port for the DB instance.</p>",
+          "type": "number"
+        },
+        "BackupRetentionPeriod": {
+          "description": "<p>The number of days for which automated backups are retained.</p>",
+          "type": "number"
+        },
+        "MultiAZ": {
+          "description": "<p>Indicates whether the Single-AZ DB instance will change to a Multi-AZ deployment.</p>",
+          "type": "boolean"
+        },
+        "EngineVersion": {
+          "description": "<p>The database engine version.</p>",
+          "type": "string"
+        },
+        "LicenseModel": {
+          "description": "<p>The license model for the DB instance.</p>\n         <p>Valid values: <code>license-included</code> | <code>bring-your-own-license</code> |\n            <code>general-public-license</code>\n         </p>",
+          "type": "string"
+        },
+        "Iops": {
+          "description": "<p>The Provisioned IOPS value for the DB instance.</p>",
+          "type": "number"
+        },
+        "DBInstanceIdentifier": {
+          "description": "<p>The  database identifier for the DB instance.</p>",
+          "type": "string"
+        },
+        "StorageType": {
+          "description": "<p>The storage type of the DB instance.</p>",
+          "type": "string"
+        },
+        "CACertificateIdentifier": {
+          "description": "<p>The identifier of the CA certificate for the DB instance.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html\">Using SSL/TLS to encrypt a connection to a DB\n            instance</a> in the <i>Amazon RDS User Guide</i> and\n            <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.SSL.html\">\n            Using SSL/TLS to encrypt a connection to a DB cluster</a> in the <i>Amazon Aurora\n            User Guide</i>.</p>",
+          "type": "string"
+        },
+        "DBSubnetGroupName": {
+          "description": "<p>The DB subnet group for the DB instance.</p>",
+          "type": "string"
+        },
+        "PendingCloudwatchLogsExports": {
+          "description": "<p>A list of the log types whose configuration is still pending. In other words, these log types are in the process of being activated or deactivated.</p>",
+          "$ref": "#/definitions/PendingCloudwatchLogsExports"
+        },
+        "ProcessorFeatures": {
+          "description": "<p>The number of CPU cores and the number of threads per core for the DB instance class\n            of the DB instance.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ProcessorFeature"
+          }
+        },
+        "IAMDatabaseAuthenticationEnabled": {
+          "description": "<p>Indicates whether mapping of Amazon Web Services Identity and Access Management (IAM) accounts to database accounts is enabled.</p>",
+          "type": "boolean"
+        },
+        "AutomationMode": {
+          "enum": [
+            "all-paused",
+            "full"
+          ],
+          "description": "<p>The automation mode of the RDS Custom DB instance: <code>full</code> or <code>all-paused</code>.\n            If <code>full</code>, the DB instance automates monitoring and instance recovery. If\n            <code>all-paused</code>, the instance pauses automation for the duration set by\n            <code>--resume-full-automation-mode-minutes</code>.</p>",
+          "type": "string"
+        },
+        "ResumeFullAutomationModeTime": {
+          "description": "<p>The number of minutes to pause the automation. When the time period ends, RDS Custom resumes full automation.\n            The minimum value is 60 (default). The maximum value is 1,440.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "StorageThroughput": {
+          "description": "<p>The storage throughput of the DB instance.</p>",
+          "type": "number"
+        },
+        "Engine": {
+          "description": "<p>The database engine of the DB instance.</p>",
+          "type": "string"
+        },
+        "DedicatedLogVolume": {
+          "description": "<p>Indicates whether the DB instance has a dedicated log volume (DLV) enabled.></p>",
+          "type": "boolean"
+        },
+        "MultiTenant": {
+          "description": "<p>Indicates whether the DB instance will change to the multi-tenant configuration (TRUE)\n            or the single-tenant configuration (FALSE). </p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "ProcessorFeature": {
+      "description": "<p>Contains the processor features of a DB instance class.</p>\n         <p>To specify the number of CPU cores, use the <code>coreCount</code> feature name\n            for the <code>Name</code> parameter. To specify the number of threads per core, use the\n            <code>threadsPerCore</code> feature name for the <code>Name</code> parameter.</p>\n         <p>You can set the processor features of the DB instance class for a DB instance when you\n            call one of the following actions:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CreateDBInstance</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ModifyDBInstance</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>RestoreDBInstanceFromDBSnapshot</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>RestoreDBInstanceFromS3</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>RestoreDBInstanceToPointInTime</code>\n               </p>\n            </li>\n         </ul>\n         <p>You can view the valid processor values for a particular instance class by calling the\n                <code>DescribeOrderableDBInstanceOptions</code> action and specifying the\n            instance class for the <code>DBInstanceClass</code> parameter.</p>\n         <p>In addition, you can use the following actions for DB instance class processor information:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>DescribeDBInstances</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>DescribeDBSnapshots</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>DescribeValidDBInstanceModifications</code>\n               </p>\n            </li>\n         </ul>\n         <p>If you call <code>DescribeDBInstances</code>, <code>ProcessorFeature</code> returns\n            non-null values only if the following conditions are met:</p>\n         <ul>\n            <li>\n               <p>You are accessing an Oracle DB instance.</p>\n            </li>\n            <li>\n               <p>Your Oracle DB instance class supports configuring the number of CPU cores and threads per core.</p>\n            </li>\n            <li>\n               <p>The current number CPU cores and threads is set to a non-default value.</p>\n            </li>\n         </ul>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html#USER_ConfigureProcessor\">\n            Configuring the processor for a DB instance class in RDS for Oracle</a> in the <i>Amazon RDS User Guide.\n            </i>\n         </p>",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "<p>The name of the processor feature. Valid names are <code>coreCount</code> and <code>threadsPerCore</code>.</p>",
+          "type": "string"
+        },
+        "Value": {
+          "description": "<p>The value of a processor feature.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "OptionGroupMembership": {
+      "description": "<p>Provides information on the option groups the DB instance is a member of.</p>",
+      "type": "object",
+      "properties": {
+        "OptionGroupName": {
+          "description": "<p>The name of the option group that the instance belongs to.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "description": "<p>The status of the DB instance's option group membership. Valid values are:\n      <code>in-sync</code>,\n      <code>pending-apply</code>,\n      <code>pending-removal</code>,\n      <code>pending-maintenance-apply</code>,\n      <code>pending-maintenance-removal</code>,\n      <code>applying</code>,\n      <code>removing</code>,\n      and <code>failed</code>.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "DBInstanceStatusInfo": {
+      "description": "<p>Provides a list of status information for a DB instance.</p>",
+      "type": "object",
+      "properties": {
+        "StatusType": {
+          "description": "<p>This value is currently \"read replication.\"</p>",
+          "type": "string"
+        },
+        "Normal": {
+          "description": "<p>Indicates whether the instance is operating normally (TRUE) or is in an error state (FALSE).</p>",
+          "type": "boolean"
+        },
+        "Status": {
+          "description": "<p>The status of the DB instance. For a StatusType of read replica, the values can be\n            replicating, replication stop point set, replication stop point reached, error, stopped,\n            or terminated.</p>",
+          "type": "string"
+        },
+        "Message": {
+          "description": "<p>Details of the error if there is an error for the instance. If the instance isn't in an error state, this value is blank.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "DBInstanceRole": {
+      "description": "<p>Information about an Amazon Web Services Identity and Access Management (IAM) role that is associated with a DB instance.</p>",
+      "type": "object",
+      "properties": {
+        "RoleArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the IAM role that is associated with the DB\n            instance.</p>",
+          "type": "string"
+        },
+        "FeatureName": {
+          "description": "<p>The name of the feature associated with the Amazon Web Services Identity and Access Management (IAM) role.\n            For information about supported feature names, see <code>DBEngineVersion</code>.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "description": "<p>Information about the state of association between the IAM role and the DB instance. The Status property returns one of the following\n            values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - the IAM role ARN is associated with the DB instance and can be used to\n                access other Amazon Web Services services on your behalf.</p>\n            </li>\n            <li>\n               <p>\n                  <code>PENDING</code> - the IAM role ARN is being associated with the DB instance.</p>\n            </li>\n            <li>\n               <p>\n                  <code>INVALID</code> - the IAM role ARN is associated with the DB instance, but the DB instance is unable\n                to assume the IAM role in order to access other Amazon Web Services services on your behalf.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        }
+      }
+    },
+    "DBInstanceAutomatedBackupsReplication": {
+      "description": "<p>Automated backups of a DB instance replicated to another Amazon Web Services Region. They consist of system backups, transaction logs, and database instance properties.</p>",
+      "type": "object",
+      "properties": {
+        "DBInstanceAutomatedBackupsArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the replicated automated backups.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "DBProxy": {
+      "description": "<p>The data structure representing a proxy managed by the RDS Proxy.</p>\n         <p>This data type is used as a response element in the <code>DescribeDBProxies</code> action.</p>",
+      "type": "object",
+      "properties": {
+        "DBProxyName": {
+          "description": "<p>The identifier for the proxy. This name must be unique for all proxies owned by your Amazon Web Services account in the specified Amazon Web Services Region.</p>",
+          "type": "string"
+        },
+        "DBProxyArn": {
+          "description": "<p>The Amazon Resource Name (ARN) for the proxy.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "enum": [
+            "available",
+            "creating",
+            "deleting",
+            "incompatible-network",
+            "insufficient-resource-limits",
+            "modifying",
+            "reactivating",
+            "suspended",
+            "suspending"
+          ],
+          "description": "<p>The current status of this proxy. A status of <code>available</code> means the\n        proxy is ready to handle requests. Other values indicate that you must wait for\n        the proxy to be ready, or take some action to resolve an issue.</p>",
+          "type": "string"
+        },
+        "EngineFamily": {
+          "description": "<p>The kinds of databases that the proxy can connect to. This value determines which database network protocol\n        the proxy recognizes when it interprets network traffic to and from the database. <code>MYSQL</code> supports Aurora MySQL,\n        RDS for MariaDB, and RDS for MySQL databases. <code>POSTGRESQL</code> supports Aurora PostgreSQL and RDS for PostgreSQL databases.\n        <code>SQLSERVER</code> supports RDS for Microsoft SQL Server databases.</p>",
+          "type": "string"
+        },
+        "VpcId": {
+          "description": "<p>Provides the VPC ID of the DB proxy.</p>",
+          "type": "string"
+        },
+        "VpcSecurityGroupIds": {
+          "description": "<p>Provides a list of VPC security groups that the proxy belongs to.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "VpcSubnetIds": {
+          "description": "<p>The EC2 subnet IDs for the proxy.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Auth": {
+          "description": "<p>One or more data structures specifying the authorization mechanism to connect to the associated RDS DB instance\n        or Aurora DB cluster.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UserAuthConfigInfo"
+          }
+        },
+        "RoleArn": {
+          "description": "<p>The Amazon Resource Name (ARN) for the IAM role that the proxy uses to access Amazon Secrets Manager.</p>",
+          "type": "string"
+        },
+        "Endpoint": {
+          "description": "<p>The endpoint that you can use to connect to the DB proxy. You include the endpoint value in the\n        connection string for a database client application.</p>",
+          "type": "string"
+        },
+        "RequireTLS": {
+          "description": "<p>Indicates whether Transport Layer Security (TLS) encryption is required for connections to the proxy.</p>",
+          "type": "boolean"
+        },
+        "IdleClientTimeout": {
+          "description": "<p>The number of seconds a connection to the proxy can have no activity before the proxy drops the client connection.\n        The proxy keeps the underlying database connection open and puts it back into the connection pool for reuse by\n        later connection requests.</p>\n         <p>Default: 1800 (30 minutes)</p>\n         <p>Constraints: 1 to 28,800</p>",
+          "type": "number"
+        },
+        "DebugLogging": {
+          "description": "<p>Indicates whether the proxy includes detailed information about SQL statements in its logs.\n        This information helps you to debug issues involving SQL behavior or the performance\n        and scalability of the proxy connections. The debug information includes the text of\n        SQL statements that you submit through the proxy. Thus, only enable this setting\n        when needed for debugging, and only when you have security measures in place to\n        safeguard any sensitive information that appears in the logs.</p>",
+          "type": "boolean"
+        },
+        "CreatedDate": {
+          "description": "<p>The date and time when the proxy was first created.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "UpdatedDate": {
+          "description": "<p>The date and time when the proxy was last updated.</p>",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "UserAuthConfigInfo": {
+      "description": "<p>Returns the details of authentication used by a proxy to log in as a specific database user.</p>",
+      "type": "object",
+      "properties": {
+        "Description": {
+          "description": "<p>A user-specified description about the authentication used by a proxy to log in as a specific database user.</p>",
+          "type": "string"
+        },
+        "UserName": {
+          "description": "<p>The name of the database user to which the proxy connects.</p>",
+          "type": "string"
+        },
+        "AuthScheme": {
+          "enum": "",
+          "description": "<p>The type of authentication that the proxy uses for connections from the proxy to the underlying database.</p>",
+          "const": "SECRETS",
+          "type": "string"
+        },
+        "SecretArn": {
+          "description": "<p>The Amazon Resource Name (ARN) representing the secret that the proxy uses to authenticate\n        to the RDS DB instance or Aurora DB cluster. These secrets are stored within Amazon Secrets Manager.</p>",
+          "type": "string"
+        },
+        "IAMAuth": {
+          "enum": [
+            "DISABLED",
+            "ENABLED",
+            "REQUIRED"
+          ],
+          "description": "<p>Whether to require or disallow Amazon Web Services Identity and Access Management (IAM) authentication for connections to the proxy.\n        The <code>ENABLED</code> value is valid only for proxies with RDS for Microsoft SQL Server.</p>",
+          "type": "string"
+        },
+        "ClientPasswordAuthType": {
+          "enum": [
+            "MYSQL_NATIVE_PASSWORD",
+            "POSTGRES_MD5",
+            "POSTGRES_SCRAM_SHA_256",
+            "SQL_SERVER_AUTHENTICATION"
+          ],
+          "description": "<p>The type of authentication the proxy uses for connections from clients.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Cluster": {
+      "description": "<p>A regional grouping of one or more container instances where you can run task\n\t\t\trequests. Each account receives a default cluster the first time you use the Amazon ECS\n\t\t\tservice, but you may also create other clusters. Clusters may contain more than one\n\t\t\tinstance type simultaneously.</p>",
+      "type": "object",
+      "properties": {
+        "clusterArn": {
+          "description": "<p>The Amazon Resource Name (ARN) that identifies the cluster. For more information about the ARN\n\t\t\tformat, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids\">Amazon Resource Name (ARN)</a> in the <i>Amazon ECS Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "clusterName": {
+          "description": "<p>A user-generated string that you use to identify your cluster.</p>",
+          "type": "string"
+        },
+        "configuration": {
+          "description": "<p>The execute command configuration for the cluster.</p>",
+          "$ref": "#/definitions/ClusterConfiguration"
+        },
+        "status": {
+          "description": "<p>The status of the cluster. The following are the possible states that are\n\t\t\treturned.</p>\n         <dl>\n            <dt>ACTIVE</dt>\n            <dd>\n               <p>The cluster is ready to accept tasks and if applicable you can register\n\t\t\t\t\t\tcontainer instances with the cluster.</p>\n            </dd>\n            <dt>PROVISIONING</dt>\n            <dd>\n               <p>The cluster has capacity providers that are associated with it and the\n\t\t\t\t\t\tresources needed for the capacity provider are being created.</p>\n            </dd>\n            <dt>DEPROVISIONING</dt>\n            <dd>\n               <p>The cluster has capacity providers that are associated with it and the\n\t\t\t\t\t\tresources needed for the capacity provider are being deleted.</p>\n            </dd>\n            <dt>FAILED</dt>\n            <dd>\n               <p>The cluster has capacity providers that are associated with it and the\n\t\t\t\t\t\tresources needed for the capacity provider have failed to create.</p>\n            </dd>\n            <dt>INACTIVE</dt>\n            <dd>\n               <p>The cluster has been deleted. Clusters with an <code>INACTIVE</code>\n\t\t\t\t\t\tstatus may remain discoverable in your account for a period of time.\n\t\t\t\t\t\tHowever, this behavior is subject to change in the future. We don't\n\t\t\t\t\t\trecommend that you rely on <code>INACTIVE</code> clusters persisting.</p>\n            </dd>\n         </dl>",
+          "type": "string"
+        },
+        "registeredContainerInstancesCount": {
+          "description": "<p>The number of container instances registered into the cluster. This includes container\n\t\t\tinstances in both <code>ACTIVE</code> and <code>DRAINING</code> status.</p>",
+          "type": "number"
+        },
+        "runningTasksCount": {
+          "description": "<p>The number of tasks in the cluster that are in the <code>RUNNING</code> state.</p>",
+          "type": "number"
+        },
+        "pendingTasksCount": {
+          "description": "<p>The number of tasks in the cluster that are in the <code>PENDING</code> state.</p>",
+          "type": "number"
+        },
+        "activeServicesCount": {
+          "description": "<p>The number of services that are running on the cluster in an <code>ACTIVE</code>\n\t\t\tstate. You can view these services with <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ListServices.html\">PListServices</a>.</p>",
+          "type": "number"
+        },
+        "statistics": {
+          "description": "<p>Additional information about your clusters that are separated by launch type. They\n\t\t\tinclude the following:</p>\n         <ul>\n            <li>\n               <p>runningEC2TasksCount</p>\n            </li>\n            <li>\n               <p>RunningFargateTasksCount</p>\n            </li>\n            <li>\n               <p>pendingEC2TasksCount</p>\n            </li>\n            <li>\n               <p>pendingFargateTasksCount</p>\n            </li>\n            <li>\n               <p>activeEC2ServiceCount</p>\n            </li>\n            <li>\n               <p>activeFargateServiceCount</p>\n            </li>\n            <li>\n               <p>drainingEC2ServiceCount</p>\n            </li>\n            <li>\n               <p>drainingFargateServiceCount</p>\n            </li>\n         </ul>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyValuePair"
+          }
+        },
+        "tags": {
+          "description": "<p>The metadata that you apply to the cluster to help you categorize and organize them.\n\t\t\tEach tag consists of a key and an optional value. You define both.</p>\n         <p>The following basic restrictions apply to tags:</p>\n         <ul>\n            <li>\n               <p>Maximum number of tags per resource - 50</p>\n            </li>\n            <li>\n               <p>For each resource, each tag key must be unique, and each tag key can have only\n                    one value.</p>\n            </li>\n            <li>\n               <p>Maximum key length - 128 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>Maximum value length - 256 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>If your tagging schema is used across multiple services and resources,\n                    remember that other services may have restrictions on allowed characters.\n                    Generally allowed characters are: letters, numbers, and spaces representable in\n                    UTF-8, and the following characters: + - = . _ : /",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag_2"
+          }
+        },
+        "settings": {
+          "description": "<p>The settings for the cluster. This parameter indicates whether CloudWatch Container Insights\n\t\t\tis on or off for a cluster.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClusterSetting"
+          }
+        },
+        "capacityProviders": {
+          "description": "<p>The capacity providers associated with the cluster.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "defaultCapacityProviderStrategy": {
+          "description": "<p>The default capacity provider strategy for the cluster. When services or tasks are run\n\t\t\tin the cluster with no launch type or capacity provider strategy specified, the default\n\t\t\tcapacity provider strategy is used.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CapacityProviderStrategyItem"
+          }
+        },
+        "attachments": {
+          "description": "<p>The resources attached to a cluster. When using a capacity provider with a cluster,\n\t\t\tthe capacity provider and associated resources are returned as cluster\n\t\t\tattachments.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Attachment"
+          }
+        },
+        "attachmentsStatus": {
+          "description": "<p>The status of the capacity providers associated with the cluster. The following are\n\t\t\tthe states that are returned.</p>\n         <dl>\n            <dt>UPDATE_IN_PROGRESS</dt>\n            <dd>\n               <p>The available capacity providers for the cluster are updating.</p>\n            </dd>\n            <dt>UPDATE_COMPLETE</dt>\n            <dd>\n               <p>The capacity providers have successfully updated.</p>\n            </dd>\n            <dt>UPDATE_FAILED</dt>\n            <dd>\n               <p>The capacity provider updates failed.</p>\n            </dd>\n         </dl>",
+          "type": "string"
+        },
+        "serviceConnectDefaults": {
+          "description": "<p>Use this parameter to set a default Service Connect namespace. After you set a default\n\tService Connect namespace, any new services with Service Connect turned on that are created in the cluster are added as\n\tclient services in the namespace. This setting only applies to new services that set the <code>enabled</code> parameter to\n\t<code>true</code> in the <code>ServiceConnectConfiguration</code>.\n\tYou can set the namespace of each service individually in the <code>ServiceConnectConfiguration</code> to override this default\n\tparameter.</p>\n         <p>Tasks that run in a namespace can use short names to connect\n\tto services in the namespace. Tasks can connect to services across all of the clusters in the namespace.\n\tTasks connect through a managed proxy container\n\tthat collects logs and metrics for increased visibility.\n\tOnly the tasks that Amazon ECS services create are supported with Service Connect.\n\tFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html\">Service Connect</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+          "$ref": "#/definitions/ClusterServiceConnectDefaults"
+        }
+      }
+    },
+    "ClusterConfiguration": {
+      "description": "<p>The execute command and managed storage configuration for the cluster.</p>",
+      "type": "object",
+      "properties": {
+        "executeCommandConfiguration": {
+          "description": "<p>The details of the execute command configuration.</p>",
+          "$ref": "#/definitions/ExecuteCommandConfiguration"
+        },
+        "managedStorageConfiguration": {
+          "description": "<p>The details of the managed storage configuration.</p>",
+          "$ref": "#/definitions/ManagedStorageConfiguration"
+        }
+      }
+    },
+    "ExecuteCommandConfiguration": {
+      "description": "<p>The details of the execute command configuration.</p>",
+      "type": "object",
+      "properties": {
+        "kmsKeyId": {
+          "description": "<p>Specify an Key Management Service key ID to encrypt the data between the local client\n\t\t\tand the container.</p>",
+          "type": "string"
+        },
+        "logging": {
+          "enum": [
+            "DEFAULT",
+            "NONE",
+            "OVERRIDE"
+          ],
+          "description": "<p>The log setting to use for redirecting logs for your execute command results. The\n\t\t\tfollowing log settings are available.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>NONE</code>: The execute command session is not logged.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DEFAULT</code>: The <code>awslogs</code> configuration in the task\n\t\t\t\t\tdefinition is used. If no logging parameter is specified, it defaults to this\n\t\t\t\t\tvalue. If no <code>awslogs</code> log driver is configured in the task\n\t\t\t\t\tdefinition, the output won't be logged.</p>\n            </li>\n            <li>\n               <p>\n                  <code>OVERRIDE</code>: Specify the logging details as a part of\n\t\t\t\t\t\t<code>logConfiguration</code>. If the <code>OVERRIDE</code> logging option\n\t\t\t\t\tis specified, the <code>logConfiguration</code> is required.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "logConfiguration": {
+          "description": "<p>The log configuration for the results of the execute command actions. The logs can be\n\t\t\tsent to CloudWatch Logs or an Amazon S3 bucket. When <code>logging=OVERRIDE</code> is\n\t\t\tspecified, a <code>logConfiguration</code> must be provided.</p>",
+          "$ref": "#/definitions/ExecuteCommandLogConfiguration"
+        }
+      }
+    },
+    "ExecuteCommandLogConfiguration": {
+      "description": "<p>The log configuration for the results of the execute command actions. The logs can be\n\t\t\tsent to CloudWatch Logs or an Amazon S3 bucket.</p>",
+      "type": "object",
+      "properties": {
+        "cloudWatchLogGroupName": {
+          "description": "<p>The name of the CloudWatch log group to send logs to.</p>\n         <note>\n            <p>The CloudWatch log group must already be created.</p>\n         </note>",
+          "type": "string"
+        },
+        "cloudWatchEncryptionEnabled": {
+          "description": "<p>Determines whether to use encryption on the CloudWatch logs. If not specified,\n\t\t\tencryption will be off.</p>",
+          "type": "boolean"
+        },
+        "s3BucketName": {
+          "description": "<p>The name of the S3 bucket to send logs to.</p>\n         <note>\n            <p>The S3 bucket must already be created.</p>\n         </note>",
+          "type": "string"
+        },
+        "s3EncryptionEnabled": {
+          "description": "<p>Determines whether to use encryption on the S3 logs. If not specified, encryption is\n\t\t\tnot used.</p>",
+          "type": "boolean"
+        },
+        "s3KeyPrefix": {
+          "description": "<p>An optional folder in the S3 bucket to place logs in.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ManagedStorageConfiguration": {
+      "description": "<p>The managed storage configuration for the cluster.</p>",
+      "type": "object",
+      "properties": {
+        "kmsKeyId": {
+          "description": "<p>Specify a Amazon Web Services Key Management Service key ID to encrypt the managed storage.</p>",
+          "type": "string"
+        },
+        "fargateEphemeralStorageKmsKeyId": {
+          "description": "<p>Specify the Key Management Service key ID for the Fargate ephemeral storage.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "KeyValuePair": {
+      "description": "<p>A key-value pair object.</p>",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "<p>The name of the key-value pair. For environment variables, this is the name of the\n\t\t\tenvironment variable.</p>",
+          "type": "string"
+        },
+        "value": {
+          "description": "<p>The value of the key-value pair. For environment variables, this is the value of the\n\t\t\tenvironment variable.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Tag_2": {
+      "description": "<p>The metadata that you apply to a resource to help you categorize and organize them.\n\t\t\tEach tag consists of a key and an optional value. You define them.</p>\n         <p>The following basic restrictions apply to tags:</p>\n         <ul>\n            <li>\n               <p>Maximum number of tags per resource - 50</p>\n            </li>\n            <li>\n               <p>For each resource, each tag key must be unique, and each tag key can have only\n                    one value.</p>\n            </li>\n            <li>\n               <p>Maximum key length - 128 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>Maximum value length - 256 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>If your tagging schema is used across multiple services and resources,\n                    remember that other services may have restrictions on allowed characters.\n                    Generally allowed characters are: letters, numbers, and spaces representable in\n                    UTF-8, and the following characters: + - = . _ : /",
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "<p>One part of a key-value pair that make up a tag. A <code>key</code> is a general label\n\t\t\tthat acts like a category for more specific tag values.</p>",
+          "type": "string"
+        },
+        "value": {
+          "description": "<p>The optional part of a key-value pair that make up a tag. A <code>value</code> acts as\n\t\t\ta descriptor within a tag category (key).</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ClusterSetting": {
+      "description": "<p>The settings to use when creating a cluster. This parameter is used to turn on CloudWatch\n\t\t\tContainer Insights for a cluster.</p>",
+      "type": "object",
+      "properties": {
+        "name": {
+          "enum": "",
+          "description": "<p>The name of the cluster setting. The value is <code>containerInsights</code> .</p>",
+          "const": "containerInsights",
+          "type": "string"
+        },
+        "value": {
+          "description": "<p>The value to set for the cluster setting. The supported values are\n\t\t\t\t<code>enabled</code> and <code>disabled</code>. </p>\n         <p>If you set <code>name</code> to <code>containerInsights</code> and <code>value</code>\n\t\t\tto <code>enabled</code>, CloudWatch Container Insights will be on for the cluster, otherwise\n\t\t\tit will be off unless the <code>containerInsights</code> account setting is turned on.\n\t\t\tIf a cluster value is specified, it will override the <code>containerInsights</code>\n\t\t\tvalue set with <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PutAccountSetting.html\">PutAccountSetting</a> or <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PutAccountSettingDefault.html\">PutAccountSettingDefault</a>.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "CapacityProviderStrategyItem": {
+      "description": "<p>The details of a capacity provider strategy. A capacity provider strategy can be set\n\t\t\twhen using the <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html\">RunTask</a>or <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateCluster.html\">CreateCluster</a> APIs or as\n\t\t\tthe default capacity provider strategy for a cluster with the <code>CreateCluster</code> API.</p>\n         <p>Only capacity providers that are already associated with a cluster and have an\n\t\t\t\t<code>ACTIVE</code> or <code>UPDATING</code> status can be used in a capacity\n\t\t\tprovider strategy. The <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PutClusterCapacityProviders.html\">PutClusterCapacityProviders</a> API is used to\n\t\t\tassociate a capacity provider with a cluster.</p>\n         <p>If specifying a capacity provider that uses an Auto Scaling group, the capacity\n\t\t\tprovider must already be created. New Auto Scaling group capacity providers can be\n\t\t\tcreated with the <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateClusterCapacityProvider.html\">CreateClusterCapacityProvider</a> API operation.</p>\n         <p>To use a Fargate capacity provider, specify either the <code>FARGATE</code> or\n\t\t\t\t<code>FARGATE_SPOT</code> capacity providers. The Fargate capacity providers are\n\t\t\tavailable to all accounts and only need to be associated with a cluster to be used in a\n\t\t\tcapacity provider strategy.</p>\n         <p>With <code>FARGATE_SPOT</code>, you can run interruption tolerant tasks at a rate that's\n\t\t\tdiscounted compared to the <code>FARGATE</code> price. <code>FARGATE_SPOT</code> runs\n\t\t\ttasks on spare compute capacity. When Amazon Web Services needs the capacity back, your tasks are\n\t\t\tinterrupted with a two-minute warning. <code>FARGATE_SPOT</code> supports Linux tasks\n\t\t\twith the X86_64 architecture on platform version 1.3.0 or later.\n\t\t\t\t<code>FARGATE_SPOT</code> supports Linux tasks with the ARM64 architecture on\n\t\t\tplatform version 1.4.0 or later.</p>\n         <p>A capacity provider strategy may contain a maximum of 6 capacity providers.</p>",
+      "type": "object",
+      "properties": {
+        "capacityProvider": {
+          "description": "<p>The short name of the capacity provider.</p>",
+          "type": "string"
+        },
+        "weight": {
+          "description": "<p>The <i>weight</i> value designates the relative percentage of the total\n\t\t\tnumber of tasks launched that should use the specified capacity provider. The\n\t\t\t\t<code>weight</code> value is taken into consideration after the <code>base</code>\n\t\t\tvalue, if defined, is satisfied.</p>\n         <p>If no <code>weight</code> value is specified, the default value of <code>0</code> is\n\t\t\tused. When multiple capacity providers are specified within a capacity provider\n\t\t\tstrategy, at least one of the capacity providers must have a weight value greater than\n\t\t\tzero and any capacity providers with a weight of <code>0</code> can't be used to place\n\t\t\ttasks. If you specify multiple capacity providers in a strategy that all have a weight\n\t\t\tof <code>0</code>, any <code>RunTask</code> or <code>CreateService</code> actions using\n\t\t\tthe capacity provider strategy will fail.</p>\n         <p>An example scenario for using weights is defining a strategy that contains two\n\t\t\tcapacity providers and both have a weight of <code>1</code>, then when the\n\t\t\t\t<code>base</code> is satisfied, the tasks will be split evenly across the two\n\t\t\tcapacity providers. Using that same logic, if you specify a weight of <code>1</code> for\n\t\t\t\t<i>capacityProviderA</i> and a weight of <code>4</code> for\n\t\t\t\t<i>capacityProviderB</i>, then for every one task that's run using\n\t\t\t\t<i>capacityProviderA</i>, four tasks would use\n\t\t\t\t<i>capacityProviderB</i>.</p>",
+          "type": "number"
+        },
+        "base": {
+          "description": "<p>The <i>base</i> value designates how many tasks, at a minimum, to run on\n\t\t\tthe specified capacity provider. Only one capacity provider in a capacity provider\n\t\t\tstrategy can have a <i>base</i> defined. If no value is specified, the\n\t\t\tdefault value of <code>0</code> is used.</p>",
+          "type": "number"
+        }
+      },
+      "required": [
+        "capacityProvider"
+      ]
+    },
+    "Attachment": {
+      "description": "<p>An object representing a container instance or task attachment.</p>",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "<p>The unique identifier for the attachment.</p>",
+          "type": "string"
+        },
+        "type": {
+          "description": "<p>The type of the attachment, such as <code>ElasticNetworkInterface</code>,\n\t\t\t\t<code>Service Connect</code>, and <code>AmazonElasticBlockStorage</code>.</p>",
+          "type": "string"
+        },
+        "status": {
+          "description": "<p> The status of the attachment. Valid values are <code>PRECREATED</code>,\n\t\t\t\t<code>CREATED</code>, <code>ATTACHING</code>, <code>ATTACHED</code>,\n\t\t\t\t<code>DETACHING</code>, <code>DETACHED</code>, <code>DELETED</code>, and\n\t\t\t\t<code>FAILED</code>.</p>",
+          "type": "string"
+        },
+        "details": {
+          "description": "<p>Details of the attachment.</p>\n         <p>For elastic network interfaces, this includes the network interface ID, the MAC\n\t\t\taddress, the subnet ID, and the private IPv4 address.</p>\n         <p>For Service Connect services, this includes <code>portName</code>,\n\t\t\t\t<code>clientAliases</code>, <code>discoveryName</code>, and\n\t\t\t\t<code>ingressPortOverride</code>.</p>\n         <p>For Elastic Block Storage, this includes <code>roleArn</code>,\n\t\t\t\t<code>deleteOnTermination</code>, <code>volumeName</code>, <code>volumeId</code>,\n\t\t\tand <code>statusReason</code> (only when the attachment fails to create or\n\t\t\tattach).</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyValuePair"
+          }
+        }
+      }
+    },
+    "ClusterServiceConnectDefaults": {
+      "description": "<p>Use this parameter to set a default Service Connect namespace. After you set a default\n\tService Connect namespace, any new services with Service Connect turned on that are created in the cluster are added as\n\tclient services in the namespace. This setting only applies to new services that set the <code>enabled</code> parameter to\n\t<code>true</code> in the <code>ServiceConnectConfiguration</code>.\n\tYou can set the namespace of each service individually in the <code>ServiceConnectConfiguration</code> to override this default\n\tparameter.</p>\n         <p>Tasks that run in a namespace can use short names to connect\n\tto services in the namespace. Tasks can connect to services across all of the clusters in the namespace.\n\tTasks connect through a managed proxy container\n\tthat collects logs and metrics for increased visibility.\n\tOnly the tasks that Amazon ECS services create are supported with Service Connect.\n\tFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html\">Service Connect</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "description": "<p>The namespace name or full Amazon Resource Name (ARN) of the Cloud Map namespace. When you create a service and don't specify a\n\t\t\tService Connect configuration, this namespace is used.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Service": {
+      "description": "<p>Details on a service within a cluster.</p>",
+      "type": "object",
+      "properties": {
+        "serviceArn": {
+          "description": "<p>The ARN that identifies the service. For more information about the ARN format,\n\t\t\tsee <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids\">Amazon Resource Name (ARN)</a> in the <i>Amazon ECS Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "serviceName": {
+          "description": "<p>The name of your service. Up to 255 letters (uppercase and lowercase), numbers, underscores, and hyphens are allowed. Service names must be unique within\n\t\t\ta cluster. However, you can have similarly named services in multiple clusters within a\n\t\t\tRegion or across multiple Regions.</p>",
+          "type": "string"
+        },
+        "clusterArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the cluster that hosts the service.</p>",
+          "type": "string"
+        },
+        "loadBalancers": {
+          "description": "<p>A list of Elastic Load Balancing load balancer objects. It contains the load balancer name, the\n\t\t\tcontainer name, and the container port to access from the load balancer. The container\n\t\t\tname is as it appears in a container definition.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LoadBalancer"
+          }
+        },
+        "serviceRegistries": {
+          "description": "<p>The details for the service discovery registries to assign to this service. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html\">Service\n\t\t\t\tDiscovery</a>.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ServiceRegistry"
+          }
+        },
+        "status": {
+          "description": "<p>The status of the service. The valid values are <code>ACTIVE</code>,\n\t\t\t\t<code>DRAINING</code>, or <code>INACTIVE</code>.</p>",
+          "type": "string"
+        },
+        "desiredCount": {
+          "description": "<p>The desired number of instantiations of the task definition to keep running on the\n\t\t\tservice. This value is specified when the service is created with <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateService.html\">CreateService</a> , and it can be modified with <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_UpdateService.html\">UpdateService</a>.</p>",
+          "type": "number"
+        },
+        "runningCount": {
+          "description": "<p>The number of tasks in the cluster that are in the <code>RUNNING</code> state.</p>",
+          "type": "number"
+        },
+        "pendingCount": {
+          "description": "<p>The number of tasks in the cluster that are in the <code>PENDING</code> state.</p>",
+          "type": "number"
+        },
+        "launchType": {
+          "enum": [
+            "EC2",
+            "EXTERNAL",
+            "FARGATE"
+          ],
+          "description": "<p>The launch type the service is using. When using the DescribeServices API, this field\n\t\t\tis omitted if the service was created using a capacity provider strategy.</p>",
+          "type": "string"
+        },
+        "capacityProviderStrategy": {
+          "description": "<p>The capacity provider strategy the service uses. When using <code>DescribeServices</code>,\n\t\t\tthis field is omitted if the service was created using a launch type.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CapacityProviderStrategyItem"
+          }
+        },
+        "platformVersion": {
+          "description": "<p>The platform version to run your service on. A platform version is only specified for\n\t\t\ttasks that are hosted on Fargate. If one isn't specified, the <code>LATEST</code>\n\t\t\tplatform version is used. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html\">Fargate Platform\n\t\t\t\tVersions</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "platformFamily": {
+          "description": "<p>The operating system that your tasks in the service run on. A platform family is\n\t\t\tspecified only for tasks using the Fargate launch type. </p>\n         <p> All tasks that run as part of this service must use the same\n\t\t\t\t<code>platformFamily</code> value as the service (for example,\n\t\t\t<code>LINUX</code>).</p>",
+          "type": "string"
+        },
+        "taskDefinition": {
+          "description": "<p>The task definition to use for tasks in the service. This value is specified when the\n\t\t\tservice is created with <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateService.html\">CreateService</a>, and it can be modified with\n\t\t\t<a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_UpdateService.html\">UpdateService</a>.</p>",
+          "type": "string"
+        },
+        "deploymentConfiguration": {
+          "description": "<p>Optional deployment parameters that control how many tasks run during the deployment\n\t\t\tand the ordering of stopping and starting tasks.</p>",
+          "$ref": "#/definitions/DeploymentConfiguration"
+        },
+        "taskSets": {
+          "description": "<p>Information about a set of Amazon ECS tasks in either an CodeDeploy or an <code>EXTERNAL</code>\n\t\t\tdeployment. An Amazon ECS task set includes details such as the desired number of tasks, how\n\t\t\tmany tasks are running, and whether the task set serves production traffic.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TaskSet"
+          }
+        },
+        "deployments": {
+          "description": "<p>The current state of deployments for the service.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Deployment"
+          }
+        },
+        "roleArn": {
+          "description": "<p>The ARN of the IAM role that's associated with the service. It allows the Amazon ECS\n\t\t\tcontainer agent to register container instances with an Elastic Load Balancing load balancer.</p>",
+          "type": "string"
+        },
+        "events": {
+          "description": "<p>The event stream for your service. A maximum of 100 of the latest events are\n\t\t\tdisplayed.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ServiceEvent"
+          }
+        },
+        "createdAt": {
+          "description": "<p>The Unix timestamp for the time when the service was created.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "placementConstraints": {
+          "description": "<p>The placement constraints for the tasks in the service.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PlacementConstraint"
+          }
+        },
+        "placementStrategy": {
+          "description": "<p>The placement strategy that determines how tasks for the service are placed.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PlacementStrategy"
+          }
+        },
+        "networkConfiguration": {
+          "description": "<p>The VPC subnet and security group configuration for tasks that receive their own\n            elastic network interface by using the <code>awsvpc</code> networking mode.</p>",
+          "$ref": "#/definitions/NetworkConfiguration"
+        },
+        "healthCheckGracePeriodSeconds": {
+          "description": "<p>The period of time, in seconds, that the Amazon ECS service scheduler ignores unhealthy\n\t\t\tElastic Load Balancing target health checks after a task has first started.</p>",
+          "type": "number"
+        },
+        "schedulingStrategy": {
+          "enum": [
+            "DAEMON",
+            "REPLICA"
+          ],
+          "description": "<p>The scheduling strategy to use for the service. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html\">Services</a>.</p>\n         <p>There are two service scheduler strategies available.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>REPLICA</code>-The replica scheduling strategy places and\n\t\t\t\t\tmaintains the desired number of tasks across your cluster. By default, the\n\t\t\t\t\tservice scheduler spreads tasks across Availability Zones. You can use task\n\t\t\t\t\tplacement strategies and constraints to customize task placement\n\t\t\t\t\tdecisions.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DAEMON</code>-The daemon scheduling strategy deploys exactly one\n\t\t\t\t\ttask on each active container instance. This task meets all of the task\n\t\t\t\t\tplacement constraints that you specify in your cluster. The service scheduler\n\t\t\t\t\talso evaluates the task placement constraints for running tasks. It stop tasks\n\t\t\t\t\tthat don't meet the placement constraints.</p>\n               <note>\n                  <p>Fargate tasks don't support the <code>DAEMON</code>\n\t\t\t\t\t\tscheduling strategy.</p>\n               </note>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "deploymentController": {
+          "description": "<p>The deployment controller type the service is using. </p>",
+          "$ref": "#/definitions/DeploymentController"
+        },
+        "tags": {
+          "description": "<p>The metadata that you apply to the service to help you categorize and organize them. Each\n\t\t\ttag consists of a key and an optional value. You define both the key and value.</p>\n         <p>The following basic restrictions apply to tags:</p>\n         <ul>\n            <li>\n               <p>Maximum number of tags per resource - 50</p>\n            </li>\n            <li>\n               <p>For each resource, each tag key must be unique, and each tag key can have only\n                    one value.</p>\n            </li>\n            <li>\n               <p>Maximum key length - 128 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>Maximum value length - 256 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>If your tagging schema is used across multiple services and resources,\n                    remember that other services may have restrictions on allowed characters.\n                    Generally allowed characters are: letters, numbers, and spaces representable in\n                    UTF-8, and the following characters: + - = . _ : /",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag_2"
+          }
+        },
+        "createdBy": {
+          "description": "<p>The principal that created the service.</p>",
+          "type": "string"
+        },
+        "enableECSManagedTags": {
+          "description": "<p>Determines whether to use Amazon ECS managed tags for the tasks in the service. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-using-tags.html\">Tagging Your Amazon ECS\n\t\t\t\tResources</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+          "type": "boolean"
+        },
+        "propagateTags": {
+          "enum": [
+            "NONE",
+            "SERVICE",
+            "TASK_DEFINITION"
+          ],
+          "description": "<p>Determines whether to propagate the tags from the task definition or the service to\n\t\t\tthe task. If no value is specified, the tags aren't propagated.</p>",
+          "type": "string"
+        },
+        "enableExecuteCommand": {
+          "description": "<p>Determines whether the execute command functionality is turned on for the service. If\n\t\t\t\t<code>true</code>, the execute command functionality is turned on for all containers\n\t\t\tin tasks as part of the service.</p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "LoadBalancer": {
+      "description": "<p>The load balancer configuration to use with a service or task set.</p>\n         <p>When you add, update, or remove a load balancer configuration, Amazon ECS starts a new\n\t\t\tdeployment with the updated Elastic Load Balancing configuration. This causes tasks to register to and\n\t\t\tderegister from load balancers.</p>\n         <p>We recommend that you verify this on a test environment before you update the Elastic Load Balancing\n\t\t\tconfiguration. </p>\n         <p>A service-linked role is required for services that use multiple target groups. For\n\t\t\tmore information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html\">Using\n\t\t\t\tservice-linked roles</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "targetGroupArn": {
+          "description": "<p>The full Amazon Resource Name (ARN) of the Elastic Load Balancing target group or groups associated with a service or\n\t\t\ttask set.</p>\n         <p>A target group ARN is only specified when using an Application Load Balancer or Network Load Balancer. </p>\n         <p>For services using the <code>ECS</code> deployment controller, you can specify one or\n\t\t\tmultiple target groups. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/register-multiple-targetgroups.html\">Registering multiple target groups with a service</a> in\n\t\t\tthe <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <p>For services using the <code>CODE_DEPLOY</code> deployment controller, you're required\n\t\t\tto define two target groups for the load balancer. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-bluegreen.html\">Blue/green deployment with CodeDeploy</a> in the\n\t\t\t<i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <important>\n            <p>If your service's task definition uses the <code>awsvpc</code> network mode, you\n\t\t\t\tmust choose <code>ip</code> as the target type, not <code>instance</code>. Do this\n\t\t\t\twhen creating your target groups because tasks that use the <code>awsvpc</code>\n\t\t\t\tnetwork mode are associated with an elastic network interface, not an Amazon EC2\n\t\t\t\tinstance. This network mode is required for the Fargate launch\n\t\t\t\ttype.</p>\n         </important>",
+          "type": "string"
+        },
+        "loadBalancerName": {
+          "description": "<p>The name of the load balancer to associate with the service or task set.</p>\n         <p>If you are using an Application Load Balancer or a Network Load Balancer the load balancer name parameter should be\n\t\t\tomitted.</p>",
+          "type": "string"
+        },
+        "containerName": {
+          "description": "<p>The name of the container (as it appears in a container definition) to associate with\n\t\t\tthe load balancer.</p>\n         <p>You need to specify the container name when configuring the target group for an Amazon ECS\n\t\t\tload balancer.</p>",
+          "type": "string"
+        },
+        "containerPort": {
+          "description": "<p>The port on the container to associate with the load balancer. This port must\n\t\t\tcorrespond to a <code>containerPort</code> in the task definition the tasks in the\n\t\t\tservice are using. For tasks that use the EC2 launch type, the container\n\t\t\tinstance they're launched on must allow ingress traffic on the <code>hostPort</code> of\n\t\t\tthe port mapping.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "ServiceRegistry": {
+      "description": "<p>The details for the service registry.</p>\n         <p>Each service may be associated with one service registry. Multiple service registries\n\t\t\tfor each service are not supported.</p>\n         <p>When you add, update, or remove the service registries configuration, Amazon ECS starts a\n\t\t\tnew deployment. New tasks are registered and deregistered to the updated service\n\t\t\tregistry configuration.</p>",
+      "type": "object",
+      "properties": {
+        "registryArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the service registry. The currently supported service registry is\n\t\t\tCloud Map. For more information, see <a href=\"https://docs.aws.amazon.com/cloud-map/latest/api/API_CreateService.html\">CreateService</a>.</p>",
+          "type": "string"
+        },
+        "port": {
+          "description": "<p>The port value used if your service discovery service specified an SRV record. This\n\t\t\tfield might be used if both the <code>awsvpc</code> network mode and SRV records are\n\t\t\tused.</p>",
+          "type": "number"
+        },
+        "containerName": {
+          "description": "<p>The container name value to be used for your service discovery service. It's already\n\t\t\tspecified in the task definition. If the task definition that your service task\n\t\t\tspecifies uses the <code>bridge</code> or <code>host</code> network mode, you must\n\t\t\tspecify a <code>containerName</code> and <code>containerPort</code> combination from the\n\t\t\ttask definition. If the task definition that your service task specifies uses the\n\t\t\t\t<code>awsvpc</code> network mode and a type SRV DNS record is used, you must specify\n\t\t\teither a <code>containerName</code> and <code>containerPort</code> combination or a\n\t\t\t\t<code>port</code> value. However, you can't specify both.</p>",
+          "type": "string"
+        },
+        "containerPort": {
+          "description": "<p>The port value to be used for your service discovery service. It's already specified\n\t\t\tin the task definition. If the task definition your service task specifies uses the\n\t\t\t\t<code>bridge</code> or <code>host</code> network mode, you must specify a\n\t\t\t\t<code>containerName</code> and <code>containerPort</code> combination from the task\n\t\t\tdefinition. If the task definition your service task specifies uses the\n\t\t\t\t<code>awsvpc</code> network mode and a type SRV DNS record is used, you must specify\n\t\t\teither a <code>containerName</code> and <code>containerPort</code> combination or a\n\t\t\t\t<code>port</code> value. However, you can't specify both.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "DeploymentConfiguration": {
+      "description": "<p>Optional deployment parameters that control how many tasks run during the deployment and the\n\t\t\tfailure detection methods.</p>",
+      "type": "object",
+      "properties": {
+        "deploymentCircuitBreaker": {
+          "description": "<note>\n            <p>The deployment circuit breaker can only be used for services using the rolling\n\t\t\t\tupdate (<code>ECS</code>) deployment type.</p>\n         </note>\n         <p>The <b>deployment circuit breaker</b> determines whether a\n\t\t\tservice deployment will fail if the service can't reach a steady state. If you use the\n\t\t\tdeployment circuit breaker, a service deployment will transition to a failed state and\n\t\t\tstop launching new tasks. If you use the rollback option, when a service deployment\n\t\t\tfails, the service is rolled back to the last deployment that completed successfully.\n\t\t\tFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-ecs.html\">Rolling\n\t\t\t\tupdate</a> in the <i>Amazon Elastic Container Service Developer\n\t\t\t\tGuide</i>\n         </p>",
+          "$ref": "#/definitions/DeploymentCircuitBreaker"
+        },
+        "maximumPercent": {
+          "description": "<p>If a service is using the rolling update (<code>ECS</code>) deployment type, the\n\t\t\t\t<code>maximumPercent</code> parameter represents an upper limit on the number of\n\t\t\tyour service's tasks that are allowed in the <code>RUNNING</code> or\n\t\t\t\t<code>PENDING</code> state during a deployment, as a percentage of the\n\t\t\t\t<code>desiredCount</code> (rounded down to the nearest integer). This parameter\n\t\t\tenables you to define the deployment batch size. For example, if your service is using\n\t\t\tthe <code>REPLICA</code> service scheduler and has a <code>desiredCount</code> of four\n\t\t\ttasks and a <code>maximumPercent</code> value of 200%, the scheduler may start four new\n\t\t\ttasks before stopping the four older tasks (provided that the cluster resources required\n\t\t\tto do this are available). The default <code>maximumPercent</code> value for a service\n\t\t\tusing the <code>REPLICA</code> service scheduler is 200%.</p>\n         <p>If a service is using either the blue/green (<code>CODE_DEPLOY</code>) or\n\t\t\t\t<code>EXTERNAL</code> deployment types, and tasks in the service use the EC2\n\t\t\tlaunch type, the <b>maximum percent</b> value is set to the\n\t\t\tdefault value. The <b>maximum percent</b> value is used to define the upper limit on the number of the tasks in the\n\t\t\tservice that remain in the <code>RUNNING</code> state while the container instances are\n\t\t\tin the <code>DRAINING</code> state.</p>\n         <note>\n            <p>You can't specify a custom <code>maximumPercent</code> value for a service that uses either the blue/green (<code>CODE_DEPLOY</code>) or\n\t\t\t<code>EXTERNAL</code> deployment types and has tasks that use the EC2 launch type.</p>\n         </note>\n         <p>If the tasks in the service use the\n\t\t\tFargate launch type, the maximum percent value is not used, although it is\n\t\t\treturned when describing your service.</p>",
+          "type": "number"
+        },
+        "minimumHealthyPercent": {
+          "description": "<p>If a service is using the rolling update (<code>ECS</code>) deployment type, the\n\t\t\t\t<code>minimumHealthyPercent</code> represents a lower limit on the number of your\n\t\t\tservice's tasks that must remain in the <code>RUNNING</code> state during a deployment,\n\t\t\tas a percentage of the <code>desiredCount</code> (rounded up to the nearest integer).\n\t\t\tThis parameter enables you to deploy without using additional cluster capacity. For\n\t\t\texample, if your service has a <code>desiredCount</code> of four tasks and a\n\t\t\t\t<code>minimumHealthyPercent</code> of 50%, the service scheduler may stop two\n\t\t\texisting tasks to free up cluster capacity before starting two new tasks. </p>\n         <p>For services that <i>do not</i> use a load balancer, the following\n\t\t\tshould be noted:</p>\n         <ul>\n            <li>\n               <p>A service is considered healthy if all essential containers within the tasks\n\t\t\t\t\tin the service pass their health checks.</p>\n            </li>\n            <li>\n               <p>If a task has no essential containers with a health check defined, the service\n\t\t\t\t\tscheduler will wait for 40 seconds after a task reaches a <code>RUNNING</code>\n\t\t\t\t\tstate before the task is counted towards the minimum healthy percent\n\t\t\t\t\ttotal.</p>\n            </li>\n            <li>\n               <p>If a task has one or more essential containers with a health check defined,\n\t\t\t\t\tthe service scheduler will wait for the task to reach a healthy status before\n\t\t\t\t\tcounting it towards the minimum healthy percent total. A task is considered\n\t\t\t\t\thealthy when all essential containers within the task have passed their health\n\t\t\t\t\tchecks. The amount of time the service scheduler can wait for is determined by\n\t\t\t\t\tthe container health check settings. </p>\n            </li>\n         </ul>\n         <p>For services that <i>do</i> use a load balancer, the following should be\n\t\t\tnoted:</p>\n         <ul>\n            <li>\n               <p>If a task has no essential containers with a health check defined, the service\n\t\t\t\t\tscheduler will wait for the load balancer target group health check to return a\n\t\t\t\t\thealthy status before counting the task towards the minimum healthy percent\n\t\t\t\t\ttotal.</p>\n            </li>\n            <li>\n               <p>If a task has an essential container with a health check defined, the service\n\t\t\t\t\tscheduler will wait for both the task to reach a healthy status and the load\n\t\t\t\t\tbalancer target group health check to return a healthy status before counting\n\t\t\t\t\tthe task towards the minimum healthy percent total.</p>\n            </li>\n         </ul>\n         <p>The default value for a replica service for <code>minimumHealthyPercent</code> is\n\t\t\t100%. The default <code>minimumHealthyPercent</code> value for a service using the\n\t\t\t\t<code>DAEMON</code> service schedule is 0% for the CLI, the Amazon Web Services SDKs, and the\n\t\t\tAPIs and 50% for the Amazon Web Services Management Console.</p>\n         <p>The minimum number of healthy tasks during a deployment is the\n\t\t\t\t<code>desiredCount</code> multiplied by the <code>minimumHealthyPercent</code>/100,\n\t\t\trounded up to the nearest integer value.</p>\n         <p>If a service is using either the blue/green (<code>CODE_DEPLOY</code>) or\n\t\t\t\t<code>EXTERNAL</code> deployment types and is running tasks that use the\n\t\t\tEC2 launch type, the <b>minimum healthy\n\t\t\t\tpercent</b> value is set to the default value. The <b>minimum healthy percent</b> value is used to define the lower\n\t\t\tlimit on the number of the tasks in the service that remain in the <code>RUNNING</code>\n\t\t\tstate while the container instances are in the <code>DRAINING</code> state.</p>\n         <note>\n            <p>You can't specify a custom <code>minimumHealthyPercent</code> value for a service that uses either the blue/green (<code>CODE_DEPLOY</code>) or\n\t\t\t<code>EXTERNAL</code> deployment types and has tasks that use the EC2 launch type.</p>\n         </note>\n         <p>If a service\n\t\t\tis using either the blue/green (<code>CODE_DEPLOY</code>) or <code>EXTERNAL</code>\n\t\t\tdeployment types and is running tasks that use the Fargate launch type,\n\t\t\tthe minimum healthy percent value is not used, although it is returned when describing\n\t\t\tyour service.</p>",
+          "type": "number"
+        },
+        "alarms": {
+          "description": "<p>Information about the CloudWatch alarms.</p>",
+          "$ref": "#/definitions/DeploymentAlarms"
+        }
+      }
+    },
+    "DeploymentCircuitBreaker": {
+      "description": "<note>\n            <p>The deployment circuit breaker can only be used for services using the rolling\n\t\t\t\tupdate (<code>ECS</code>) deployment type.</p>\n         </note>\n         <p>The <b>deployment circuit breaker</b> determines whether a\n\t\t\tservice deployment will fail if the service can't reach a steady state. If it is turned\n\t\t\ton, a service deployment will transition to a failed state and stop launching new tasks.\n\t\t\tYou can also configure Amazon ECS to roll back your service to the last completed deployment\n\t\t\tafter a failure. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-ecs.html\">Rolling\n\t\t\t\tupdate</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <p>For more information about API failure reasons, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/api_failures_messages.html\">API failure\n\t\t\t\treasons</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "enable": {
+          "description": "<p>Determines whether to use the deployment circuit breaker logic for the service.</p>",
+          "type": "boolean"
+        },
+        "rollback": {
+          "description": "<p>Determines whether to configure Amazon ECS to roll back the service if a service deployment\n\t\t\tfails. If rollback is on, when a service deployment fails, the service is rolled back to\n\t\t\tthe last deployment that completed successfully.</p>",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enable",
+        "rollback"
+      ]
+    },
+    "DeploymentAlarms": {
+      "description": "<p>One of the methods which provide a way for you to quickly identify when a deployment\n\t\t\thas failed, and then to optionally roll back the failure to the last working\n\t\t\tdeployment.</p>\n         <p>When the alarms are generated, Amazon ECS sets the service deployment to failed. Set the\n\t\t\trollback parameter to have Amazon ECS to roll back your service to the last completed\n\t\t\tdeployment after a failure.</p>\n         <p>You can only use the <code>DeploymentAlarms</code> method to detect failures when the\n\t\t\t\t<code>DeploymentController</code> is set to <code>ECS</code> (rolling\n\t\t\tupdate).</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-ecs.html\">Rolling\n\t\t\t\tupdate</a> in the <i>\n               <i>Amazon Elastic Container Service Developer Guide</i>\n            </i>.</p>",
+      "type": "object",
+      "properties": {
+        "alarmNames": {
+          "description": "<p>One or more CloudWatch alarm names. Use a \",\" to separate the alarms.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rollback": {
+          "description": "<p>Determines whether to configure Amazon ECS to roll back the service if a service deployment\n\t\t\tfails. If rollback is used, when a service deployment fails, the service is rolled back\n\t\t\tto the last deployment that completed successfully.</p>",
+          "type": "boolean"
+        },
+        "enable": {
+          "description": "<p>Determines whether to use the CloudWatch alarm option in the service deployment\n\t\t\tprocess.</p>",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "alarmNames",
+        "enable",
+        "rollback"
+      ]
+    },
+    "TaskSet": {
+      "description": "<p>Information about a set of Amazon ECS tasks in either an CodeDeploy or an <code>EXTERNAL</code>\n\t\t\tdeployment. An Amazon ECS task set includes details such as the desired number of tasks, how\n\t\t\tmany tasks are running, and whether the task set serves production traffic.</p>",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "<p>The ID of the task set.</p>",
+          "type": "string"
+        },
+        "taskSetArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the task set.</p>",
+          "type": "string"
+        },
+        "serviceArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the service the task set exists in.</p>",
+          "type": "string"
+        },
+        "clusterArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the cluster that the service that hosts the task set exists\n\t\t\tin.</p>",
+          "type": "string"
+        },
+        "startedBy": {
+          "description": "<p>The tag specified when a task set is started. If an CodeDeploy deployment created the task\n\t\t\tset, the <code>startedBy</code> parameter is <code>CODE_DEPLOY</code>. If an external\n\t\t\tdeployment created the task set, the <code>startedBy</code> field isn't used.</p>",
+          "type": "string"
+        },
+        "externalId": {
+          "description": "<p>The external ID associated with the task set.</p>\n         <p>If an CodeDeploy deployment created a task set, the <code>externalId</code> parameter\n\t\t\tcontains the CodeDeploy deployment ID.</p>\n         <p>If a task set is created for an external deployment and is associated with a service\n\t\t\tdiscovery registry, the <code>externalId</code> parameter contains the\n\t\t\t\t<code>ECS_TASK_SET_EXTERNAL_ID</code> Cloud Map attribute.</p>",
+          "type": "string"
+        },
+        "status": {
+          "description": "<p>The status of the task set. The following describes each state.</p>\n         <dl>\n            <dt>PRIMARY</dt>\n            <dd>\n               <p>The task set is serving production traffic.</p>\n            </dd>\n            <dt>ACTIVE</dt>\n            <dd>\n               <p>The task set isn't serving production traffic.</p>\n            </dd>\n            <dt>DRAINING</dt>\n            <dd>\n               <p>The tasks in the task set are being stopped, and their corresponding\n\t\t\t\t\t\ttargets are being deregistered from their target group.</p>\n            </dd>\n         </dl>",
+          "type": "string"
+        },
+        "taskDefinition": {
+          "description": "<p>The task definition that the task set is using.</p>",
+          "type": "string"
+        },
+        "computedDesiredCount": {
+          "description": "<p>The computed desired count for the task set. This is calculated by multiplying the\n\t\t\tservice's <code>desiredCount</code> by the task set's <code>scale</code> percentage. The\n\t\t\tresult is always rounded up. For example, if the computed desired count is 1.2, it\n\t\t\trounds up to 2 tasks.</p>",
+          "type": "number"
+        },
+        "pendingCount": {
+          "description": "<p>The number of tasks in the task set that are in the <code>PENDING</code> status during\n\t\t\ta deployment. A task in the <code>PENDING</code> state is preparing to enter the\n\t\t\t\t<code>RUNNING</code> state. A task set enters the <code>PENDING</code> status when\n\t\t\tit launches for the first time or when it's restarted after being in the\n\t\t\t\t<code>STOPPED</code> state.</p>",
+          "type": "number"
+        },
+        "runningCount": {
+          "description": "<p>The number of tasks in the task set that are in the <code>RUNNING</code> status during\n\t\t\ta deployment. A task in the <code>RUNNING</code> state is running and ready for\n\t\t\tuse.</p>",
+          "type": "number"
+        },
+        "createdAt": {
+          "description": "<p>The Unix timestamp for the time when the task set was created.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedAt": {
+          "description": "<p>The Unix timestamp for the time when the task set was last updated.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "launchType": {
+          "enum": [
+            "EC2",
+            "EXTERNAL",
+            "FARGATE"
+          ],
+          "description": "<p>The launch type the tasks in the task set are using. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html\">Amazon ECS\n\t\t\t\tlaunch types</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "capacityProviderStrategy": {
+          "description": "<p>The capacity provider strategy that are associated with the task set.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CapacityProviderStrategyItem"
+          }
+        },
+        "platformVersion": {
+          "description": "<p>The Fargate platform version where the tasks in the task set are running. A platform\n\t\t\tversion is only specified for tasks run on Fargate. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html\">Fargate platform versions</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "platformFamily": {
+          "description": "<p>The operating system that your tasks in the set are running on. A platform family is\n\t\t\tspecified only for tasks that use the Fargate launch type. </p>\n         <p> All tasks in the set must have the same value.</p>",
+          "type": "string"
+        },
+        "networkConfiguration": {
+          "description": "<p>The network configuration for the task set.</p>",
+          "$ref": "#/definitions/NetworkConfiguration"
+        },
+        "loadBalancers": {
+          "description": "<p>Details on a load balancer that are used with a task set.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LoadBalancer"
+          }
+        },
+        "serviceRegistries": {
+          "description": "<p>The details for the service discovery registries to assign to this task set. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html\">Service\n\t\t\t\tdiscovery</a>.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ServiceRegistry"
+          }
+        },
+        "scale": {
+          "description": "<p>A floating-point percentage of your desired number of tasks to place and keep running\n\t\t\tin the task set.</p>",
+          "$ref": "#/definitions/Scale"
+        },
+        "stabilityStatus": {
+          "enum": [
+            "STABILIZING",
+            "STEADY_STATE"
+          ],
+          "description": "<p>The stability status. This indicates whether the task set has reached a steady state.\n\t\t\tIf the following conditions are met, the task set are in\n\t\t\t<code>STEADY_STATE</code>:</p>\n         <ul>\n            <li>\n               <p>The task <code>runningCount</code> is equal to the\n\t\t\t\t\t\t<code>computedDesiredCount</code>.</p>\n            </li>\n            <li>\n               <p>The <code>pendingCount</code> is <code>0</code>.</p>\n            </li>\n            <li>\n               <p>There are no tasks that are running on container instances in the\n\t\t\t\t\t\t<code>DRAINING</code> status.</p>\n            </li>\n            <li>\n               <p>All tasks are reporting a healthy status from the load balancers, service\n\t\t\t\t\tdiscovery, and container health checks.</p>\n            </li>\n         </ul>\n         <p>If any of those conditions aren't met, the stability status returns\n\t\t\t\t<code>STABILIZING</code>.</p>",
+          "type": "string"
+        },
+        "stabilityStatusAt": {
+          "description": "<p>The Unix timestamp for the time when the task set stability status was\n\t\t\tretrieved.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "tags": {
+          "description": "<p>The metadata that you apply to the task set to help you categorize and organize them.\n\t\t\tEach tag consists of a key and an optional value. You define both.</p>\n         <p>The following basic restrictions apply to tags:</p>\n         <ul>\n            <li>\n               <p>Maximum number of tags per resource - 50</p>\n            </li>\n            <li>\n               <p>For each resource, each tag key must be unique, and each tag key can have only\n                    one value.</p>\n            </li>\n            <li>\n               <p>Maximum key length - 128 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>Maximum value length - 256 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>If your tagging schema is used across multiple services and resources,\n                    remember that other services may have restrictions on allowed characters.\n                    Generally allowed characters are: letters, numbers, and spaces representable in\n                    UTF-8, and the following characters: + - = . _ : /",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag_2"
+          }
+        },
+        "fargateEphemeralStorage": {
+          "description": "<p>The Fargate ephemeral storage settings for the task set.</p>",
+          "$ref": "#/definitions/DeploymentEphemeralStorage"
+        }
+      }
+    },
+    "NetworkConfiguration": {
+      "description": "<p>The network configuration for a task or service.</p>",
+      "type": "object",
+      "properties": {
+        "awsvpcConfiguration": {
+          "description": "<p>The VPC subnets and security groups that are associated with a task.</p>\n         <note>\n            <p>All specified subnets and security groups must be from the same VPC.</p>\n         </note>",
+          "$ref": "#/definitions/AwsVpcConfiguration"
+        }
+      }
+    },
+    "AwsVpcConfiguration": {
+      "description": "<p>An object representing the networking details for a task or service. For example\n\t\t\t\t<code>awsVpcConfiguration=\\{subnets=[\"subnet-12344321\"],securityGroups=[\"sg-12344321\"]\\}</code>.</p>",
+      "type": "object",
+      "properties": {
+        "subnets": {
+          "description": "<p>The IDs of the subnets associated with the task or service. There's a limit of 16\n\t\t\tsubnets that can be specified per <code>awsvpcConfiguration</code>.</p>\n         <note>\n            <p>All specified subnets must be from the same VPC.</p>\n         </note>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "securityGroups": {
+          "description": "<p>The IDs of the security groups associated with the task or service. If you don't\n\t\t\tspecify a security group, the default security group for the VPC is used. There's a\n\t\t\tlimit of 5 security groups that can be specified per\n\t\t\t<code>awsvpcConfiguration</code>.</p>\n         <note>\n            <p>All specified security groups must be from the same VPC.</p>\n         </note>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "assignPublicIp": {
+          "enum": [
+            "DISABLED",
+            "ENABLED"
+          ],
+          "description": "<p>Whether the task's elastic network interface receives a public IP address. The default\n\t\t\tvalue is <code>DISABLED</code>.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "subnets"
+      ]
+    },
+    "Scale": {
+      "description": "<p>A floating-point percentage of the desired number of tasks to place and keep running\n\t\t\tin the task set.</p>",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "<p>The value, specified as a percent total of a service's <code>desiredCount</code>, to\n\t\t\tscale the task set. Accepted values are numbers between 0 and 100.</p>",
+          "type": "number"
+        },
+        "unit": {
+          "enum": "",
+          "description": "<p>The unit of measure for the scale value.</p>",
+          "const": "PERCENT",
+          "type": "string"
+        }
+      }
+    },
+    "DeploymentEphemeralStorage": {
+      "description": "<p>The amount of ephemeral storage to allocate for the deployment.</p>",
+      "type": "object",
+      "properties": {
+        "kmsKeyId": {
+          "description": "<p>Specify an Amazon Web Services Key Management Service key ID to encrypt the ephemeral storage for\n\t\t\tdeployment.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Deployment": {
+      "description": "<p>The details of an Amazon ECS service deployment. This is used only when a service uses the\n\t\t\t\t<code>ECS</code> deployment controller type.</p>",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "<p>The ID of the deployment.</p>",
+          "type": "string"
+        },
+        "status": {
+          "description": "<p>The status of the deployment. The following describes each state.</p>\n         <dl>\n            <dt>PRIMARY</dt>\n            <dd>\n               <p>The most recent deployment of a service.</p>\n            </dd>\n            <dt>ACTIVE</dt>\n            <dd>\n               <p>A service deployment that still has running tasks, but are in the process\n\t\t\t\t\t\tof being replaced with a new <code>PRIMARY</code> deployment.</p>\n            </dd>\n            <dt>INACTIVE</dt>\n            <dd>\n               <p>A deployment that has been completely replaced.</p>\n            </dd>\n         </dl>",
+          "type": "string"
+        },
+        "taskDefinition": {
+          "description": "<p>The most recent task definition that was specified for the tasks in the service to\n\t\t\tuse.</p>",
+          "type": "string"
+        },
+        "desiredCount": {
+          "description": "<p>The most recent desired count of tasks that was specified for the service to deploy or\n\t\t\tmaintain.</p>",
+          "type": "number"
+        },
+        "pendingCount": {
+          "description": "<p>The number of tasks in the deployment that are in the <code>PENDING</code>\n\t\t\tstatus.</p>",
+          "type": "number"
+        },
+        "runningCount": {
+          "description": "<p>The number of tasks in the deployment that are in the <code>RUNNING</code>\n\t\t\tstatus.</p>",
+          "type": "number"
+        },
+        "failedTasks": {
+          "description": "<p>The number of consecutively failed tasks in the deployment. A task is considered a\n\t\t\tfailure if the service scheduler can't launch the task, the task doesn't transition to a\n\t\t\t\t<code>RUNNING</code> state, or if it fails any of its defined health checks and is\n\t\t\tstopped.</p>\n         <note>\n            <p>Once a service deployment has one or more successfully running tasks, the failed\n\t\t\t\ttask count resets to zero and stops being evaluated.</p>\n         </note>",
+          "type": "number"
+        },
+        "createdAt": {
+          "description": "<p>The Unix timestamp for the time when the service deployment was created.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedAt": {
+          "description": "<p>The Unix timestamp for the time when the service deployment was last updated.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "capacityProviderStrategy": {
+          "description": "<p>The capacity provider strategy that the deployment is using.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CapacityProviderStrategyItem"
+          }
+        },
+        "launchType": {
+          "enum": [
+            "EC2",
+            "EXTERNAL",
+            "FARGATE"
+          ],
+          "description": "<p>The launch type the tasks in the service are using. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html\">Amazon ECS\n\t\t\t\tLaunch Types</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "platformVersion": {
+          "description": "<p>The platform version that your tasks in the service run on. A platform version is only\n\t\t\tspecified for tasks using the Fargate launch type. If one isn't specified,\n\t\t\tthe <code>LATEST</code> platform version is used. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html\">Fargate Platform Versions</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "platformFamily": {
+          "description": "<p>The operating system that your tasks in the service, or tasks are running on. A\n\t\t\tplatform family is specified only for tasks using the Fargate launch type. </p>\n         <p> All tasks that run as part of this service must use the same\n\t\t\t\t<code>platformFamily</code> value as the service, for example, <code>\n\t\t\tLINUX.</code>.</p>",
+          "type": "string"
+        },
+        "networkConfiguration": {
+          "description": "<p>The VPC subnet and security group configuration for tasks that receive their own\n            elastic network interface by using the <code>awsvpc</code> networking mode.</p>",
+          "$ref": "#/definitions/NetworkConfiguration"
+        },
+        "rolloutState": {
+          "enum": [
+            "COMPLETED",
+            "FAILED",
+            "IN_PROGRESS"
+          ],
+          "description": "<note>\n            <p>The <code>rolloutState</code> of a service is only returned for services that use\n\t\t\t\tthe rolling update (<code>ECS</code>) deployment type that aren't behind a\n\t\t\t\tClassic Load Balancer.</p>\n         </note>\n         <p>The rollout state of the deployment. When a service deployment is started, it begins\n\t\t\tin an <code>IN_PROGRESS</code> state. When the service reaches a steady state, the\n\t\t\tdeployment transitions to a <code>COMPLETED</code> state. If the service fails to reach\n\t\t\ta steady state and circuit breaker is turned on, the deployment transitions to a\n\t\t\t\t<code>FAILED</code> state. A deployment in <code>FAILED</code> state doesn't launch\n\t\t\tany new tasks. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DeploymentCircuitBreaker.html\">DeploymentCircuitBreaker</a>.</p>",
+          "type": "string"
+        },
+        "rolloutStateReason": {
+          "description": "<p>A description of the rollout state of a deployment.</p>",
+          "type": "string"
+        },
+        "serviceConnectConfiguration": {
+          "description": "<p>The details of the Service Connect configuration that's used by this deployment.\n\t\t\tCompare the configuration between multiple deployments when troubleshooting issues with\n\t\t\tnew deployments.</p>\n         <p>The configuration for this service to discover and connect to\n\tservices, and be discovered by, and connected from, other services within a namespace.</p>\n         <p>Tasks that run in a namespace can use short names to connect\n\tto services in the namespace. Tasks can connect to services across all of the clusters in the namespace.\n\tTasks connect through a managed proxy container\n\tthat collects logs and metrics for increased visibility.\n\tOnly the tasks that Amazon ECS services create are supported with Service Connect.\n\tFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html\">Service Connect</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+          "$ref": "#/definitions/ServiceConnectConfiguration"
+        },
+        "serviceConnectResources": {
+          "description": "<p>The list of Service Connect resources that are associated with this deployment. Each\n\t\t\tlist entry maps a discovery name to a Cloud Map service name.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ServiceConnectServiceResource"
+          }
+        },
+        "volumeConfigurations": {
+          "description": "<p>The details of the volume that was <code>configuredAtLaunch</code>. You can configure\n\t\t\tdifferent settings like the size, throughput, volumeType, and ecryption in <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ServiceManagedEBSVolumeConfiguration.html\">ServiceManagedEBSVolumeConfiguration</a>. The <code>name</code> of the volume\n\t\t\tmust match the <code>name</code> from the task definition.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ServiceVolumeConfiguration"
+          }
+        },
+        "fargateEphemeralStorage": {
+          "description": "<p>The Fargate ephemeral storage settings for the deployment.</p>",
+          "$ref": "#/definitions/DeploymentEphemeralStorage"
+        }
+      }
+    },
+    "ServiceConnectConfiguration": {
+      "description": "<p>The Service Connect configuration of your Amazon ECS service. The configuration for this\n\t\t\tservice to discover and connect to services, and be discovered by, and connected from,\n\t\t\tother services within a namespace.</p>\n         <p>Tasks that run in a namespace can use short names to connect\n\tto services in the namespace. Tasks can connect to services across all of the clusters in the namespace.\n\tTasks connect through a managed proxy container\n\tthat collects logs and metrics for increased visibility.\n\tOnly the tasks that Amazon ECS services create are supported with Service Connect.\n\tFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html\">Service Connect</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "<p>Specifies whether to use Service Connect with this service.</p>",
+          "type": "boolean"
+        },
+        "namespace": {
+          "description": "<p>The namespace name or full Amazon Resource Name (ARN) of the Cloud Map namespace for use with Service Connect. The namespace must be in\n\t\t\tthe same Amazon Web Services Region as the Amazon ECS service and cluster. The type of namespace doesn't\n\t\t\taffect Service Connect. For more information about Cloud Map, see <a href=\"https://docs.aws.amazon.com/cloud-map/latest/dg/working-with-services.html\">Working\n\t\t\t\twith Services</a> in the <i>Cloud Map Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "services": {
+          "description": "<p>The list of Service Connect service objects. These are names and aliases (also known\n\t\t\tas endpoints) that are used by other Amazon ECS services to connect to this service.\n\t\t\t</p>\n         <p>This field is not required for a \"client\" Amazon ECS service that's a member of a namespace\n\t\t\tonly to connect to other services within the namespace. An example of this would be a\n\t\t\tfrontend application that accepts incoming requests from either a load balancer that's\n\t\t\tattached to the service or by other means.</p>\n         <p>An object selects a port from the task definition, assigns a name for the Cloud Map\n\t\t\tservice, and a list of aliases (endpoints) and ports for client applications to refer to\n\t\t\tthis service.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ServiceConnectService"
+          }
+        },
+        "logConfiguration": {
+          "description": "<p>The log configuration for the container. This parameter maps to <code>LogConfig</code>\n\t\t\tin the docker container create command and the\n\t\t\t\t<code>--log-driver</code> option to docker\n\t\t\t\t\trun.</p>\n         <p>By default, containers use the same logging driver that the Docker daemon uses.\n\t\t\tHowever, the container might use a different logging driver than the Docker daemon by\n\t\t\tspecifying a log driver configuration in the container definition.</p>\n         <p>Understand the following when specifying a log configuration for your\n\t\t\tcontainers.</p>\n         <ul>\n            <li>\n               <p>Amazon ECS currently supports a subset of the logging drivers available to the\n\t\t\t\t\tDocker daemon. Additional log drivers may be available in future releases of the\n\t\t\t\t\tAmazon ECS container agent.</p>\n               <p>For tasks on Fargate, the supported log drivers are <code>awslogs</code>,\n\t\t\t\t\t\t<code>splunk</code>, and <code>awsfirelens</code>.</p>\n               <p>For tasks hosted on Amazon EC2 instances, the supported log drivers are\n\t\t\t\t\t\t<code>awslogs</code>, <code>fluentd</code>, <code>gelf</code>,\n\t\t\t\t\t\t<code>json-file</code>, <code>journald</code>,<code>syslog</code>,\n\t\t\t\t\t\t<code>splunk</code>, and <code>awsfirelens</code>.</p>\n            </li>\n            <li>\n               <p>This parameter requires version 1.18 of the Docker Remote API or greater on\n\t\t\t\t\tyour container instance.</p>\n            </li>\n            <li>\n               <p>For tasks that are hosted on Amazon EC2 instances, the Amazon ECS container agent must\n\t\t\t\t\tregister the available logging drivers with the\n\t\t\t\t\t\t<code>ECS_AVAILABLE_LOGGING_DRIVERS</code> environment variable before\n\t\t\t\t\tcontainers placed on that instance can use these log configuration options. For\n\t\t\t\t\tmore information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html\">Amazon ECS container agent configuration</a> in the\n\t\t\t\t\t<i>Amazon Elastic Container Service Developer Guide</i>.</p>\n            </li>\n            <li>\n               <p>For tasks that are on Fargate, because you don't have access to the\n\t\t\t\t\tunderlying infrastructure your tasks are hosted on, any additional software\n\t\t\t\t\tneeded must be installed outside of the task. For example, the Fluentd output\n\t\t\t\t\taggregators or a remote host running Logstash to send Gelf logs to.</p>\n            </li>\n         </ul>",
+          "$ref": "#/definitions/LogConfiguration"
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "ServiceConnectService": {
+      "description": "<p>The Service Connect service object configuration. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html\">Service Connect</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "portName": {
+          "description": "<p>The <code>portName</code> must match the name of one of the <code>portMappings</code>\n\t\t\tfrom all the containers in the task definition of this Amazon ECS service.</p>",
+          "type": "string"
+        },
+        "discoveryName": {
+          "description": "<p>The <code>discoveryName</code> is the name of the new Cloud Map service that Amazon ECS creates\n\t\t\tfor this Amazon ECS service. This must be unique within the Cloud Map namespace. The name can contain up to 64 characters. The name can include lowercase letters,\n\t\t\tnumbers, underscores (_), and hyphens (-). The name can't start with a hyphen.</p>\n         <p>If the <code>discoveryName</code> isn't specified, the port mapping name from the task definition is used in <code>portName.namespace</code>.</p>",
+          "type": "string"
+        },
+        "clientAliases": {
+          "description": "<p>The list of client aliases for this Service Connect service. You use these to assign\n\t\t\tnames that can be used by client applications. The maximum number of client aliases that\n\t\t\tyou can have in this list is 1.</p>\n         <p>Each alias (\"endpoint\") is a fully-qualified name and port number that other Amazon ECS\n\t\t\ttasks (\"clients\") can use to connect to this service.</p>\n         <p>Each name and port mapping must be unique within the namespace.</p>\n         <p>For each <code>ServiceConnectService</code>, you must provide at least one\n\t\t\t\t<code>clientAlias</code> with one <code>port</code>.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ServiceConnectClientAlias"
+          }
+        },
+        "ingressPortOverride": {
+          "description": "<p>The port number for the Service Connect proxy to listen on.</p>\n         <p>Use the value of this field to bypass the proxy for traffic on the port number\n\t\t\tspecified in the named <code>portMapping</code> in the task definition of this\n\t\t\tapplication, and then use it in your VPC security groups to allow traffic into the proxy\n\t\t\tfor this Amazon ECS service.</p>\n         <p>In <code>awsvpc</code> mode and Fargate, the default value is the container port\n\t\t\tnumber. The container port number is in the <code>portMapping</code> in the task\n\t\t\tdefinition. In bridge mode, the default value is the ephemeral port of the\n\t\t\tService Connect proxy.</p>",
+          "type": "number"
+        },
+        "timeout": {
+          "description": "<p>A reference to an object that represents the configured timeouts for\n\t\t\tService Connect.</p>",
+          "$ref": "#/definitions/TimeoutConfiguration"
+        },
+        "tls": {
+          "description": "<p>A reference to an object that represents a Transport Layer Security (TLS)\n\t\t\tconfiguration.</p>",
+          "$ref": "#/definitions/ServiceConnectTlsConfiguration"
+        }
+      },
+      "required": [
+        "portName"
+      ]
+    },
+    "ServiceConnectClientAlias": {
+      "description": "<p>Each alias (\"endpoint\") is a fully-qualified name and port number that other tasks\n\t\t\t(\"clients\") can use to connect to this service.</p>\n         <p>Each name and port mapping must be unique within the namespace.</p>\n         <p>Tasks that run in a namespace can use short names to connect\n\tto services in the namespace. Tasks can connect to services across all of the clusters in the namespace.\n\tTasks connect through a managed proxy container\n\tthat collects logs and metrics for increased visibility.\n\tOnly the tasks that Amazon ECS services create are supported with Service Connect.\n\tFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html\">Service Connect</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "port": {
+          "description": "<p>The listening port number for the Service Connect proxy. This port is available\n\t\t\tinside of all of the tasks within the same namespace.</p>\n         <p>To avoid changing your applications in client Amazon ECS services, set this to the same\n\t\t\tport that the client application uses by default. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html\">Service Connect</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+          "type": "number"
+        },
+        "dnsName": {
+          "description": "<p>The <code>dnsName</code> is the name that you use in the applications of client tasks\n\t\t\tto connect to this service. The name must be a valid DNS name but doesn't need to be\n\t\t\tfully-qualified. The name can include up to 127 characters. The name can include\n\t\t\tlowercase letters, numbers, underscores (_), hyphens (-), and periods (.). The name\n\t\t\tcan't start with a hyphen.</p>\n         <p>If this parameter isn't specified, the default value of <code>discoveryName.namespace</code> is used. If the <code>discoveryName</code> isn't specified, the port mapping name from the task definition is used in <code>portName.namespace</code>.</p>\n         <p>To avoid changing your applications in client Amazon ECS services, set this to the same\n\t\t\tname that the client application uses by default. For example, a few common names are\n\t\t\t\t<code>database</code>, <code>db</code>, or the lowercase name of a database, such as\n\t\t\t\t<code>mysql</code> or <code>redis</code>. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html\">Service Connect</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "port"
+      ]
+    },
+    "TimeoutConfiguration": {
+      "description": "<p>An object that represents the timeout configurations for Service Connect.</p>\n         <note>\n            <p>If <code>idleTimeout</code> is set to a time that is less than\n\t\t\t\t\t<code>perRequestTimeout</code>, the connection will close when the\n\t\t\t\t\t<code>idleTimeout</code> is reached and not the\n\t\t\t\t<code>perRequestTimeout</code>.</p>\n         </note>",
+      "type": "object",
+      "properties": {
+        "idleTimeoutSeconds": {
+          "description": "<p>The amount of time in seconds a connection will stay active while idle. A value of\n\t\t\t\t<code>0</code> can be set to disable <code>idleTimeout</code>.</p>\n         <p>The <code>idleTimeout</code> default for\n\t\t\t\t<code>HTTP</code>/<code>HTTP2</code>/<code>GRPC</code> is 5 minutes.</p>\n         <p>The <code>idleTimeout</code> default for <code>TCP</code> is 1 hour.</p>",
+          "type": "number"
+        },
+        "perRequestTimeoutSeconds": {
+          "description": "<p>The amount of time waiting for the upstream to respond with a complete response per\n\t\t\trequest. A value of <code>0</code> can be set to disable <code>perRequestTimeout</code>.\n\t\t\t\t<code>perRequestTimeout</code> can only be set if Service Connect\n\t\t\t\t<code>appProtocol</code> isn't <code>TCP</code>. Only <code>idleTimeout</code> is\n\t\t\tallowed for <code>TCP</code>\n            <code>appProtocol</code>.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "ServiceConnectTlsConfiguration": {
+      "description": "<p>The key that encrypts and decrypts your resources for Service Connect TLS.</p>",
+      "type": "object",
+      "properties": {
+        "issuerCertificateAuthority": {
+          "description": "<p>The signer certificate authority.</p>",
+          "$ref": "#/definitions/ServiceConnectTlsCertificateAuthority"
+        },
+        "kmsKey": {
+          "description": "<p>The Amazon Web Services Key Management Service key.</p>",
+          "type": "string"
+        },
+        "roleArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the IAM role that's associated with the Service Connect TLS.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "issuerCertificateAuthority"
+      ]
+    },
+    "ServiceConnectTlsCertificateAuthority": {
+      "description": "<p>The certificate root authority that secures your service.</p>",
+      "type": "object",
+      "properties": {
+        "awsPcaAuthorityArn": {
+          "description": "<p>The ARN of the Amazon Web Services Private Certificate Authority certificate.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "LogConfiguration": {
+      "description": "<p>The log configuration for the container. This parameter maps to <code>LogConfig</code>\n\t\t\tin the docker container create command and the\n\t\t\t\t<code>--log-driver</code> option to docker\n\t\t\t\t\trun.</p>\n         <p>By default, containers use the same logging driver that the Docker daemon uses.\n\t\t\tHowever, the container might use a different logging driver than the Docker daemon by\n\t\t\tspecifying a log driver configuration in the container definition.</p>\n         <p>Understand the following when specifying a log configuration for your\n\t\t\tcontainers.</p>\n         <ul>\n            <li>\n               <p>Amazon ECS currently supports a subset of the logging drivers available to the\n\t\t\t\t\tDocker daemon. Additional log drivers may be available in future releases of the\n\t\t\t\t\tAmazon ECS container agent.</p>\n               <p>For tasks on Fargate, the supported log drivers are <code>awslogs</code>,\n\t\t\t\t\t\t<code>splunk</code>, and <code>awsfirelens</code>.</p>\n               <p>For tasks hosted on Amazon EC2 instances, the supported log drivers are\n\t\t\t\t\t\t<code>awslogs</code>, <code>fluentd</code>, <code>gelf</code>,\n\t\t\t\t\t\t<code>json-file</code>, <code>journald</code>,<code>syslog</code>,\n\t\t\t\t\t\t<code>splunk</code>, and <code>awsfirelens</code>.</p>\n            </li>\n            <li>\n               <p>This parameter requires version 1.18 of the Docker Remote API or greater on\n\t\t\t\t\tyour container instance.</p>\n            </li>\n            <li>\n               <p>For tasks that are hosted on Amazon EC2 instances, the Amazon ECS container agent must\n\t\t\t\t\tregister the available logging drivers with the\n\t\t\t\t\t\t<code>ECS_AVAILABLE_LOGGING_DRIVERS</code> environment variable before\n\t\t\t\t\tcontainers placed on that instance can use these log configuration options. For\n\t\t\t\t\tmore information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html\">Amazon ECS container agent configuration</a> in the\n\t\t\t\t\t<i>Amazon Elastic Container Service Developer Guide</i>.</p>\n            </li>\n            <li>\n               <p>For tasks that are on Fargate, because you don't have access to the\n\t\t\t\t\tunderlying infrastructure your tasks are hosted on, any additional software\n\t\t\t\t\tneeded must be installed outside of the task. For example, the Fluentd output\n\t\t\t\t\taggregators or a remote host running Logstash to send Gelf logs to.</p>\n            </li>\n         </ul>",
+      "type": "object",
+      "properties": {
+        "logDriver": {
+          "description": "<p>The log driver to use for the container.</p>\n         <p>For tasks on Fargate, the supported log drivers are <code>awslogs</code>,\n\t\t\t\t<code>splunk</code>, and <code>awsfirelens</code>.</p>\n         <p>For tasks hosted on Amazon EC2 instances, the supported log drivers are\n\t\t\t\t<code>awslogs</code>, <code>fluentd</code>, <code>gelf</code>,\n\t\t\t\t<code>json-file</code>, <code>journald</code>, <code>syslog</code>,\n\t\t\t\t<code>splunk</code>, and <code>awsfirelens</code>.</p>\n         <p>For more information about using the <code>awslogs</code> log driver, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html\">Send\n\t\t\t\tAmazon ECS logs to CloudWatch</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <p>For more information about using the <code>awsfirelens</code> log driver, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html\">Send\n\t\t\t\tAmazon ECS logs to an Amazon Web Services service or Amazon Web Services Partner</a>.</p>\n         <note>\n            <p>If you have a custom driver that isn't listed, you can fork the Amazon ECS container\n\t\t\t\tagent project that's <a href=\"https://github.com/aws/amazon-ecs-agent\">available\n\t\t\t\t\ton GitHub</a> and customize it to work with that driver. We encourage you to\n\t\t\t\tsubmit pull requests for changes that you would like to have included. However, we\n\t\t\t\tdon't currently provide support for running modified copies of this software.</p>\n         </note>",
+          "enum": [
+            "awsfirelens",
+            "awslogs",
+            "fluentd",
+            "gelf",
+            "journald",
+            "json-file",
+            "splunk",
+            "syslog"
+          ],
+          "type": "string"
+        },
+        "options": {
+          "description": "<p>The configuration options to send to the log driver.</p>\n         <p>The options you can specify depend on the log driver. Some\n\t\t\t\tof the options you can specify when you use the <code>awslogs</code> log driver to route logs to\n\t\t\t\tAmazon CloudWatch include the following:</p>\n         <dl>\n            <dt>awslogs-create-group</dt>\n            <dd>\n               <p>Required: No</p>\n               <p>Specify whether you want the log group to be\n\t\t\t\t\t\t\tcreated automatically. If this option isn't\n\t\t\t\t\t\t\tspecified, it defaults to\n\t\t\t\t\t\t\t<code>false</code>.</p>\n               <note>\n                  <p>Your IAM policy must include the\n\t\t\t\t\t\t\t\t<code>logs:CreateLogGroup</code> permission before\n\t\t\t\t\t\t\t\tyou attempt to use\n\t\t\t\t\t\t\t\t<code>awslogs-create-group</code>.</p>\n               </note>\n            </dd>\n            <dt>awslogs-region</dt>\n            <dd>\n               <p>Required: Yes</p>\n               <p>Specify the Amazon Web Services Region that the\n\t\t\t\t\t\t\t<code>awslogs</code> log driver is to send your\n\t\t\t\t\t\t\tDocker logs to. You can choose to send all of your\n\t\t\t\t\t\t\tlogs from clusters in different Regions to a\n\t\t\t\t\t\t\tsingle region in CloudWatch Logs. This is so that they're\n\t\t\t\t\t\t\tall visible in one location. Otherwise, you can\n\t\t\t\t\t\t\tseparate them by Region for more granularity. Make\n\t\t\t\t\t\t\tsure that the specified log group exists in the\n\t\t\t\t\t\t\tRegion that you specify with this option.</p>\n            </dd>\n            <dt>awslogs-group</dt>\n            <dd>\n               <p>Required: Yes</p>\n               <p>Make sure to specify a log group that the\n\t\t\t\t\t\t\t<code>awslogs</code> log driver sends its log\n\t\t\t\t\t\t\tstreams to.</p>\n            </dd>\n            <dt>awslogs-stream-prefix</dt>\n            <dd>\n               <p>Required: Yes, when\n\t\t\t\t\t\t\tusing the Fargate launch\n\t\t\t\t\t\t\ttype.Optional for\n\t\t\t\t\t\t\t\tthe EC2 launch type, required for\n\t\t\t\t\t\t\t\tthe Fargate launch\n\t\t\t\t\t\t\t\ttype.</p>\n               <p>Use the <code>awslogs-stream-prefix</code>\n\t\t\t\t\t\t\toption to associate a log stream with the\n\t\t\t\t\t\t\tspecified prefix, the container name, and the ID\n\t\t\t\t\t\t\tof the Amazon ECS task that the container belongs to.\n\t\t\t\t\t\t\tIf you specify a prefix with this option, then the\n\t\t\t\t\t\t\tlog stream takes the format <code>prefix-name/container-name/ecs-task-id</code>.</p>\n               <p>If you don't specify a prefix\n\t\t\t\t\t\t\twith this option, then the log stream is named\n\t\t\t\t\t\t\tafter the container ID that's assigned by the\n\t\t\t\t\t\t\tDocker daemon on the container instance. Because\n\t\t\t\t\t\t\tit's difficult to trace logs back to the container\n\t\t\t\t\t\t\tthat sent them with just the Docker container ID\n\t\t\t\t\t\t\t(which is only available on the container\n\t\t\t\t\t\t\tinstance), we recommend that you specify a prefix\n\t\t\t\t\t\t\twith this option.</p>\n               <p>For Amazon ECS services, you can use the service\n\t\t\t\t\t\t\tname as the prefix. Doing so, you can trace log\n\t\t\t\t\t\t\tstreams to the service that the container belongs\n\t\t\t\t\t\t\tto, the name of the container that sent them, and\n\t\t\t\t\t\t\tthe ID of the task that the container belongs\n\t\t\t\t\t\t\tto.</p>\n               <p>You must specify a\n\t\t\t\t\t\t\tstream-prefix for your logs to have your logs\n\t\t\t\t\t\t\tappear in the Log pane when using the Amazon ECS\n\t\t\t\t\t\t\tconsole.</p>\n            </dd>\n            <dt>awslogs-datetime-format</dt>\n            <dd>\n               <p>Required: No</p>\n               <p>This option defines a multiline start pattern\n\t\t\t\t\t\t\tin Python <code>strftime</code> format. A log\n\t\t\t\t\t\t\tmessage consists of a line that matches the\n\t\t\t\t\t\t\tpattern and any following lines that don’t match\n\t\t\t\t\t\t\tthe pattern. The matched line is the delimiter\n\t\t\t\t\t\t\tbetween log messages.</p>\n               <p>One example of a use case for using this\n\t\t\t\t\t\t\tformat is for parsing output such as a stack dump,\n\t\t\t\t\t\t\twhich might otherwise be logged in multiple\n\t\t\t\t\t\t\tentries. The correct pattern allows it to be\n\t\t\t\t\t\t\tcaptured in a single entry.</p>\n               <p>For more information, see <a href=\"https://docs.docker.com/config/containers/logging/awslogs/#awslogs-datetime-format\">awslogs-datetime-format</a>.</p>\n               <p>You cannot configure both the\n\t\t\t\t\t\t\t<code>awslogs-datetime-format</code> and\n\t\t\t\t\t\t\t<code>awslogs-multiline-pattern</code>\n\t\t\t\t\t\t\toptions.</p>\n               <note>\n                  <p>Multiline logging performs regular\n\t\t\t\t\t\t\t\texpression parsing and matching of all log\n\t\t\t\t\t\t\t\tmessages. This might have a negative impact on\n\t\t\t\t\t\t\t\tlogging performance.</p>\n               </note>\n            </dd>\n            <dt>awslogs-multiline-pattern</dt>\n            <dd>\n               <p>Required: No</p>\n               <p>This option defines a multiline start pattern\n\t\t\t\t\t\t\tthat uses a regular expression. A log message\n\t\t\t\t\t\t\tconsists of a line that matches the pattern and\n\t\t\t\t\t\t\tany following lines that don’t match the pattern.\n\t\t\t\t\t\t\tThe matched line is the delimiter between log\n\t\t\t\t\t\t\tmessages.</p>\n               <p>For more information, see <a href=\"https://docs.docker.com/config/containers/logging/awslogs/#awslogs-multiline-pattern\">awslogs-multiline-pattern</a>.</p>\n               <p>This option is ignored if\n\t\t\t\t\t\t\t<code>awslogs-datetime-format</code> is also\n\t\t\t\t\t\t\tconfigured.</p>\n               <p>You cannot configure both the\n\t\t\t\t\t\t\t<code>awslogs-datetime-format</code> and\n\t\t\t\t\t\t\t<code>awslogs-multiline-pattern</code>\n\t\t\t\t\t\t\toptions.</p>\n               <note>\n                  <p>Multiline logging performs regular\n\t\t\t\t\t\t\t\texpression parsing and matching of all log\n\t\t\t\t\t\t\t\tmessages. This might have a negative impact on\n\t\t\t\t\t\t\t\tlogging performance.</p>\n               </note>\n            </dd>\n            <dt>mode</dt>\n            <dd>\n               <p>Required: No</p>\n               <p>Valid values: <code>non-blocking</code> |\n\t\t\t\t\t\t\t<code>blocking</code>\n               </p>\n               <p>This option defines the delivery mode of log\n\t\t\t\t\t\t\tmessages from the container to CloudWatch Logs. The delivery\n\t\t\t\t\t\t\tmode you choose affects application availability\n\t\t\t\t\t\t\twhen the flow of logs from container to CloudWatch is\n\t\t\t\t\t\t\tinterrupted.</p>\n               <p>If you use the <code>blocking</code>\n\t\t\t\t\t\t\tmode and the flow of logs to CloudWatch is interrupted,\n\t\t\t\t\t\t\tcalls from container code to write to the\n\t\t\t\t\t\t\t<code>stdout</code> and <code>stderr</code>\n\t\t\t\t\t\t\tstreams will block. The logging thread of the\n\t\t\t\t\t\t\tapplication will block as a result. This may cause\n\t\t\t\t\t\t\tthe application to become unresponsive and lead to\n\t\t\t\t\t\t\tcontainer healthcheck failure. </p>\n               <p>If you use the <code>non-blocking</code> mode,\n\t\t\t\t\t\t\tthe container's logs are instead stored in an\n\t\t\t\t\t\t\tin-memory intermediate buffer configured with the\n\t\t\t\t\t\t\t<code>max-buffer-size</code> option. This prevents\n\t\t\t\t\t\t\tthe application from becoming unresponsive when\n\t\t\t\t\t\t\tlogs cannot be sent to CloudWatch. We recommend using this mode if you want to\n\t\t\t\t\t\t\tensure service availability and are okay with some\n\t\t\t\t\t\t\tlog loss. For more information, see <a href=\"http://aws.amazon.com/blogs/containers/preventing-log-loss-with-non-blocking-mode-in-the-awslogs-container-log-driver/\">Preventing log loss with non-blocking mode in the <code>awslogs</code> container log driver</a>.</p>\n            </dd>\n            <dt>max-buffer-size</dt>\n            <dd>\n               <p>Required: No</p>\n               <p>Default value: <code>1m</code>\n               </p>\n               <p>When <code>non-blocking</code> mode is used,\n\t\t\t\t\t\t\tthe <code>max-buffer-size</code> log option\n\t\t\t\t\t\t\tcontrols the size of the buffer that's used for\n\t\t\t\t\t\t\tintermediate message storage. Make sure to specify\n\t\t\t\t\t\t\tan adequate buffer size based on your application.\n\t\t\t\t\t\t\tWhen the buffer fills up, further logs cannot be\n\t\t\t\t\t\t\tstored. Logs that cannot be stored are lost.\n\t\t\t\t\t\t</p>\n            </dd>\n         </dl>\n         <p>To route logs using the <code>splunk</code> log router, you need to specify a\n\t\t\t\t<code>splunk-token</code> and a\n\t\t\t\t<code>splunk-url</code>.</p>\n         <p>When you use the <code>awsfirelens</code> log router to route logs to an Amazon Web Services Service or\n\t\t\t\tAmazon Web Services Partner Network destination for log storage and analytics, you can\n\t\t\t\tset the <code>log-driver-buffer-limit</code> option to limit\n\t\t\t\tthe number of events that are buffered in memory, before\n\t\t\t\tbeing sent to the log router container. It can help to\n\t\t\t\tresolve potential log loss issue because high throughput\n\t\t\t\tmight result in memory running out for the buffer inside of\n\t\t\t\tDocker.</p>\n         <p>Other options you can specify when using <code>awsfirelens</code> to route\n\t\t\t\tlogs depend on the destination. When you export logs to\n\t\t\t\tAmazon Data Firehose, you can specify the Amazon Web Services Region with\n\t\t\t\t<code>region</code> and a name for the log stream with\n\t\t\t\t<code>delivery_stream</code>.</p>\n         <p>When you export logs to\n\t\t\t\tAmazon Kinesis Data Streams, you can specify an Amazon Web Services Region with\n\t\t\t\t<code>region</code> and a data stream name with\n\t\t\t\t<code>stream</code>.</p>\n         <p> When you export logs to Amazon OpenSearch Service,\n\t\t\t\tyou can specify options like <code>Name</code>,\n\t\t\t\t<code>Host</code> (OpenSearch Service endpoint without protocol), <code>Port</code>,\n\t\t\t\t<code>Index</code>, <code>Type</code>,\n\t\t\t\t<code>Aws_auth</code>, <code>Aws_region</code>, <code>Suppress_Type_Name</code>, and\n\t\t\t\t<code>tls</code>.</p>\n         <p>When you export logs to Amazon S3, you can\n\t\t\t\t\tspecify the bucket using the <code>bucket</code> option. You can also specify <code>region</code>,\n\t\t\t\t\t<code>total_file_size</code>, <code>upload_timeout</code>,\n\t\t\t\t\tand <code>use_put_object</code> as options.</p>\n         <p>This parameter requires version 1.19 of the Docker Remote API or greater on your container instance. To check the Docker Remote API version on your container instance, log in to your container instance and run the following command: <code>sudo docker version --format '\\{\\{.Server.APIVersion\\}\\}'</code>\n         </p>",
+          "$ref": "#/definitions/Record<string,string>"
+        },
+        "secretOptions": {
+          "description": "<p>The secrets to pass to the log configuration. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html\">Specifying\n\t\t\t\tsensitive data</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Secret"
+          }
+        }
+      },
+      "required": [
+        "logDriver"
+      ]
+    },
+    "Secret": {
+      "description": "<p>An object representing the secret to expose to your container. Secrets can be exposed\n\t\t\tto a container in the following ways:</p>\n         <ul>\n            <li>\n               <p>To inject sensitive data into your containers as environment variables, use\n\t\t\t\t\tthe <code>secrets</code> container definition parameter.</p>\n            </li>\n            <li>\n               <p>To reference sensitive information in the log configuration of a container,\n\t\t\t\t\tuse the <code>secretOptions</code> container definition parameter.</p>\n            </li>\n         </ul>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html\">Specifying\n\t\t\t\tsensitive data</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "<p>The name of the secret.</p>",
+          "type": "string"
+        },
+        "valueFrom": {
+          "description": "<p>The secret to expose to the container. The supported values are either the full ARN\n\t\t\tof the Secrets Manager secret or the full ARN of the parameter in the SSM\n\t\t\tParameter Store.</p>\n         <p>For information about the require Identity and Access Management permissions, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html#secrets-iam\">Required IAM permissions for Amazon ECS secrets</a> (for Secrets Manager) or\n\t\t\t\t<a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-parameters.html\">Required IAM permissions for Amazon ECS secrets</a> (for Systems Manager Parameter\n\t\t\tstore) in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <note>\n            <p>If the SSM Parameter Store parameter exists in the same Region as the task\n\t\t\t\tyou're launching, then you can use either the full ARN or name of the parameter.\n\t\t\t\tIf the parameter exists in a different Region, then the full ARN must be\n\t\t\t\tspecified.</p>\n         </note>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "valueFrom"
+      ]
+    },
+    "ServiceConnectServiceResource": {
+      "description": "<p>The Service Connect resource. Each configuration maps a discovery name to a\n\t\t\tCloud Map service name. The data is stored in Cloud Map as part of the\n\t\t\tService Connect configuration for each discovery name of this Amazon ECS service.</p>\n         <p>A task can resolve the <code>dnsName</code> for each of the <code>clientAliases</code>\n\t\t\tof a service. However a task can't resolve the discovery names. If you want to connect\n\t\t\tto a service, refer to the <code>ServiceConnectConfiguration</code> of that service for\n\t\t\tthe list of <code>clientAliases</code> that you can use.</p>",
+      "type": "object",
+      "properties": {
+        "discoveryName": {
+          "description": "<p>The discovery name of this Service Connect resource.</p>\n         <p>The <code>discoveryName</code> is the name of the new Cloud Map service that Amazon ECS creates\n\t\t\tfor this Amazon ECS service. This must be unique within the Cloud Map namespace. The name can contain up to 64 characters. The name can include lowercase letters,\n\t\t\tnumbers, underscores (_), and hyphens (-). The name can't start with a hyphen.</p>\n         <p>If the <code>discoveryName</code> isn't specified, the port mapping name from the task definition is used in <code>portName.namespace</code>.</p>",
+          "type": "string"
+        },
+        "discoveryArn": {
+          "description": "<p>The Amazon Resource Name (ARN) for the namespace in Cloud Map that matches the discovery name for this\n\t\t\tService Connect resource. You can use this ARN in other integrations with Cloud Map.\n\t\t\tHowever, Service Connect can't ensure connectivity outside of Amazon ECS.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ServiceVolumeConfiguration": {
+      "description": "<p>The configuration for a volume specified in the task definition as a volume that is\n\t\t\tconfigured at launch time. Currently, the only supported volume type is an Amazon EBS\n\t\t\tvolume.</p>",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "<p>The name of the volume. This value must match the volume name from the\n\t\t\t\t<code>Volume</code> object in the task definition.</p>",
+          "type": "string"
+        },
+        "managedEBSVolume": {
+          "description": "<p>The configuration for the Amazon EBS volume that Amazon ECS creates and manages on your behalf.\n\t\t\tThese settings are used to create each Amazon EBS volume, with one volume created for each\n\t\t\ttask in the service. The Amazon EBS volumes are visible in your account in the Amazon EC2 console\n\t\t\tonce they are created.</p>",
+          "$ref": "#/definitions/ServiceManagedEBSVolumeConfiguration"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "ServiceManagedEBSVolumeConfiguration": {
+      "description": "<p>The configuration for the Amazon EBS volume that Amazon ECS creates and manages on your behalf. These\n\t\t\tsettings are used to create each Amazon EBS volume, with one volume created for each task in\n\t\t\tthe service. For information about the supported launch types and operating systems, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ebs-volumes.html#ebs-volumes-configuration\">Supported operating systems and launch types</a>\n\t\t\tin the<i> Amazon Elastic Container Service Developer Guide</i>.</p>\n         <p>Many of these parameters map 1:1 with the Amazon EBS <code>CreateVolume</code> API request\n\t\t\tparameters.</p>",
+      "type": "object",
+      "properties": {
+        "encrypted": {
+          "description": "<p>Indicates whether the volume should be encrypted. If no value is specified, encryption\n\t\t\tis turned on by default. This parameter maps 1:1 with the <code>Encrypted</code>\n\t\t\tparameter of the <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVolume.html\">CreateVolume API</a> in\n\t\t\tthe <i>Amazon EC2 API Reference</i>.</p>",
+          "type": "boolean"
+        },
+        "kmsKeyId": {
+          "description": "<p>The Amazon Resource Name (ARN) identifier of the Amazon Web Services Key Management Service key to use for Amazon EBS encryption. When\n\t\t\tencryption is turned on and no Amazon Web Services Key Management Service key is specified, the default Amazon Web Services managed key\n\t\t\tfor Amazon EBS volumes is used. This parameter maps 1:1 with the <code>KmsKeyId</code>\n\t\t\tparameter of the <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVolume.html\">CreateVolume API</a> in\n\t\t\tthe <i>Amazon EC2 API Reference</i>.</p>\n         <important>\n            <p>Amazon Web Services authenticates the Amazon Web Services Key Management Service key asynchronously. Therefore, if you specify an\n\t\t\t\tID, alias, or ARN that is invalid, the action can appear to complete, but\n\t\t\t\teventually fails.</p>\n         </important>",
+          "type": "string"
+        },
+        "volumeType": {
+          "description": "<p>The volume type. This parameter maps 1:1 with the <code>VolumeType</code> parameter of\n\t\t\tthe <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVolume.html\">CreateVolume API</a> in the <i>Amazon EC2 API Reference</i>. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html\">Amazon EBS volume types</a> in\n\t\t\tthe <i>Amazon EC2 User Guide</i>.</p>\n         <p>The following are the supported volume types.</p>\n         <ul>\n            <li>\n               <p>General Purpose SSD: <code>gp2</code>|<code>gp3</code>\n               </p>\n            </li>\n            <li>\n               <p>Provisioned IOPS SSD: <code>io1</code>|<code>io2</code>\n               </p>\n            </li>\n            <li>\n               <p>Throughput Optimized HDD: <code>st1</code>\n               </p>\n            </li>\n            <li>\n               <p>Cold HDD: <code>sc1</code>\n               </p>\n            </li>\n            <li>\n               <p>Magnetic: <code>standard</code>\n               </p>\n               <note>\n                  <p>The magnetic volume type is not supported on Fargate.</p>\n               </note>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "sizeInGiB": {
+          "description": "<p>The size of the volume in GiB. You must specify either a volume size or a snapshot ID.\n\t\t\tIf you specify a snapshot ID, the snapshot size is used for the volume size by default.\n\t\t\tYou can optionally specify a volume size greater than or equal to the snapshot size.\n\t\t\tThis parameter maps 1:1 with the <code>Size</code> parameter of the <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVolume.html\">CreateVolume API</a> in the <i>Amazon EC2 API Reference</i>.</p>\n         <p>The following are the supported volume size values for each volume type.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>gp2</code> and <code>gp3</code>: 1-16,384</p>\n            </li>\n            <li>\n               <p>\n                  <code>io1</code> and <code>io2</code>: 4-16,384</p>\n            </li>\n            <li>\n               <p>\n                  <code>st1</code> and <code>sc1</code>: 125-16,384</p>\n            </li>\n            <li>\n               <p>\n                  <code>standard</code>: 1-1,024</p>\n            </li>\n         </ul>",
+          "type": "number"
+        },
+        "snapshotId": {
+          "description": "<p>The snapshot that Amazon ECS uses to create the volume. You must specify either a snapshot\n\t\t\tID or a volume size. This parameter maps 1:1 with the <code>SnapshotId</code> parameter\n\t\t\tof the <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVolume.html\">CreateVolume API</a> in\n\t\t\tthe <i>Amazon EC2 API Reference</i>.</p>",
+          "type": "string"
+        },
+        "iops": {
+          "description": "<p>The number of I/O operations per second (IOPS). For <code>gp3</code>,\n\t\t\t<code>io1</code>, and <code>io2</code> volumes, this represents the number of IOPS that\n\t\t\tare provisioned for the volume. For <code>gp2</code> volumes, this represents the\n\t\t\tbaseline performance of the volume and the rate at which the volume accumulates I/O\n\t\t\tcredits for bursting.</p>\n         <p>The following are the supported values for each volume type.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>gp3</code>: 3,000 - 16,000 IOPS</p>\n            </li>\n            <li>\n               <p>\n                  <code>io1</code>: 100 - 64,000 IOPS</p>\n            </li>\n            <li>\n               <p>\n                  <code>io2</code>: 100 - 256,000 IOPS</p>\n            </li>\n         </ul>\n         <p>This parameter is required for <code>io1</code> and <code>io2</code> volume types. The\n\t\t\tdefault for <code>gp3</code> volumes is <code>3,000 IOPS</code>. This parameter is not\n\t\t\tsupported for <code>st1</code>, <code>sc1</code>, or <code>standard</code> volume\n\t\t\ttypes.</p>\n         <p>This parameter maps 1:1 with the <code>Iops</code> parameter of the <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVolume.html\">CreateVolume API</a> in the <i>Amazon EC2 API Reference</i>.</p>",
+          "type": "number"
+        },
+        "throughput": {
+          "description": "<p>The throughput to provision for a volume, in MiB/s, with a maximum of 1,000 MiB/s.\n\t\t\tThis parameter maps 1:1 with the <code>Throughput</code> parameter of the <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVolume.html\">CreateVolume API</a> in the <i>Amazon EC2 API Reference</i>.</p>\n         <important>\n            <p>This parameter is only supported for the <code>gp3</code> volume type.</p>\n         </important>",
+          "type": "number"
+        },
+        "tagSpecifications": {
+          "description": "<p>The tags to apply to the volume. Amazon ECS applies service-managed tags by default. This\n\t\t\tparameter maps 1:1 with the <code>TagSpecifications.N</code> parameter of the <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVolume.html\">CreateVolume API</a> in the <i>Amazon EC2 API Reference</i>.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EBSTagSpecification"
+          }
+        },
+        "roleArn": {
+          "description": "<p>The ARN of the IAM role to associate with this volume. This is the Amazon ECS\n\t\t\tinfrastructure IAM role that is used to manage your Amazon Web Services infrastructure. We recommend\n\t\t\tusing the Amazon ECS-managed <code>AmazonECSInfrastructureRolePolicyForVolumes</code> IAM\n\t\t\tpolicy with this role. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/infrastructure_IAM_role.html\">Amazon ECS\n\t\t\t\tinfrastructure IAM role</a> in the <i>Amazon ECS Developer\n\t\t\tGuide</i>.</p>",
+          "type": "string"
+        },
+        "filesystemType": {
+          "enum": [
+            "ext3",
+            "ext4",
+            "ntfs",
+            "xfs"
+          ],
+          "description": "<p>The filesystem type for the volume. For volumes created from a snapshot, you must specify\n\t\t\tthe same filesystem type that the volume was using when the snapshot was created. If\n\t\t\tthere is a filesystem type mismatch, the task will fail to start.</p>\n         <p>The available Linux filesystem types are\n<code>ext3</code>, <code>ext4</code>, and\n\t\t\t\t<code>xfs</code>. If no value is specified, the <code>xfs</code> filesystem type is\n\t\t\tused by default.</p>\n         <p>The available Windows filesystem types are <code>NTFS</code>.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "roleArn"
+      ]
+    },
+    "EBSTagSpecification": {
+      "description": "<p>The tag specifications of an Amazon EBS volume.</p>",
+      "type": "object",
+      "properties": {
+        "resourceType": {
+          "description": "<p>The type of volume resource.</p>",
+          "const": "volume",
+          "type": "string"
+        },
+        "tags": {
+          "description": "<p>The tags applied to this Amazon EBS volume. <code>AmazonECSCreated</code> and\n\t\t\t\t<code>AmazonECSManaged</code> are reserved tags that can't be used.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag_2"
+          }
+        },
+        "propagateTags": {
+          "enum": [
+            "NONE",
+            "SERVICE",
+            "TASK_DEFINITION"
+          ],
+          "description": "<p>Determines whether to propagate the tags from the task definition to\nthe Amazon EBS\n\t\t\tvolume. Tags can only propagate to a <code>SERVICE</code> specified in\n\n<code>ServiceVolumeConfiguration</code>. If no value is specified, the tags aren't\n\npropagated.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "resourceType"
+      ]
+    },
+    "ServiceEvent": {
+      "description": "<p>The details for an event that's associated with a service.</p>",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "<p>The ID string for the event.</p>",
+          "type": "string"
+        },
+        "createdAt": {
+          "description": "<p>The Unix timestamp for the time when the event was triggered.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "message": {
+          "description": "<p>The event message.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "PlacementConstraint": {
+      "description": "<p>An object representing a constraint on task placement. For more information, see\n\t\t\t\t<a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html\">Task placement constraints</a> in the\n\t\t\t<i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <note>\n            <p>If you're using the Fargate launch type, task placement constraints\n\t\t\t\taren't supported.</p>\n         </note>",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "distinctInstance",
+            "memberOf"
+          ],
+          "description": "<p>The type of constraint. Use <code>distinctInstance</code> to ensure that each task in\n\t\t\ta particular group is running on a different container instance. Use\n\t\t\t\t<code>memberOf</code> to restrict the selection to a group of valid\n\t\t\tcandidates.</p>",
+          "type": "string"
+        },
+        "expression": {
+          "description": "<p>A cluster query language expression to apply to the constraint. The expression can\n\t\t\thave a maximum length of 2000 characters. You can't specify an expression if the\n\t\t\tconstraint type is <code>distinctInstance</code>. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html\">Cluster query language</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "PlacementStrategy": {
+      "description": "<p>The task placement strategy for a task or service. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html\">Task placement strategies</a> in the\n\t\t\t<i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "binpack",
+            "random",
+            "spread"
+          ],
+          "description": "<p>The type of placement strategy. The <code>random</code> placement strategy randomly\n\t\t\tplaces tasks on available candidates. The <code>spread</code> placement strategy spreads\n\t\t\tplacement across available candidates evenly based on the <code>field</code> parameter.\n\t\t\tThe <code>binpack</code> strategy places tasks on available candidates that have the\n\t\t\tleast available amount of the resource that's specified with the <code>field</code>\n\t\t\tparameter. For example, if you binpack on memory, a task is placed on the instance with\n\t\t\tthe least amount of remaining memory but still enough to run the task.</p>",
+          "type": "string"
+        },
+        "field": {
+          "description": "<p>The field to apply the placement strategy against. For the <code>spread</code>\n\t\t\tplacement strategy, valid values are <code>instanceId</code> (or <code>host</code>,\n\t\t\twhich has the same effect), or any platform or custom attribute that's applied to a\n\t\t\tcontainer instance, such as <code>attribute:ecs.availability-zone</code>. For the\n\t\t\t\t<code>binpack</code> placement strategy, valid values are <code>cpu</code> and\n\t\t\t\t<code>memory</code>. For the <code>random</code> placement strategy, this field is\n\t\t\tnot used.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "DeploymentController": {
+      "description": "<p>The deployment controller to use for the service. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-types.html\">Amazon ECS deployment types</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "<p>The deployment controller type to use.</p>\n         <p>There are three deployment controller types available:</p>\n         <dl>\n            <dt>ECS</dt>\n            <dd>\n               <p>The rolling update (<code>ECS</code>) deployment type involves replacing\n\t\t\t\t\t\tthe current running version of the container with the latest version. The\n\t\t\t\t\t\tnumber of containers Amazon ECS adds or removes from the service during a rolling\n\t\t\t\t\t\tupdate is controlled by adjusting the minimum and maximum number of healthy\n\t\t\t\t\t\ttasks allowed during a service deployment, as specified in the <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DeploymentConfiguration.html\">DeploymentConfiguration</a>.</p>\n            </dd>\n            <dt>CODE_DEPLOY</dt>\n            <dd>\n               <p>The blue/green (<code>CODE_DEPLOY</code>) deployment type uses the\n\t\t\t\t\t\tblue/green deployment model powered by CodeDeploy, which allows you to verify a\n\t\t\t\t\t\tnew deployment of a service before sending production traffic to it.</p>\n            </dd>\n            <dt>EXTERNAL</dt>\n            <dd>\n               <p>The external (<code>EXTERNAL</code>) deployment type enables you to use\n\t\t\t\t\t\tany third-party deployment controller for full control over the deployment\n\t\t\t\t\t\tprocess for an Amazon ECS service.</p>\n            </dd>\n         </dl>",
+          "enum": [
+            "CODE_DEPLOY",
+            "ECS",
+            "EXTERNAL"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "Task": {
+      "description": "<p>Details on a task in a cluster.</p>",
+      "type": "object",
+      "properties": {
+        "attachments": {
+          "description": "<p>The Elastic Network Adapter that's associated with the task if the task uses the\n\t\t\t\t<code>awsvpc</code> network mode.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Attachment"
+          }
+        },
+        "attributes": {
+          "description": "<p>The attributes of the task</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "availabilityZone": {
+          "description": "<p>The Availability Zone for the task.</p>",
+          "type": "string"
+        },
+        "capacityProviderName": {
+          "description": "<p>The capacity provider that's associated with the task.</p>",
+          "type": "string"
+        },
+        "clusterArn": {
+          "description": "<p>The ARN of the cluster that hosts the task.</p>",
+          "type": "string"
+        },
+        "connectivity": {
+          "enum": [
+            "CONNECTED",
+            "DISCONNECTED"
+          ],
+          "description": "<p>The connectivity status of a task.</p>",
+          "type": "string"
+        },
+        "connectivityAt": {
+          "description": "<p>The Unix timestamp for the time when the task last went into <code>CONNECTED</code>\n\t\t\tstatus.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "containerInstanceArn": {
+          "description": "<p>The ARN of the container instances that host the task.</p>",
+          "type": "string"
+        },
+        "containers": {
+          "description": "<p>The containers that's associated with the task.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Container"
+          }
+        },
+        "cpu": {
+          "description": "<p>The number of CPU units used by the task as expressed in a task definition. It can be\n\t\t\texpressed as an integer using CPU units (for example, <code>1024</code>). It can also be\n\t\t\texpressed as a string using vCPUs (for example, <code>1 vCPU</code> or <code>1\n\t\t\t\tvcpu</code>). String values are converted to an integer that indicates the CPU units\n\t\t\twhen the task definition is registered.</p>\n         <p>If you use the EC2 launch type, this field is optional. Supported values\n\t\t\tare between <code>128</code> CPU units (<code>0.125</code> vCPUs) and <code>10240</code>\n\t\t\tCPU units (<code>10</code> vCPUs).</p>\n         <p>If you use the Fargate launch type, this field is required. You must use\n\t\t\tone of the following values. These values determine the range of supported values for\n\t\t\tthe <code>memory</code> parameter:</p>\n         <p>The CPU units cannot be less than 1 vCPU when you use Windows containers on\n\t\t\tFargate.</p>\n         <ul>\n            <li>\n               <p>256 (.25 vCPU) - Available <code>memory</code> values: 512 (0.5 GB), 1024 (1 GB), 2048 (2 GB)</p>\n            </li>\n            <li>\n               <p>512 (.5 vCPU) - Available <code>memory</code> values: 1024 (1 GB), 2048 (2 GB), 3072 (3 GB), 4096 (4 GB)</p>\n            </li>\n            <li>\n               <p>1024 (1 vCPU) - Available <code>memory</code> values: 2048 (2 GB), 3072 (3 GB), 4096 (4 GB), 5120 (5 GB), 6144 (6 GB), 7168 (7 GB), 8192 (8 GB)</p>\n            </li>\n            <li>\n               <p>2048 (2 vCPU) - Available <code>memory</code> values: 4096 (4 GB) and 16384 (16 GB) in increments of 1024 (1 GB)</p>\n            </li>\n            <li>\n               <p>4096 (4 vCPU) - Available <code>memory</code> values: 8192 (8 GB) and 30720 (30 GB) in increments of 1024 (1 GB)</p>\n            </li>\n            <li>\n               <p>8192 (8 vCPU)  - Available <code>memory</code> values: 16 GB and 60 GB in 4 GB increments</p>\n               <p>This option requires Linux platform <code>1.4.0</code> or\n                                        later.</p>\n            </li>\n            <li>\n               <p>16384 (16vCPU)  - Available <code>memory</code> values: 32GB and 120 GB in 8 GB increments</p>\n               <p>This option requires Linux platform <code>1.4.0</code> or\n                                        later.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "createdAt": {
+          "description": "<p>The Unix timestamp for the time when the task was created. More specifically, it's for\n\t\t\tthe time when the task entered the <code>PENDING</code> state.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "desiredStatus": {
+          "description": "<p>The desired status of the task. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-lifecycle.html\">Task\n\t\t\tLifecycle</a>.</p>",
+          "type": "string"
+        },
+        "enableExecuteCommand": {
+          "description": "<p>Determines whether execute command functionality is turned on for this task. If\n\t\t\t\t<code>true</code>, execute command functionality is turned on all the containers in\n\t\t\tthe task.</p>",
+          "type": "boolean"
+        },
+        "executionStoppedAt": {
+          "description": "<p>The Unix timestamp for the time when the task execution stopped.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "group": {
+          "description": "<p>The name of the task group that's associated with the task.</p>",
+          "type": "string"
+        },
+        "healthStatus": {
+          "enum": [
+            "HEALTHY",
+            "UNHEALTHY",
+            "UNKNOWN"
+          ],
+          "description": "<p>The health status for the task. It's determined by the health of the essential\n\t\t\tcontainers in the task. If all essential containers in the task are reporting as\n\t\t\t\t<code>HEALTHY</code>, the task status also reports as <code>HEALTHY</code>. If any\n\t\t\tessential containers in the task are reporting as <code>UNHEALTHY</code> or\n\t\t\t\t<code>UNKNOWN</code>, the task status also reports as <code>UNHEALTHY</code> or\n\t\t\t\t<code>UNKNOWN</code>.</p>\n         <note>\n            <p>The Amazon ECS container agent doesn't monitor or report on Docker health checks that\n\t\t\t\tare embedded in a container image and not specified in the container definition. For\n\t\t\t\texample, this includes those specified in a parent image or from the image's\n\t\t\t\tDockerfile. Health check parameters that are specified in a container definition\n\t\t\t\toverride any Docker health checks that are found in the container image.</p>\n         </note>",
+          "type": "string"
+        },
+        "inferenceAccelerators": {
+          "description": "<p>The Elastic Inference accelerator that's associated with the task.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InferenceAccelerator"
+          }
+        },
+        "lastStatus": {
+          "description": "<p>The last known status for the task. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-lifecycle.html\">Task\n\t\t\t\tLifecycle</a>.</p>",
+          "type": "string"
+        },
+        "launchType": {
+          "enum": [
+            "EC2",
+            "EXTERNAL",
+            "FARGATE"
+          ],
+          "description": "<p>The infrastructure where your task runs on. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html\">Amazon ECS\n\t\t\t\tlaunch types</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "memory": {
+          "description": "<p>The amount of memory (in MiB) that the task uses as expressed in a task definition. It\n\t\t\tcan be expressed as an integer using MiB (for example, <code>1024</code>). If it's\n\t\t\texpressed as a string using GB (for example, <code>1GB</code> or <code>1 GB</code>),\n\t\t\tit's converted to an integer indicating the MiB when the task definition is\n\t\t\tregistered.</p>\n         <p>If you use the EC2 launch type, this field is optional.</p>\n         <p>If you use the Fargate launch type, this field is required. You must use\n\t\t\tone of the following values. The value that you choose determines the range of supported\n\t\t\tvalues for the <code>cpu</code> parameter.</p>\n         <ul>\n            <li>\n               <p>512 (0.5 GB), 1024 (1 GB), 2048 (2 GB) - Available <code>cpu</code> values: 256 (.25 vCPU)</p>\n            </li>\n            <li>\n               <p>1024 (1 GB), 2048 (2 GB), 3072 (3 GB), 4096 (4 GB) - Available <code>cpu</code> values: 512 (.5 vCPU)</p>\n            </li>\n            <li>\n               <p>2048 (2 GB), 3072 (3 GB), 4096 (4 GB), 5120 (5 GB), 6144 (6 GB), 7168 (7 GB), 8192 (8 GB) - Available <code>cpu</code> values: 1024 (1 vCPU)</p>\n            </li>\n            <li>\n               <p>Between 4096 (4 GB) and 16384 (16 GB) in increments of 1024 (1 GB) - Available <code>cpu</code> values: 2048 (2 vCPU)</p>\n            </li>\n            <li>\n               <p>Between 8192 (8 GB) and 30720 (30 GB) in increments of 1024 (1 GB) - Available <code>cpu</code> values: 4096 (4 vCPU)</p>\n            </li>\n            <li>\n               <p>Between 16 GB and 60 GB in 4 GB increments - Available <code>cpu</code> values: 8192 (8 vCPU)</p>\n               <p>This option requires Linux platform <code>1.4.0</code> or\n                                        later.</p>\n            </li>\n            <li>\n               <p>Between 32GB and 120 GB in 8 GB increments - Available <code>cpu</code> values: 16384 (16 vCPU)</p>\n               <p>This option requires Linux platform <code>1.4.0</code> or\n                                        later.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "overrides": {
+          "description": "<p>One or more container overrides.</p>",
+          "$ref": "#/definitions/TaskOverride"
+        },
+        "platformVersion": {
+          "description": "<p>The platform version where your task runs on. A platform version is only specified for\n\t\t\ttasks that use the Fargate launch type. If you didn't specify one, the\n\t\t\t\t<code>LATEST</code> platform version is used. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html\">Fargate Platform Versions</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "platformFamily": {
+          "description": "<p>The operating system that your tasks are running on. A platform family is specified\n\t\t\tonly for tasks that use the Fargate launch type. </p>\n         <p> All tasks that run as part of this service must use the same\n\t\t\t\t<code>platformFamily</code> value as the service (for example,\n\t\t\t<code>LINUX.</code>).</p>",
+          "type": "string"
+        },
+        "pullStartedAt": {
+          "description": "<p>The Unix timestamp for the time when the container image pull began.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "pullStoppedAt": {
+          "description": "<p>The Unix timestamp for the time when the container image pull completed.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "startedAt": {
+          "description": "<p>The Unix timestamp for the time when the task started. More specifically, it's for the\n\t\t\ttime when the task transitioned from the <code>PENDING</code> state to the\n\t\t\t\t<code>RUNNING</code> state.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "startedBy": {
+          "description": "<p>The tag specified when a task is started. If an Amazon ECS service started the task, the\n\t\t\t\t<code>startedBy</code> parameter contains the deployment ID of that service.</p>",
+          "type": "string"
+        },
+        "stopCode": {
+          "enum": [
+            "EssentialContainerExited",
+            "ServiceSchedulerInitiated",
+            "SpotInterruption",
+            "TaskFailedToStart",
+            "TerminationNotice",
+            "UserInitiated"
+          ],
+          "description": "<p>The stop code indicating why a task was stopped. The <code>stoppedReason</code> might\n\t\t\tcontain additional details. </p>\n         <p>For more information about stop code, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/stopped-task-error-codes.html\">Stopped tasks\n\t\t\t\terror codes</a> in the <i>Amazon ECS Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "stoppedAt": {
+          "description": "<p>The Unix timestamp for the time when the task was stopped. More specifically, it's for\n\t\t\tthe time when the task transitioned from the <code>RUNNING</code> state to the\n\t\t\t\t<code>STOPPED</code> state.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "stoppedReason": {
+          "description": "<p>The reason that the task was stopped.</p>",
+          "type": "string"
+        },
+        "stoppingAt": {
+          "description": "<p>The Unix timestamp for the time when the task stops. More specifically, it's for the\n\t\t\ttime when the task transitions from the <code>RUNNING</code> state to\n\t\t\t\t<code>STOPPING</code>.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "tags": {
+          "description": "<p>The metadata that you apply to the task to help you categorize and organize the task.\n\t\t\tEach tag consists of a key and an optional value. You define both the key and\n\t\t\tvalue.</p>\n         <p>The following basic restrictions apply to tags:</p>\n         <ul>\n            <li>\n               <p>Maximum number of tags per resource - 50</p>\n            </li>\n            <li>\n               <p>For each resource, each tag key must be unique, and each tag key can have only\n                    one value.</p>\n            </li>\n            <li>\n               <p>Maximum key length - 128 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>Maximum value length - 256 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>If your tagging schema is used across multiple services and resources,\n                    remember that other services may have restrictions on allowed characters.\n                    Generally allowed characters are: letters, numbers, and spaces representable in\n                    UTF-8, and the following characters: + - = . _ : /",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag_2"
+          }
+        },
+        "taskArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the task.</p>",
+          "type": "string"
+        },
+        "taskDefinitionArn": {
+          "description": "<p>The ARN of the task definition that creates the task.</p>",
+          "type": "string"
+        },
+        "version": {
+          "description": "<p>The version counter for the task. Every time a task experiences a change that starts a\n\t\t\tCloudWatch event, the version counter is incremented. If you replicate your Amazon ECS task state\n\t\t\twith CloudWatch Events, you can compare the version of a task reported by the Amazon ECS API\n\t\t\tactions with the version reported in CloudWatch Events for the task (inside the\n\t\t\t\t<code>detail</code> object) to verify that the version in your event stream is\n\t\t\tcurrent.</p>",
+          "type": "number"
+        },
+        "ephemeralStorage": {
+          "description": "<p>The ephemeral storage settings for the task.</p>",
+          "$ref": "#/definitions/EphemeralStorage_1"
+        },
+        "fargateEphemeralStorage": {
+          "description": "<p>The Fargate ephemeral storage settings for the task.</p>",
+          "$ref": "#/definitions/TaskEphemeralStorage"
+        }
+      }
+    },
+    "Attribute": {
+      "description": "<p>An attribute is a name-value pair that's associated with an Amazon ECS object. Use\n\t\t\tattributes to extend the Amazon ECS data model by adding custom metadata to your resources.\n\t\t\tFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html#attributes\">Attributes</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "<p>The name of the attribute. The <code>name</code> must contain between 1 and 128\n\t\t\tcharacters. The name may contain letters (uppercase and lowercase), numbers, hyphens\n\t\t\t(-), underscores (_), forward slashes (/), back slashes (\\), or periods (.).</p>",
+          "type": "string"
+        },
+        "value": {
+          "description": "<p>The value of the attribute. The <code>value</code> must contain between 1 and 128\n\t\t\tcharacters. It can contain letters (uppercase and lowercase), numbers, hyphens (-),\n\t\t\tunderscores (_), periods (.), at signs (@), forward slashes (/), back slashes (\\),\n\t\t\tcolons (:), or spaces. The value can't start or end with a space.</p>",
+          "type": "string"
+        },
+        "targetType": {
+          "enum": "",
+          "description": "<p>The type of the target to attach the attribute with. This parameter is required if you\n\t\t\tuse the short form ID for a resource instead of the full ARN.</p>",
+          "const": "container-instance",
+          "type": "string"
+        },
+        "targetId": {
+          "description": "<p>The ID of the target. You can specify the short form ID for a resource or the full\n\t\t\tAmazon Resource Name (ARN).</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "Container": {
+      "description": "<p>A Docker container that's part of a task.</p>",
+      "type": "object",
+      "properties": {
+        "containerArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the container.</p>",
+          "type": "string"
+        },
+        "taskArn": {
+          "description": "<p>The ARN of the task.</p>",
+          "type": "string"
+        },
+        "name": {
+          "description": "<p>The name of the container.</p>",
+          "type": "string"
+        },
+        "image": {
+          "description": "<p>The image used for the container.</p>",
+          "type": "string"
+        },
+        "imageDigest": {
+          "description": "<p>The container image manifest digest.</p>",
+          "type": "string"
+        },
+        "runtimeId": {
+          "description": "<p>The ID of the Docker container.</p>",
+          "type": "string"
+        },
+        "lastStatus": {
+          "description": "<p>The last known status of the container.</p>",
+          "type": "string"
+        },
+        "exitCode": {
+          "description": "<p>The exit code returned from the container.</p>",
+          "type": "number"
+        },
+        "reason": {
+          "description": "<p>A short (255 max characters) human-readable string to provide additional details about\n\t\t\ta running or stopped container.</p>",
+          "type": "string"
+        },
+        "networkBindings": {
+          "description": "<p>The network bindings associated with the container.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkBinding"
+          }
+        },
+        "networkInterfaces": {
+          "description": "<p>The network interfaces associated with the container.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkInterface_1"
+          }
+        },
+        "healthStatus": {
+          "enum": [
+            "HEALTHY",
+            "UNHEALTHY",
+            "UNKNOWN"
+          ],
+          "description": "<p>The health status of the container. If health checks aren't configured for this\n\t\t\tcontainer in its task definition, then it reports the health status as\n\t\t\t\t<code>UNKNOWN</code>.</p>",
+          "type": "string"
+        },
+        "managedAgents": {
+          "description": "<p>The details of any Amazon ECS managed agents associated with the container.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ManagedAgent"
+          }
+        },
+        "cpu": {
+          "description": "<p>The number of CPU units set for the container. The value is <code>0</code> if no value\n\t\t\twas specified in the container definition when the task definition was\n\t\t\tregistered.</p>",
+          "type": "string"
+        },
+        "memory": {
+          "description": "<p>The hard limit (in MiB) of memory set for the container.</p>",
+          "type": "string"
+        },
+        "memoryReservation": {
+          "description": "<p>The soft limit (in MiB) of memory set for the container.</p>",
+          "type": "string"
+        },
+        "gpuIds": {
+          "description": "<p>The IDs of each GPU assigned to the container.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NetworkBinding": {
+      "description": "<p>Details on the network bindings between a container and its host container instance.\n\t\t\tAfter a task reaches the <code>RUNNING</code> status, manual and automatic host and\n\t\t\tcontainer port assignments are visible in the <code>networkBindings</code> section of\n\t\t\t<a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTasks.html\">DescribeTasks</a> API responses.</p>",
+      "type": "object",
+      "properties": {
+        "bindIP": {
+          "description": "<p>The IP address that the container is bound to on the container instance.</p>",
+          "type": "string"
+        },
+        "containerPort": {
+          "description": "<p>The port number on the container that's used with the network binding.</p>",
+          "type": "number"
+        },
+        "hostPort": {
+          "description": "<p>The port number on the host that's used with the network binding.</p>",
+          "type": "number"
+        },
+        "protocol": {
+          "enum": [
+            "tcp",
+            "udp"
+          ],
+          "description": "<p>The protocol used for the network binding.</p>",
+          "type": "string"
+        },
+        "containerPortRange": {
+          "description": "<p>The port number range on the container that's bound to the dynamically mapped host\n\t\t\tport range.</p>\n         <p>The following rules apply when you specify a <code>containerPortRange</code>:</p>\n         <ul>\n            <li>\n               <p>You must use either the <code>bridge</code> network mode or the <code>awsvpc</code>\n\t\t\t\t\tnetwork mode.</p>\n            </li>\n            <li>\n               <p>This parameter is available for both the EC2 and Fargate launch types.</p>\n            </li>\n            <li>\n               <p>This parameter is available for both the Linux and Windows operating systems.</p>\n            </li>\n            <li>\n               <p>The container instance must have at least version 1.67.0 of the container agent\n\t\t\t\t\tand at least version 1.67.0-1 of the <code>ecs-init</code> package </p>\n            </li>\n            <li>\n               <p>You can specify a maximum of 100 port ranges per container.</p>\n            </li>\n            <li>\n               <p>You do not specify a <code>hostPortRange</code>. The value of the <code>hostPortRange</code> is set\n\t\t\t\t\tas follows:</p>\n               <ul>\n                  <li>\n                     <p>For containers in a task with the <code>awsvpc</code> network mode,\n\t\t\t\t\t\t\tthe <code>hostPortRange</code> is set to the same value as the\n\t\t\t\t\t\t\t\t<code>containerPortRange</code>. This is a static mapping\n\t\t\t\t\t\t\tstrategy.</p>\n                  </li>\n                  <li>\n                     <p>For containers in a task with the <code>bridge</code> network mode, the Amazon ECS agent finds open host ports from the default ephemeral range and passes it to docker to bind them to the container ports.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>The <code>containerPortRange</code> valid values are between 1 and\n\t\t\t\t\t65535.</p>\n            </li>\n            <li>\n               <p>A port can only be included in one port mapping per container.</p>\n            </li>\n            <li>\n               <p>You cannot specify overlapping port ranges.</p>\n            </li>\n            <li>\n               <p>The first port in the range must be less than last port in the range.</p>\n            </li>\n            <li>\n               <p>Docker recommends that you turn off the docker-proxy in the Docker daemon config file when you have a large number of ports.</p>\n               <p>For more information, see <a href=\"https://github.com/moby/moby/issues/11185\"> Issue #11185</a> on the Github website.</p>\n               <p>For information about how to  turn off the docker-proxy in the Docker daemon config file, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bootstrap_container_instance.html#bootstrap_docker_daemon\">Docker daemon</a> in the <i>Amazon ECS Developer Guide</i>.</p>\n            </li>\n         </ul>\n         <p>You can call <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTasks.html\">\n               <code>DescribeTasks</code>\n            </a> to view the <code>hostPortRange</code> which\n\t\t\tare the host ports that are bound to the container ports.</p>",
+          "type": "string"
+        },
+        "hostPortRange": {
+          "description": "<p>The port number range on the host that's used with the network binding. This is\n\t\t\tassigned is assigned by Docker and delivered by the Amazon ECS agent.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "NetworkInterface_1": {
+      "description": "<p>An object representing the elastic network interface for tasks that use the\n\t\t\t\t<code>awsvpc</code> network mode.</p>",
+      "type": "object",
+      "properties": {
+        "attachmentId": {
+          "description": "<p>The attachment ID for the network interface.</p>",
+          "type": "string"
+        },
+        "privateIpv4Address": {
+          "description": "<p>The private IPv4 address for the network interface.</p>",
+          "type": "string"
+        },
+        "ipv6Address": {
+          "description": "<p>The private IPv6 address for the network interface.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ManagedAgent": {
+      "description": "<p>Details about the managed agent status for the container.</p>",
+      "type": "object",
+      "properties": {
+        "lastStartedAt": {
+          "description": "<p>The Unix timestamp for the time when the managed agent was last started.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "enum": "",
+          "description": "<p>The name of the managed agent. When the execute command feature is turned on, the\n\t\t\tmanaged agent name is <code>ExecuteCommandAgent</code>.</p>",
+          "const": "ExecuteCommandAgent",
+          "type": "string"
+        },
+        "reason": {
+          "description": "<p>The reason for why the managed agent is in the state it is in.</p>",
+          "type": "string"
+        },
+        "lastStatus": {
+          "description": "<p>The last known status of the managed agent.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "InferenceAccelerator": {
+      "description": "<p>Details on an Elastic Inference accelerator. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html\">Working with Amazon Elastic Inference on Amazon ECS</a> in the\n\t\t\t<i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "deviceName": {
+          "description": "<p>The Elastic Inference accelerator device name. The <code>deviceName</code> must also\n\t\t\tbe referenced in a container definition as a <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ResourceRequirement.html\">ResourceRequirement</a>.</p>",
+          "type": "string"
+        },
+        "deviceType": {
+          "description": "<p>The Elastic Inference accelerator type to use.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "deviceName",
+        "deviceType"
+      ]
+    },
+    "TaskOverride": {
+      "description": "<p>The overrides that are associated with a task.</p>",
+      "type": "object",
+      "properties": {
+        "containerOverrides": {
+          "description": "<p>One or more container overrides that are sent to a task.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContainerOverride"
+          }
+        },
+        "cpu": {
+          "description": "<p>The CPU override for the task.</p>",
+          "type": "string"
+        },
+        "inferenceAcceleratorOverrides": {
+          "description": "<p>The Elastic Inference accelerator override for the task.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InferenceAcceleratorOverride"
+          }
+        },
+        "executionRoleArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the task execution role override for the task. For more information,\n\t\t\tsee <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html\">Amazon ECS task\n\t\t\t\texecution IAM role</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "memory": {
+          "description": "<p>The memory override for the task.</p>",
+          "type": "string"
+        },
+        "taskRoleArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the role that containers in this task can assume. All containers in\n\t\t\tthis task are granted the permissions that are specified in this role. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html\">IAM Role for Tasks</a>\n\t\t\tin the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "ephemeralStorage": {
+          "description": "<p>The ephemeral storage setting override for the task.</p>\n         <note>\n            <p>This parameter is only supported for tasks hosted on Fargate that\n\t\t\t\tuse the following platform versions:</p>\n            <ul>\n               <li>\n                  <p>Linux platform version <code>1.4.0</code> or later.</p>\n               </li>\n               <li>\n                  <p>Windows platform version <code>1.0.0</code> or later.</p>\n               </li>\n            </ul>\n         </note>",
+          "$ref": "#/definitions/EphemeralStorage_1"
+        }
+      }
+    },
+    "ContainerOverride": {
+      "description": "<p>The overrides that are sent to a container. An empty container override can be passed\n\t\t\tin. An example of an empty container override is <code>\\{\"containerOverrides\": [ ]\n\t\t\t\t\\}</code>. If a non-empty container override is specified, the <code>name</code>\n\t\t\tparameter must be included.</p>\n         <p>You can use Secrets Manager or Amazon Web Services Systems Manager Parameter Store to store the\n\t\t\tsensitive data. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/secrets-envvar.html\">Retrieve secrets through\n\t\t\t\tenvironment variables</a> in the Amazon ECS Developer Guide.</p>",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "<p>The name of the container that receives the override. This parameter is required if\n\t\t\tany override is specified.</p>",
+          "type": "string"
+        },
+        "command": {
+          "description": "<p>The command to send to the container that overrides the default command from the\n\t\t\tDocker image or the task definition. You must also specify a container name.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "environment": {
+          "description": "<p>The environment variables to send to the container. You can add new environment\n\t\t\tvariables, which are added to the container at launch, or you can override the existing\n\t\t\tenvironment variables from the Docker image or the task definition. You must also\n\t\t\tspecify a container name.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyValuePair"
+          }
+        },
+        "environmentFiles": {
+          "description": "<p>A list of files containing the environment variables to pass to a container, instead\n\t\t\tof the value from the container definition.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EnvironmentFile"
+          }
+        },
+        "cpu": {
+          "description": "<p>The number of <code>cpu</code> units reserved for the container, instead of the\n\t\t\tdefault value from the task definition. You must also specify a container name.</p>",
+          "type": "number"
+        },
+        "memory": {
+          "description": "<p>The hard limit (in MiB) of memory to present to the container, instead of the default\n\t\t\tvalue from the task definition. If your container attempts to exceed the memory\n\t\t\tspecified here, the container is killed. You must also specify a container name.</p>",
+          "type": "number"
+        },
+        "memoryReservation": {
+          "description": "<p>The soft limit (in MiB) of memory to reserve for the container, instead of the default\n\t\t\tvalue from the task definition. You must also specify a container name.</p>",
+          "type": "number"
+        },
+        "resourceRequirements": {
+          "description": "<p>The type and amount of a resource to assign to a container, instead of the default\n\t\t\tvalue from the task definition. The only supported resource is a GPU.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ResourceRequirement"
+          }
+        }
+      }
+    },
+    "EnvironmentFile": {
+      "description": "<p>A list of files containing the environment variables to pass to a container. You can\n\t\t\tspecify up to ten environment files. The file must have a <code>.env</code> file\n\t\t\textension. Each line in an environment file should contain an environment variable in\n\t\t\t\t<code>VARIABLE=VALUE</code> format. Lines beginning with <code>#</code> are treated\n\t\t\tas comments and are ignored.</p>\n         <p>If there are environment variables specified using the <code>environment</code>\n\t\t\tparameter in a container definition, they take precedence over the variables contained\n\t\t\twithin an environment file. If multiple environment files are specified that contain the\n\t\t\tsame variable, they're processed from the top down. We recommend that you use unique\n\t\t\tvariable names. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/use-environment-file.html\">Use a file to pass\n\t\t\t\tenvironment variables to a container</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <p>Environment variable files are objects in Amazon S3 and all Amazon S3 security considerations\n\t\t\tapply. </p>\n         <p>You must use the following platforms for the Fargate launch type:</p>\n         <ul>\n            <li>\n               <p>Linux platform version <code>1.4.0</code> or later.</p>\n            </li>\n            <li>\n               <p>Windows platform version <code>1.0.0</code> or later.</p>\n            </li>\n         </ul>\n         <p>Consider the following when using the Fargate launch type:</p>\n         <ul>\n            <li>\n               <p>The file is handled like a native Docker env-file.</p>\n            </li>\n            <li>\n               <p>There is no support for shell escape handling.</p>\n            </li>\n            <li>\n               <p>The container entry point interperts the <code>VARIABLE</code> values.</p>\n            </li>\n         </ul>",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "<p>The Amazon Resource Name (ARN) of the Amazon S3 object containing the environment\n\t\t\tvariable file.</p>",
+          "type": "string"
+        },
+        "type": {
+          "description": "<p>The file type to use. Environment files are objects in Amazon S3. The only supported value\n\t\t\tis <code>s3</code>.</p>",
+          "const": "s3",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "ResourceRequirement": {
+      "description": "<p>The type and amount of a resource to assign to a container. The supported resource\n\t\t\ttypes are GPUs and Elastic Inference accelerators. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html\">Working with\n\t\t\t\tGPUs on Amazon ECS</a> or <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html\">Working with Amazon Elastic\n\t\t\t\tInference on Amazon ECS</a> in the <i>Amazon Elastic Container Service Developer Guide</i>\n         </p>",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "<p>The value for the specified resource type.</p>\n         <p>When the type is <code>GPU</code>, the value is the number of physical <code>GPUs</code> the\n\t\t\tAmazon ECS container agent reserves for the container. The number of GPUs that's reserved for\n\t\t\tall containers in a task can't exceed the number of available GPUs on the container\n\t\t\tinstance that the task is launched on.</p>\n         <p>When the type is <code>InferenceAccelerator</code>, the <code>value</code> matches\n\t\t\tthe <code>deviceName</code> for an <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_InferenceAccelerator.html\">InferenceAccelerator</a> specified in a task definition.</p>",
+          "type": "string"
+        },
+        "type": {
+          "description": "<p>The type of resource to assign to a container. </p>",
+          "enum": [
+            "GPU",
+            "InferenceAccelerator"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "InferenceAcceleratorOverride": {
+      "description": "<p>Details on an Elastic Inference accelerator task override. This parameter is used to\n\t\t\toverride the Elastic Inference accelerator specified in the task definition. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html\">Working with Amazon\n\t\t\t\tElastic Inference on Amazon ECS</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "deviceName": {
+          "description": "<p>The Elastic Inference accelerator device name to override for the task. This parameter\n\t\t\tmust match a <code>deviceName</code> specified in the task definition.</p>",
+          "type": "string"
+        },
+        "deviceType": {
+          "description": "<p>The Elastic Inference accelerator type to use.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "EphemeralStorage_1": {
+      "description": "<p>The amount of ephemeral storage to allocate for the task. This parameter is used to\n\t\t\texpand the total amount of ephemeral storage available, beyond the default amount, for\n\t\t\ttasks hosted on Fargate. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_data_volumes.html\">Using data volumes in\n\t\t\t\ttasks</a> in the <i>Amazon ECS Developer Guide;</i>.</p>\n         <note>\n            <p>For tasks using the Fargate launch type, the task requires the\n\t\t\t\tfollowing platforms:</p>\n            <ul>\n               <li>\n                  <p>Linux platform version <code>1.4.0</code> or later.</p>\n               </li>\n               <li>\n                  <p>Windows platform version <code>1.0.0</code> or later.</p>\n               </li>\n            </ul>\n         </note>",
+      "type": "object",
+      "properties": {
+        "sizeInGiB": {
+          "description": "<p>The total amount, in GiB, of ephemeral storage to set for the task. The minimum\n\t\t\tsupported value is <code>20</code> GiB and the maximum supported value is\n\t\t\t\t<code>200</code> GiB.</p>",
+          "type": "number"
+        }
+      },
+      "required": [
+        "sizeInGiB"
+      ]
+    },
+    "TaskEphemeralStorage": {
+      "description": "<p>The amount of ephemeral storage to allocate for the task.</p>",
+      "type": "object",
+      "properties": {
+        "sizeInGiB": {
+          "description": "<p>The total amount, in GiB, of the ephemeral storage to set for the task. The minimum\n\t\t\tsupported value is <code>20</code> GiB and the maximum supported value is\n\t\t\t\t<code>200</code> GiB.</p>",
+          "type": "number"
+        },
+        "kmsKeyId": {
+          "description": "<p>Specify an Amazon Web Services Key Management Service key ID to encrypt the ephemeral storage for the\n\t\t\ttask.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Cluster_1": {
+      "description": "<p>An object representing an Amazon EKS cluster.</p>",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "<p>The name of your cluster.</p>",
+          "type": "string"
+        },
+        "arn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the cluster.</p>",
+          "type": "string"
+        },
+        "createdAt": {
+          "description": "<p>The Unix epoch timestamp at object creation.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "version": {
+          "description": "<p>The Kubernetes server version for the cluster.</p>",
+          "type": "string"
+        },
+        "endpoint": {
+          "description": "<p>The endpoint for your Kubernetes API server.</p>",
+          "type": "string"
+        },
+        "roleArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the IAM role that provides permissions for the Kubernetes\n            control plane to make calls to Amazon Web Services API operations on your behalf.</p>",
+          "type": "string"
+        },
+        "resourcesVpcConfig": {
+          "description": "<p>The VPC configuration used by the cluster control plane. Amazon EKS VPC\n            resources have specific requirements to work properly with Kubernetes. For more information,\n            see <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html\">Cluster VPC\n                considerations</a> and <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\">Cluster security group considerations</a> in the\n            <i>Amazon EKS User Guide</i>.</p>",
+          "$ref": "#/definitions/VpcConfigResponse_1"
+        },
+        "kubernetesNetworkConfig": {
+          "description": "<p>The Kubernetes network configuration for the cluster.</p>",
+          "$ref": "#/definitions/KubernetesNetworkConfigResponse"
+        },
+        "logging": {
+          "description": "<p>The logging configuration for your cluster.</p>",
+          "$ref": "#/definitions/Logging"
+        },
+        "identity": {
+          "description": "<p>The identity provider information for the cluster.</p>",
+          "$ref": "#/definitions/Identity"
+        },
+        "status": {
+          "enum": [
+            "ACTIVE",
+            "CREATING",
+            "DELETING",
+            "FAILED",
+            "PENDING",
+            "UPDATING"
+          ],
+          "description": "<p>The current status of the cluster.</p>",
+          "type": "string"
+        },
+        "certificateAuthority": {
+          "description": "<p>The <code>certificate-authority-data</code> for your cluster.</p>",
+          "$ref": "#/definitions/Certificate"
+        },
+        "clientRequestToken": {
+          "description": "<p>A unique, case-sensitive identifier that you provide to ensure\nthe idempotency of the request.</p>",
+          "type": "string"
+        },
+        "platformVersion": {
+          "description": "<p>The platform version of your Amazon EKS cluster. For more information about\n            clusters deployed on the Amazon Web Services Cloud, see <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html\">Platform\n                versions</a> in the <i>\n               <i>Amazon EKS User Guide</i>\n            </i>. For more information\n            about local clusters deployed on an Outpost, see <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/eks-outposts-platform-versions.html\">Amazon EKS local cluster platform versions</a> in the\n                <i>\n               <i>Amazon EKS User Guide</i>\n            </i>.</p>",
+          "type": "string"
+        },
+        "tags": {
+          "description": "<p>Metadata that assists with categorization and organization.\n            Each tag consists of a key and an optional value. You define both. Tags don't\n            propagate to any other cluster or Amazon Web Services resources.</p>",
+          "$ref": "#/definitions/Record<string,string>"
+        },
+        "encryptionConfig": {
+          "description": "<p>The encryption configuration for the cluster.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EncryptionConfig"
+          }
+        },
+        "connectorConfig": {
+          "description": "<p>The configuration used to connect to a cluster for registration.</p>",
+          "$ref": "#/definitions/ConnectorConfigResponse"
+        },
+        "id": {
+          "description": "<p>The ID of your local Amazon EKS cluster on an Amazon Web Services Outpost. This\n            property isn't available for an Amazon EKS cluster on the Amazon Web Services\n            cloud.</p>",
+          "type": "string"
+        },
+        "health": {
+          "description": "<p>An object representing the health of your Amazon EKS cluster.</p>",
+          "$ref": "#/definitions/ClusterHealth"
+        },
+        "outpostConfig": {
+          "description": "<p>An object representing the configuration of your local Amazon EKS cluster on\n            an Amazon Web Services Outpost. This object isn't available for clusters on the Amazon Web Services cloud.</p>",
+          "$ref": "#/definitions/OutpostConfigResponse"
+        },
+        "accessConfig": {
+          "description": "<p>The access configuration for the cluster.</p>",
+          "$ref": "#/definitions/AccessConfigResponse"
+        },
+        "upgradePolicy": {
+          "description": "<p>This value indicates if extended support is enabled or disabled for the cluster.</p>\n         <p>\n            <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/extended-support-control.html\">Learn more about EKS Extended Support in the EKS User Guide.</a>\n         </p>",
+          "$ref": "#/definitions/UpgradePolicyResponse"
+        },
+        "zonalShiftConfig": {
+          "description": "<p>The configuration for zonal shift for the cluster.</p>",
+          "$ref": "#/definitions/ZonalShiftConfigResponse"
+        }
+      }
+    },
+    "VpcConfigResponse_1": {
+      "description": "<p>An object representing an Amazon EKS cluster VPC configuration\n            response.</p>",
+      "type": "object",
+      "properties": {
+        "subnetIds": {
+          "description": "<p>The subnets associated with your cluster.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "securityGroupIds": {
+          "description": "<p>The security groups associated with the cross-account elastic network interfaces that\n            are used to allow communication between your nodes and the Kubernetes control plane.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "clusterSecurityGroupId": {
+          "description": "<p>The cluster security group that was created by Amazon EKS for the cluster.\n            Managed node groups use this security group for control-plane-to-data-plane\n            communication.</p>",
+          "type": "string"
+        },
+        "vpcId": {
+          "description": "<p>The VPC associated with your cluster.</p>",
+          "type": "string"
+        },
+        "endpointPublicAccess": {
+          "description": "<p>Whether the public API server endpoint is enabled.</p>",
+          "type": "boolean"
+        },
+        "endpointPrivateAccess": {
+          "description": "<p>This parameter indicates whether the Amazon EKS private API server endpoint is\n            enabled. If the Amazon EKS private API server endpoint is enabled, Kubernetes API\n            requests that originate from within your cluster's VPC use the private VPC endpoint\n            instead of traversing the internet. If this value is disabled and you have nodes or\n                Fargate pods in the cluster, then ensure that\n                <code>publicAccessCidrs</code> includes the necessary CIDR blocks for communication\n            with the nodes or Fargate pods. For more information, see <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html\">Amazon EKS cluster endpoint access control</a> in the\n                <i>\n               <i>Amazon EKS User Guide</i>\n            </i>.</p>",
+          "type": "boolean"
+        },
+        "publicAccessCidrs": {
+          "description": "<p>The CIDR blocks that are allowed access to your cluster's public Kubernetes API server\n            endpoint.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "KubernetesNetworkConfigResponse": {
+      "description": "<p>The Kubernetes network configuration for the cluster. The response contains a value for\n                <b>serviceIpv6Cidr</b> or <b>serviceIpv4Cidr</b>, but not both. </p>",
+      "type": "object",
+      "properties": {
+        "serviceIpv4Cidr": {
+          "description": "<p>The CIDR block that Kubernetes <code>Pod</code> and <code>Service</code> object IP\n            addresses are assigned from. Kubernetes assigns addresses from an <code>IPv4</code> CIDR\n            block assigned to a subnet that the node is in. If you didn't specify a CIDR block when\n            you created the cluster, then Kubernetes assigns addresses from either the\n                <code>10.100.0.0/16</code> or <code>172.20.0.0/16</code> CIDR blocks. If this was\n            specified, then it was specified when the cluster was created and it can't be\n            changed.</p>",
+          "type": "string"
+        },
+        "serviceIpv6Cidr": {
+          "description": "<p>The CIDR block that Kubernetes pod and service IP addresses are assigned from if you\n            created a 1.21 or later cluster with version 1.10.1 or later of the Amazon VPC CNI add-on and\n            specified <code>ipv6</code> for <b>ipFamily</b> when you\n            created the cluster. Kubernetes assigns service addresses from the unique local address range\n                (<code>fc00::/7</code>) because you can't specify a custom IPv6 CIDR block when you\n            create the cluster.</p>",
+          "type": "string"
+        },
+        "ipFamily": {
+          "enum": [
+            "ipv4",
+            "ipv6"
+          ],
+          "description": "<p>The IP family used to assign Kubernetes <code>Pod</code> and <code>Service</code> objects\n            IP addresses. The IP family is always <code>ipv4</code>, unless you have a\n                <code>1.21</code> or later cluster running version <code>1.10.1</code> or later of\n            the Amazon VPC CNI plugin for Kubernetes and specified <code>ipv6</code> when you created the cluster.\n        </p>",
+          "type": "string"
+        }
+      }
+    },
+    "Logging": {
+      "description": "<p>An object representing the logging configuration for resources in your cluster.</p>",
+      "type": "object",
+      "properties": {
+        "clusterLogging": {
+          "description": "<p>The cluster control plane logging configuration for your cluster.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LogSetup"
+          }
+        }
+      }
+    },
+    "LogSetup": {
+      "description": "<p>An object representing the enabled or disabled Kubernetes control plane logs for your\n            cluster.</p>",
+      "type": "object",
+      "properties": {
+        "types": {
+          "description": "<p>The available cluster control plane log types.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LogType"
+          }
+        },
+        "enabled": {
+          "description": "<p>If a log type is enabled, that log type exports its control plane logs to CloudWatch Logs. If a log type isn't enabled, that log type doesn't export its control\n            plane logs. Each individual log type can be enabled or disabled independently.</p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "LogType": {
+      "enum": [
+        "api",
+        "audit",
+        "authenticator",
+        "controllerManager",
+        "scheduler"
+      ],
+      "type": "string"
+    },
+    "Identity": {
+      "description": "<p>An object representing an identity provider.</p>",
+      "type": "object",
+      "properties": {
+        "oidc": {
+          "description": "<p>An object representing the <a href=\"https://openid.net/connect/\">OpenID Connect</a>\n            identity provider information.</p>",
+          "$ref": "#/definitions/OIDC"
+        }
+      }
+    },
+    "OIDC": {
+      "description": "<p>An object representing the <a href=\"https://openid.net/connect/\">OpenID Connect</a>\n            (OIDC) identity provider information for the cluster.</p>",
+      "type": "object",
+      "properties": {
+        "issuer": {
+          "description": "<p>The issuer URL for the OIDC identity provider.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Certificate": {
+      "description": "<p>An object representing the <code>certificate-authority-data</code> for your\n            cluster.</p>",
+      "type": "object",
+      "properties": {
+        "data": {
+          "description": "<p>The Base64-encoded certificate data required to communicate with your cluster. Add\n            this to the <code>certificate-authority-data</code> section of the\n                <code>kubeconfig</code> file for your cluster.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "EncryptionConfig": {
+      "description": "<p>The encryption configuration for the cluster.</p>",
+      "type": "object",
+      "properties": {
+        "resources": {
+          "description": "<p>Specifies the resources to be encrypted. The only supported value is\n                <code>secrets</code>.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "provider": {
+          "description": "<p>Key Management Service (KMS) key. Either the ARN or the alias can be\n            used.</p>",
+          "$ref": "#/definitions/Provider"
+        }
+      }
+    },
+    "Provider": {
+      "description": "<p>Identifies the Key Management Service (KMS) key used to encrypt the\n            secrets.</p>",
+      "type": "object",
+      "properties": {
+        "keyArn": {
+          "description": "<p>Amazon Resource Name (ARN) or alias of the KMS key. The KMS key must be\n            symmetric and created in the same Amazon Web Services Region as the cluster. If the\n                KMS key was created in a different account, the <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html\">IAM principal</a> must\n            have access to the KMS key. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-modifying-external-accounts.html\">Allowing\n                users in other accounts to use a KMS key</a> in the\n                    <i>Key Management Service Developer Guide</i>.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ConnectorConfigResponse": {
+      "description": "<p>The full description of your connected cluster.</p>",
+      "type": "object",
+      "properties": {
+        "activationId": {
+          "description": "<p>A unique ID associated with the cluster for registration purposes.</p>",
+          "type": "string"
+        },
+        "activationCode": {
+          "description": "<p>A unique code associated with the cluster for registration purposes.</p>",
+          "type": "string"
+        },
+        "activationExpiry": {
+          "description": "<p>The expiration time of the connected cluster. The cluster's YAML file must be applied\n            through the native provider.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "provider": {
+          "description": "<p>The cluster's cloud service provider.</p>",
+          "type": "string"
+        },
+        "roleArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the role to communicate with services from the connected Kubernetes\n            cluster.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ClusterHealth": {
+      "description": "<p>An object representing the health of your Amazon EKS cluster.</p>",
+      "type": "object",
+      "properties": {
+        "issues": {
+          "description": "<p>An object representing the health issues of your Amazon EKS cluster.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClusterIssue"
+          }
+        }
+      }
+    },
+    "ClusterIssue": {
+      "description": "<p>An issue with your Amazon EKS cluster.</p>",
+      "type": "object",
+      "properties": {
+        "code": {
+          "enum": [
+            "AccessDenied",
+            "ClusterUnreachable",
+            "ConfigurationConflict",
+            "Ec2SecurityGroupNotFound",
+            "Ec2ServiceNotSubscribed",
+            "Ec2SubnetNotFound",
+            "IamRoleNotFound",
+            "InsufficientFreeAddresses",
+            "InternalFailure",
+            "KmsGrantRevoked",
+            "KmsKeyDisabled",
+            "KmsKeyMarkedForDeletion",
+            "KmsKeyNotFound",
+            "Other",
+            "ResourceLimitExceeded",
+            "ResourceNotFound",
+            "StsRegionalEndpointDisabled",
+            "UnsupportedVersion",
+            "VpcNotFound"
+          ],
+          "description": "<p>The error code of the issue.</p>",
+          "type": "string"
+        },
+        "message": {
+          "description": "<p>A description of the issue.</p>",
+          "type": "string"
+        },
+        "resourceIds": {
+          "description": "<p>The resource IDs that the issue relates to.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "OutpostConfigResponse": {
+      "description": "<p>An object representing the configuration of your local Amazon EKS cluster on\n            an Amazon Web Services Outpost. This API isn't available for Amazon EKS clusters\n            on the Amazon Web Services cloud.</p>",
+      "type": "object",
+      "properties": {
+        "outpostArns": {
+          "description": "<p>The ARN of the Outpost that you specified for use with your local Amazon EKS\n            cluster on Outposts.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "controlPlaneInstanceType": {
+          "description": "<p>The Amazon EC2 instance type used for the control plane. The instance type is\n            the same for all control plane instances.</p>",
+          "type": "string"
+        },
+        "controlPlanePlacement": {
+          "description": "<p>An object representing the placement configuration for all the control plane instances\n            of your local Amazon EKS cluster on an Amazon Web Services Outpost. For more\n            information, see <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/eks-outposts-capacity-considerations.html\">Capacity\n                considerations</a> in the <i>Amazon EKS User Guide</i>.</p>",
+          "$ref": "#/definitions/ControlPlanePlacementResponse"
+        }
+      },
+      "required": [
+        "controlPlaneInstanceType",
+        "outpostArns"
+      ]
+    },
+    "ControlPlanePlacementResponse": {
+      "description": "<p>The placement configuration for all the control plane instances of your local Amazon EKS cluster on an Amazon Web Services Outpost. For more information, see\n                <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/eks-outposts-capacity-considerations.html\">Capacity considerations</a> in the <i>Amazon EKS User Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "groupName": {
+          "description": "<p>The name of the placement group for the Kubernetes control plane instances.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "AccessConfigResponse": {
+      "description": "<p>The access configuration for the cluster.</p>",
+      "type": "object",
+      "properties": {
+        "bootstrapClusterCreatorAdminPermissions": {
+          "description": "<p>Specifies whether or not the cluster creator IAM principal was set as a\n            cluster admin access entry during cluster creation time.</p>",
+          "type": "boolean"
+        },
+        "authenticationMode": {
+          "enum": [
+            "API",
+            "API_AND_CONFIG_MAP",
+            "CONFIG_MAP"
+          ],
+          "description": "<p>The current authentication mode of the cluster.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "UpgradePolicyResponse": {
+      "description": "<p>This value indicates if extended support is enabled or disabled for the cluster.</p>\n         <p>\n            <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/extended-support-control.html\">Learn more about EKS Extended Support in the EKS User Guide.</a>\n         </p>",
+      "type": "object",
+      "properties": {
+        "supportType": {
+          "enum": [
+            "EXTENDED",
+            "STANDARD"
+          ],
+          "description": "<p>If the cluster is set to <code>EXTENDED</code>, it will enter extended support at the end of standard support. If the cluster is set to <code>STANDARD</code>, it will be automatically upgraded at the end of standard support.</p>\n         <p>\n            <a href=\"https://docs.aws.amazon.com/eks/latest/userguide/extended-support-control.html\">Learn more about EKS Extended Support in the EKS User Guide.</a>\n         </p>",
+          "type": "string"
+        }
+      }
+    },
+    "ZonalShiftConfigResponse": {
+      "description": "<p>The status of zonal shift configuration for the cluster</p>",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "<p>Whether the zonal shift is enabled.</p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "Topic": {
+      "description": "<p>A wrapper type for the topic's Amazon Resource Name (ARN). To retrieve a topic's\n            attributes, use <code>GetTopicAttributes</code>.</p>",
+      "type": "object",
+      "properties": {
+        "TopicArn": {
+          "description": "<p>The topic's ARN.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "LoadBalancer_1": {
+      "description": "<p>Information about a load balancer.</p>",
+      "type": "object",
+      "properties": {
+        "LoadBalancerArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the load balancer.</p>",
+          "type": "string"
+        },
+        "DNSName": {
+          "description": "<p>The public DNS name of the load balancer.</p>",
+          "type": "string"
+        },
+        "CanonicalHostedZoneId": {
+          "description": "<p>The ID of the Amazon Route 53 hosted zone associated with the load balancer.</p>",
+          "type": "string"
+        },
+        "CreatedTime": {
+          "description": "<p>The date and time the load balancer was created.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "LoadBalancerName": {
+          "description": "<p>The name of the load balancer.</p>",
+          "type": "string"
+        },
+        "Scheme": {
+          "enum": [
+            "internal",
+            "internet-facing"
+          ],
+          "description": "<p>The nodes of an Internet-facing load balancer have public IP addresses. The DNS name of an\n      Internet-facing load balancer is publicly resolvable to the public IP addresses of the nodes.\n      Therefore, Internet-facing load balancers can route requests from clients over the\n      internet.</p>\n         <p>The nodes of an internal load balancer have only private IP addresses. The DNS name of an\n      internal load balancer is publicly resolvable to the private IP addresses of the nodes.\n      Therefore, internal load balancers can route requests only from clients with access to the VPC\n      for the load balancer.</p>",
+          "type": "string"
+        },
+        "VpcId": {
+          "description": "<p>The ID of the VPC for the load balancer.</p>",
+          "type": "string"
+        },
+        "State": {
+          "description": "<p>The state of the load balancer.</p>",
+          "$ref": "#/definitions/LoadBalancerState"
+        },
+        "Type": {
+          "enum": [
+            "application",
+            "gateway",
+            "network"
+          ],
+          "description": "<p>The type of load balancer.</p>",
+          "type": "string"
+        },
+        "AvailabilityZones": {
+          "description": "<p>The subnets for the load balancer.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AvailabilityZone_1"
+          }
+        },
+        "SecurityGroups": {
+          "description": "<p>The IDs of the security groups for the load balancer.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "IpAddressType": {
+          "enum": [
+            "dualstack",
+            "dualstack-without-public-ipv4",
+            "ipv4"
+          ],
+          "description": "<p>The type of IP addresses used for public or private connections by the subnets\n      attached to your load balancer.</p>\n         <p>[Application Load Balancers] The possible values are <code>ipv4</code> (IPv4 addresses),\n      <code>dualstack</code> (IPv4 and IPv6 addresses), and <code>dualstack-without-public-ipv4</code>\n      (public IPv6 addresses and private IPv4 and IPv6 addresses).</p>\n         <p>[Network Load Balancers and Gateway Load Balancers] The possible values are <code>ipv4</code>\n      (IPv4 addresses) and <code>dualstack</code> (IPv4 and IPv6 addresses).</p>",
+          "type": "string"
+        },
+        "CustomerOwnedIpv4Pool": {
+          "description": "<p>[Application Load Balancers on Outposts] The ID of the customer-owned address pool.</p>",
+          "type": "string"
+        },
+        "EnforceSecurityGroupInboundRulesOnPrivateLinkTraffic": {
+          "description": "<p>Indicates whether to evaluate inbound security group rules for traffic sent to a\n      Network Load Balancer through Amazon Web Services PrivateLink.</p>",
+          "type": "string"
+        },
+        "EnablePrefixForIpv6SourceNat": {
+          "enum": [
+            "off",
+            "on"
+          ],
+          "description": "<p>[Network Load Balancers with UDP listeners] Indicates whether to use an IPv6 prefix\n      from each subnet for source NAT. The IP address type must be <code>dualstack</code>.\n      The default value is <code>off</code>.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "LoadBalancerState": {
+      "description": "<p>Information about the state of the load balancer.</p>",
+      "type": "object",
+      "properties": {
+        "Code": {
+          "enum": [
+            "active",
+            "active_impaired",
+            "failed",
+            "provisioning"
+          ],
+          "description": "<p>The state code. The initial state of the load balancer is <code>provisioning</code>. After\n      the load balancer is fully set up and ready to route traffic, its state is\n      <code>active</code>. If load balancer is routing traffic but does not have the resources it\n      needs to scale, its state is<code>active_impaired</code>. If the load balancer could not be\n      set up, its state is <code>failed</code>.</p>",
+          "type": "string"
+        },
+        "Reason": {
+          "description": "<p>A description of the state.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "AvailabilityZone_1": {
+      "description": "<p>Information about an Availability Zone.</p>",
+      "type": "object",
+      "properties": {
+        "ZoneName": {
+          "description": "<p>The name of the Availability Zone.</p>",
+          "type": "string"
+        },
+        "SubnetId": {
+          "description": "<p>The ID of the subnet. You can specify one subnet per Availability Zone.</p>",
+          "type": "string"
+        },
+        "OutpostId": {
+          "description": "<p>[Application Load Balancers on Outposts] The ID of the Outpost.</p>",
+          "type": "string"
+        },
+        "LoadBalancerAddresses": {
+          "description": "<p>[Network Load Balancers] If you need static IP addresses for your load balancer, you can\n      specify one Elastic IP address per Availability Zone when you create an internal-facing load\n      balancer. For internal load balancers, you can specify a private IP address from the IPv4\n      range of the subnet.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LoadBalancerAddress"
+          }
+        },
+        "SourceNatIpv6Prefixes": {
+          "description": "<p>[Network Load Balancers with UDP listeners] The IPv6 prefixes to use for source NAT.\n      For each subnet, specify an IPv6 prefix (/80 netmask) from the subnet CIDR block or\n     <code>auto_assigned</code> to use an IPv6 prefix selected at random from the subnet CIDR\n      block.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "LoadBalancerAddress": {
+      "description": "<p>Information about a static IP address for a load balancer.</p>",
+      "type": "object",
+      "properties": {
+        "IpAddress": {
+          "description": "<p>The static IP address.</p>",
+          "type": "string"
+        },
+        "AllocationId": {
+          "description": "<p>[Network Load Balancers] The allocation ID of the Elastic IP address for an\n      internal-facing load balancer.</p>",
+          "type": "string"
+        },
+        "PrivateIPv4Address": {
+          "description": "<p>[Network Load Balancers] The private IPv4 address for an internal load balancer.</p>",
+          "type": "string"
+        },
+        "IPv6Address": {
+          "description": "<p>[Network Load Balancers] The IPv6 address.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "TargetGroup": {
+      "description": "<p>Information about a target group.</p>",
+      "type": "object",
+      "properties": {
+        "TargetGroupArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the target group.</p>",
+          "type": "string"
+        },
+        "TargetGroupName": {
+          "description": "<p>The name of the target group.</p>",
+          "type": "string"
+        },
+        "Protocol": {
+          "enum": [
+            "GENEVE",
+            "HTTP",
+            "HTTPS",
+            "TCP",
+            "TCP_UDP",
+            "TLS",
+            "UDP"
+          ],
+          "description": "<p>The protocol to use for routing traffic to the targets.</p>",
+          "type": "string"
+        },
+        "Port": {
+          "description": "<p>The port on which the targets are listening. This parameter is not used if the target is\n      a Lambda function.</p>",
+          "type": "number"
+        },
+        "VpcId": {
+          "description": "<p>The ID of the VPC for the targets.</p>",
+          "type": "string"
+        },
+        "HealthCheckProtocol": {
+          "enum": [
+            "GENEVE",
+            "HTTP",
+            "HTTPS",
+            "TCP",
+            "TCP_UDP",
+            "TLS",
+            "UDP"
+          ],
+          "description": "<p>The protocol to use to connect with the target. The GENEVE, TLS, UDP, and TCP_UDP\n      protocols are not supported for health checks.</p>",
+          "type": "string"
+        },
+        "HealthCheckPort": {
+          "description": "<p>The port to use to connect with the target.</p>",
+          "type": "string"
+        },
+        "HealthCheckEnabled": {
+          "description": "<p>Indicates whether health checks are enabled.</p>",
+          "type": "boolean"
+        },
+        "HealthCheckIntervalSeconds": {
+          "description": "<p>The approximate amount of time, in seconds, between health checks of an individual\n      target.</p>",
+          "type": "number"
+        },
+        "HealthCheckTimeoutSeconds": {
+          "description": "<p>The amount of time, in seconds, during which no response means a failed health\n      check.</p>",
+          "type": "number"
+        },
+        "HealthyThresholdCount": {
+          "description": "<p>The number of consecutive health checks successes required before considering an unhealthy\n      target healthy.</p>",
+          "type": "number"
+        },
+        "UnhealthyThresholdCount": {
+          "description": "<p>The number of consecutive health check failures required before considering the target\n      unhealthy.</p>",
+          "type": "number"
+        },
+        "HealthCheckPath": {
+          "description": "<p>The destination for health checks on the targets.</p>",
+          "type": "string"
+        },
+        "Matcher": {
+          "description": "<p>The HTTP or gRPC codes to use when checking for a successful response from a\n      target.</p>",
+          "$ref": "#/definitions/Matcher"
+        },
+        "LoadBalancerArns": {
+          "description": "<p>The Amazon Resource Name (ARN) of the load balancer that routes traffic to this target\n      group. You can use each target group with only one load balancer.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TargetType": {
+          "enum": [
+            "alb",
+            "instance",
+            "ip",
+            "lambda"
+          ],
+          "description": "<p>The type of target that you must specify when registering targets with this target group.\n      The possible values are <code>instance</code> (register targets by instance ID),\n        <code>ip</code> (register targets by IP address), <code>lambda</code> (register a single\n      Lambda function as a target), or <code>alb</code> (register a single Application Load Balancer\n      as a target).</p>",
+          "type": "string"
+        },
+        "ProtocolVersion": {
+          "description": "<p>[HTTP/HTTPS protocol] The protocol version. The possible values are <code>GRPC</code>,\n        <code>HTTP1</code>, and <code>HTTP2</code>.</p>",
+          "type": "string"
+        },
+        "IpAddressType": {
+          "enum": [
+            "ipv4",
+            "ipv6"
+          ],
+          "description": "<p>The IP address type. The default value is <code>ipv4</code>.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Matcher": {
+      "description": "<p>The codes to use when checking for a successful response from a target. If the protocol\n      version is gRPC, these are gRPC codes. Otherwise, these are HTTP codes. </p>",
+      "type": "object",
+      "properties": {
+        "HttpCode": {
+          "description": "<p>For Application Load Balancers, you can specify values between 200 and 499, with the\n      default value being 200. You can specify multiple values (for example, \"200,202\") or a range of values (for example, \"200-299\").</p>\n         <p>For Network Load Balancers, you can specify values between 200 and 599, with the\n      default value being 200-399. You can specify multiple values (for example, \"200,202\") or a range of values (for example, \"200-299\").</p>\n         <p>For Gateway Load Balancers, this must be \"200–399\".</p>\n         <p>Note that when using shorthand syntax, some values such as commas need to be\n      escaped.</p>",
+          "type": "string"
+        },
+        "GrpcCode": {
+          "description": "<p>You can specify values between 0 and 99. You can specify multiple values (for example,\n      \"0,1\") or a range of values (for example, \"0-5\"). The default value is 12.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "LoadBalancerDescription": {
+      "description": "<p>Information about a load balancer.</p>",
+      "type": "object",
+      "properties": {
+        "LoadBalancerName": {
+          "description": "<p>The name of the load balancer.</p>",
+          "type": "string"
+        },
+        "DNSName": {
+          "description": "<p>The DNS name of the load balancer.</p>",
+          "type": "string"
+        },
+        "CanonicalHostedZoneName": {
+          "description": "<p>The DNS name of the load balancer.</p>\n        <p>For more information, see <a href=\"https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/using-domain-names-with-elb.html\">Configure a Custom Domain Name</a>\n            in the <i>Classic Load Balancers Guide</i>.</p>",
+          "type": "string"
+        },
+        "CanonicalHostedZoneNameID": {
+          "description": "<p>The ID of the Amazon Route 53 hosted zone for the load balancer.</p>",
+          "type": "string"
+        },
+        "ListenerDescriptions": {
+          "description": "<p>The listeners for the load balancer.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ListenerDescription"
+          }
+        },
+        "Policies": {
+          "description": "<p>The policies defined for the load balancer.</p>",
+          "$ref": "#/definitions/Policies"
+        },
+        "BackendServerDescriptions": {
+          "description": "<p>Information about your EC2 instances.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BackendServerDescription"
+          }
+        },
+        "AvailabilityZones": {
+          "description": "<p>The Availability Zones for the load balancer.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Subnets": {
+          "description": "<p>The IDs of the subnets for the load balancer.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "VPCId": {
+          "description": "<p>The ID of the VPC for the load balancer.</p>",
+          "type": "string"
+        },
+        "Instances": {
+          "description": "<p>The IDs of the instances for the load balancer.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Instance_2"
+          }
+        },
+        "HealthCheck": {
+          "description": "<p>Information about the health checks conducted on the load balancer.</p>",
+          "$ref": "#/definitions/HealthCheck"
+        },
+        "SourceSecurityGroup": {
+          "description": "<p>The security group for the load balancer, which you can use as part of your inbound rules for your registered instances.\n            To only allow traffic from load balancers, add a security group rule that specifies this source security group as the inbound source.</p>",
+          "$ref": "#/definitions/SourceSecurityGroup"
+        },
+        "SecurityGroups": {
+          "description": "<p>The security groups for the load balancer. Valid only for load balancers in a VPC.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "CreatedTime": {
+          "description": "<p>The date and time the load balancer was created.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "Scheme": {
+          "description": "<p>The type of load balancer. Valid only for load balancers in a VPC.</p>\n         <p>If <code>Scheme</code> is <code>internet-facing</code>, the load balancer\n           has a public DNS name that resolves to a public IP address.</p>\n        <p>If <code>Scheme</code> is <code>internal</code>, the load balancer has a public\n           DNS name that resolves to a private IP address.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ListenerDescription": {
+      "description": "<p>The policies enabled for a listener.</p>",
+      "type": "object",
+      "properties": {
+        "Listener": {
+          "description": "<p>The listener.</p>",
+          "$ref": "#/definitions/Listener"
+        },
+        "PolicyNames": {
+          "description": "<p>The policies. If there are no policies enabled, the list is empty.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Listener": {
+      "description": "<p>Information about a listener.</p>\n        <p>For information about the protocols and the ports supported by Elastic Load Balancing, see <a href=\"https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-listener-config.html\">Listeners for Your Classic Load Balancer</a>\n            in the <i>Classic Load Balancers Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "Protocol": {
+          "description": "<p>The load balancer transport protocol to use for routing: HTTP, HTTPS, TCP, or SSL.</p>",
+          "type": "string"
+        },
+        "LoadBalancerPort": {
+          "description": "<p>The port on which the load balancer is listening. On EC2-VPC, you can specify any port from the range 1-65535. On EC2-Classic, you can specify any port from the following list: 25, 80, 443, 465, 587, 1024-65535.</p>",
+          "type": "number"
+        },
+        "InstanceProtocol": {
+          "description": "<p>The protocol to use for routing traffic to instances: HTTP, HTTPS, TCP, or SSL.</p>\n         <p>If the front-end protocol is TCP or SSL, the back-end protocol must be TCP or SSL.\n           If the front-end protocol is HTTP or HTTPS, the back-end protocol must be HTTP or HTTPS.</p>\n         <p>If there is another listener with the same <code>InstancePort</code> whose <code>InstanceProtocol</code> is secure,\n          (HTTPS or SSL), the listener's <code>InstanceProtocol</code> must also be secure.</p>\n        <p>If there is another listener with the same <code>InstancePort</code> whose <code>InstanceProtocol</code> is HTTP or TCP,\n           the listener's <code>InstanceProtocol</code> must be HTTP or TCP.</p>",
+          "type": "string"
+        },
+        "InstancePort": {
+          "description": "<p>The port on which the instance is listening.</p>",
+          "type": "number"
+        },
+        "SSLCertificateId": {
+          "description": "<p>The Amazon Resource Name (ARN) of the server certificate.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "InstancePort",
+        "LoadBalancerPort",
+        "Protocol"
+      ]
+    },
+    "Policies": {
+      "description": "<p>The policies for a load balancer.</p>",
+      "type": "object",
+      "properties": {
+        "AppCookieStickinessPolicies": {
+          "description": "<p>The stickiness policies created using <a>CreateAppCookieStickinessPolicy</a>.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AppCookieStickinessPolicy"
+          }
+        },
+        "LBCookieStickinessPolicies": {
+          "description": "<p>The stickiness policies created using <a>CreateLBCookieStickinessPolicy</a>.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LBCookieStickinessPolicy"
+          }
+        },
+        "OtherPolicies": {
+          "description": "<p>The policies other than the stickiness policies.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AppCookieStickinessPolicy": {
+      "description": "<p>Information about a policy for application-controlled session stickiness.</p>",
+      "type": "object",
+      "properties": {
+        "PolicyName": {
+          "description": "<p>The mnemonic name for the policy being created. The name must be unique within a set of policies for this load balancer.</p>",
+          "type": "string"
+        },
+        "CookieName": {
+          "description": "<p>The name of the application cookie used for stickiness.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "LBCookieStickinessPolicy": {
+      "description": "<p>Information about a policy for duration-based session stickiness.</p>",
+      "type": "object",
+      "properties": {
+        "PolicyName": {
+          "description": "<p>The name of the policy. This name must be unique within the set of policies for this load balancer.</p>",
+          "type": "string"
+        },
+        "CookieExpirationPeriod": {
+          "description": "<p>The time period, in seconds, after which the cookie should be considered stale. If this parameter is not specified, the stickiness session lasts for the duration of the browser session.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "BackendServerDescription": {
+      "description": "<p>Information about the configuration of an EC2 instance.</p>",
+      "type": "object",
+      "properties": {
+        "InstancePort": {
+          "description": "<p>The port on which the EC2 instance is listening.</p>",
+          "type": "number"
+        },
+        "PolicyNames": {
+          "description": "<p>The names of the policies enabled for the EC2 instance.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Instance_2": {
+      "description": "<p>The ID of an EC2 instance.</p>",
+      "type": "object",
+      "properties": {
+        "InstanceId": {
+          "description": "<p>The instance ID.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "HealthCheck": {
+      "description": "<p>Information about a health check.</p>",
+      "type": "object",
+      "properties": {
+        "Target": {
+          "description": "<p>The instance being checked. The protocol is either TCP, HTTP, HTTPS, or SSL. The range of valid ports is one (1) through 65535.</p>\n        <p>TCP is the default, specified as a TCP: port pair, for example \"TCP:5000\". In this case, a health check simply attempts to open a TCP connection to the instance on the specified port. Failure to connect within the configured timeout is considered unhealthy.</p>\n        <p>SSL is also specified as SSL: port pair, for example, SSL:5000.</p>\n        <p>For HTTP/HTTPS, you must include a ping path in the string. HTTP is specified as a HTTP:port;/;PathToPing; grouping, for example \"HTTP:80/weather/us/wa/seattle\". In this case, a HTTP GET request is issued to the instance on the given port and path. Any answer other than \"200 OK\" within the timeout period is considered unhealthy.</p>\n         <p>The total length of the HTTP ping target must be 1024 16-bit Unicode characters or less.</p>",
+          "type": "string"
+        },
+        "Interval": {
+          "description": "<p>The approximate interval, in seconds, between health checks of an individual instance.</p>",
+          "type": "number"
+        },
+        "Timeout": {
+          "description": "<p>The amount of time, in seconds, during which no response means a failed health check.</p>\n        <p>This value must be less than the <code>Interval</code> value.</p>",
+          "type": "number"
+        },
+        "UnhealthyThreshold": {
+          "description": "<p>The number of consecutive health check failures required before moving the instance to the <code>Unhealthy</code> state.</p>",
+          "type": "number"
+        },
+        "HealthyThreshold": {
+          "description": "<p>The number of consecutive health checks successes required before moving the instance to the <code>Healthy</code> state.</p>",
+          "type": "number"
+        }
+      },
+      "required": [
+        "HealthyThreshold",
+        "Interval",
+        "Target",
+        "Timeout",
+        "UnhealthyThreshold"
+      ]
+    },
+    "SourceSecurityGroup": {
+      "description": "<p>Information about a source security group.</p>",
+      "type": "object",
+      "properties": {
+        "OwnerAlias": {
+          "description": "<p>The owner of the security group.</p>",
+          "type": "string"
+        },
+        "GroupName": {
+          "description": "<p>The name of the security group.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "DistributionSummary": {
+      "description": "<p>A summary of the information about a CloudFront distribution.</p>",
+      "type": "object",
+      "properties": {
+        "Id": {
+          "description": "<p>The identifier for the distribution. For example: <code>EDFDVBD632BHDS5</code>.</p>",
+          "type": "string"
+        },
+        "ARN": {
+          "description": "<p>The ARN (Amazon Resource Name) for the distribution. For example:\n\t\t\t\t<code>arn:aws:cloudfront::123456789012:distribution/EDFDVBD632BHDS5</code>, where\n\t\t\t\t<code>123456789012</code> is your Amazon Web Services account ID.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "description": "<p>The current status of the distribution. When the status is <code>Deployed</code>, the\n\t\t\tdistribution's information is propagated to all CloudFront edge locations.</p>",
+          "type": "string"
+        },
+        "LastModifiedTime": {
+          "description": "<p>The date and time the distribution was last modified.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "DomainName": {
+          "description": "<p>The domain name that corresponds to the distribution, for example,\n\t\t\t\t<code>d111111abcdef8.cloudfront.net</code>.</p>",
+          "type": "string"
+        },
+        "Aliases": {
+          "description": "<p>A complex type that contains information about CNAMEs (alternate domain names), if\n\t\t\tany, for this distribution.</p>",
+          "$ref": "#/definitions/Aliases"
+        },
+        "Origins": {
+          "description": "<p>A complex type that contains information about origins for this distribution.</p>",
+          "$ref": "#/definitions/Origins"
+        },
+        "OriginGroups": {
+          "description": "<p>A complex type that contains information about origin groups for this\n\t\t\tdistribution.</p>",
+          "$ref": "#/definitions/OriginGroups"
+        },
+        "DefaultCacheBehavior": {
+          "description": "<p>A complex type that describes the default cache behavior if you don't specify a\n\t\t\t\t<code>CacheBehavior</code> element or if files don't match any of the values of\n\t\t\t\t<code>PathPattern</code> in <code>CacheBehavior</code> elements. You must create\n\t\t\texactly one default cache behavior.</p>",
+          "$ref": "#/definitions/DefaultCacheBehavior"
+        },
+        "CacheBehaviors": {
+          "description": "<p>A complex type that contains zero or more <code>CacheBehavior</code> elements.</p>",
+          "$ref": "#/definitions/CacheBehaviors"
+        },
+        "CustomErrorResponses": {
+          "description": "<p>A complex type that contains zero or more <code>CustomErrorResponses</code>\n\t\t\telements.</p>",
+          "$ref": "#/definitions/CustomErrorResponses"
+        },
+        "Comment": {
+          "description": "<p>The comment originally specified when this distribution was created.</p>",
+          "type": "string"
+        },
+        "PriceClass": {
+          "description": "<p>A complex type that contains information about price class for this streaming\n\t\t\tdistribution.</p>",
+          "enum": [
+            "PriceClass_100",
+            "PriceClass_200",
+            "PriceClass_All"
+          ],
+          "type": "string"
+        },
+        "Enabled": {
+          "description": "<p>Whether the distribution is enabled to accept user requests for content.</p>",
+          "type": "boolean"
+        },
+        "ViewerCertificate": {
+          "description": "<p>A complex type that determines the distribution's SSL/TLS configuration for\n\t\t\tcommunicating with viewers.</p>",
+          "$ref": "#/definitions/ViewerCertificate"
+        },
+        "Restrictions": {
+          "description": "<p>A complex type that identifies ways in which you want to restrict distribution of your\n\t\t\tcontent.</p>",
+          "$ref": "#/definitions/Restrictions"
+        },
+        "WebACLId": {
+          "description": "<p>The Web ACL Id (if any) associated with the distribution.</p>",
+          "type": "string"
+        },
+        "HttpVersion": {
+          "description": "<p>Specify the maximum HTTP version that you want viewers to use to communicate with\n\t\t\tCloudFront. The default value for new web distributions is <code>http2</code>. Viewers that\n\t\t\tdon't support <code>HTTP/2</code> will automatically use an earlier version.</p>",
+          "enum": [
+            "http1.1",
+            "http2",
+            "http2and3",
+            "http3"
+          ],
+          "type": "string"
+        },
+        "IsIPV6Enabled": {
+          "description": "<p>Whether CloudFront responds to IPv6 DNS requests with an IPv6 address for your\n\t\t\tdistribution.</p>",
+          "type": "boolean"
+        },
+        "AliasICPRecordals": {
+          "description": "<p>Amazon Web Services services in China customers must file for an Internet Content Provider (ICP)\n\t\t\trecordal if they want to serve content publicly on an alternate domain name, also known\n\t\t\tas a CNAME, that they've added to CloudFront. AliasICPRecordal provides the ICP recordal\n\t\t\tstatus for CNAMEs associated with distributions.</p>\n         <p>For more information about ICP recordals, see <a href=\"https://docs.amazonaws.cn/en_us/aws/latest/userguide/accounts-and-credentials.html\"> Signup, Accounts, and Credentials</a> in <i>Getting Started with Amazon Web Services\n\t\t\t\tservices in China</i>.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AliasICPRecordal"
+          }
+        },
+        "Staging": {
+          "description": "<p>A Boolean that indicates whether this is a staging distribution. When this value is\n\t\t\t\t<code>true</code>, this is a staging distribution. When this value is\n\t\t\t\t<code>false</code>, this is not a staging distribution.</p>",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ARN",
+        "Aliases",
+        "CacheBehaviors",
+        "Comment",
+        "CustomErrorResponses",
+        "DefaultCacheBehavior",
+        "DomainName",
+        "Enabled",
+        "HttpVersion",
+        "Id",
+        "IsIPV6Enabled",
+        "LastModifiedTime",
+        "Origins",
+        "PriceClass",
+        "Restrictions",
+        "Staging",
+        "Status",
+        "ViewerCertificate",
+        "WebACLId"
+      ]
+    },
+    "Aliases": {
+      "description": "<p>A complex type that contains information about CNAMEs (alternate domain names), if\n\t\t\tany, for this distribution.</p>",
+      "type": "object",
+      "properties": {
+        "Quantity": {
+          "description": "<p>The number of CNAME aliases, if any, that you want to associate with this\n\t\t\tdistribution.</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>A complex type that contains the CNAME aliases, if any, that you want to associate\n\t\t\twith this distribution.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "Quantity"
+      ]
+    },
+    "Origins": {
+      "description": "<p>Contains information about the origins for this distribution.</p>",
+      "type": "object",
+      "properties": {
+        "Quantity": {
+          "description": "<p>The number of origins for this distribution.</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>A list of origins.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Origin"
+          }
+        }
+      },
+      "required": [
+        "Items",
+        "Quantity"
+      ]
+    },
+    "Origin": {
+      "description": "<p>An origin.</p>\n         <p>An origin is the location where content is stored, and from which CloudFront gets content to\n\t\t\tserve to viewers. To specify an origin:</p>\n         <ul>\n            <li>\n               <p>Use <code>S3OriginConfig</code> to specify an Amazon S3 bucket that is not\n\t\t\t\t\tconfigured with static website hosting.</p>\n            </li>\n            <li>\n               <p>Use <code>CustomOriginConfig</code> to specify all other kinds of origins,\n\t\t\t\t\tincluding:</p>\n               <ul>\n                  <li>\n                     <p>An Amazon S3 bucket that is configured with static website hosting</p>\n                  </li>\n                  <li>\n                     <p>An Elastic Load Balancing load balancer</p>\n                  </li>\n                  <li>\n                     <p>An Elemental MediaPackage endpoint</p>\n                  </li>\n                  <li>\n                     <p>An Elemental MediaStore container</p>\n                  </li>\n                  <li>\n                     <p>Any other HTTP server, running on an Amazon EC2 instance or any other kind\n\t\t\t\t\t\t\tof host</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>For the current maximum number of origins that you can specify per distribution, see\n\t\t\t\t<a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-limits.html#limits-web-distributions\">General Quotas on Web Distributions</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i> (quotas were formerly referred to as\n\t\t\tlimits).</p>",
+      "type": "object",
+      "properties": {
+        "Id": {
+          "description": "<p>A unique identifier for the origin. This value must be unique within the\n\t\t\tdistribution.</p>\n         <p>Use this value to specify the <code>TargetOriginId</code> in a\n\t\t\t\t<code>CacheBehavior</code> or <code>DefaultCacheBehavior</code>.</p>",
+          "type": "string"
+        },
+        "DomainName": {
+          "description": "<p>The domain name for the origin.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesDomainName\">Origin Domain Name</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "OriginPath": {
+          "description": "<p>An optional path that CloudFront appends to the origin domain name when CloudFront requests\n\t\t\tcontent from the origin.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesOriginPath\">Origin Path</a> in the\n\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "CustomHeaders": {
+          "description": "<p>A list of HTTP header names and values that CloudFront adds to the requests that it sends to\n\t\t\tthe origin.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/add-origin-custom-headers.html\">Adding Custom Headers to Origin Requests</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "$ref": "#/definitions/CustomHeaders"
+        },
+        "S3OriginConfig": {
+          "description": "<p>Use this type to specify an origin that is an Amazon S3 bucket that is not configured with\n\t\t\tstatic website hosting. To specify any other type of origin, including an Amazon S3 bucket\n\t\t\tthat is configured with static website hosting, use the <code>CustomOriginConfig</code>\n\t\t\ttype instead.</p>",
+          "$ref": "#/definitions/S3OriginConfig"
+        },
+        "CustomOriginConfig": {
+          "description": "<p>Use this type to specify an origin that is not an Amazon S3 bucket, with one exception. If\n\t\t\tthe Amazon S3 bucket is configured with static website hosting, use this type. If the Amazon S3\n\t\t\tbucket is not configured with static website hosting, use the\n\t\t\t\t<code>S3OriginConfig</code> type instead.</p>",
+          "$ref": "#/definitions/CustomOriginConfig"
+        },
+        "ConnectionAttempts": {
+          "description": "<p>The number of times that CloudFront attempts to connect to the origin. The minimum number is\n\t\t\t1, the maximum is 3, and the default (if you don't specify otherwise) is 3.</p>\n         <p>For a custom origin (including an Amazon S3 bucket that's configured with static website\n\t\t\thosting), this value also specifies the number of times that CloudFront attempts to get a\n\t\t\tresponse from the origin, in the case of an <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesOriginResponseTimeout\">Origin Response Timeout</a>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#origin-connection-attempts\">Origin Connection Attempts</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "number"
+        },
+        "ConnectionTimeout": {
+          "description": "<p>The number of seconds that CloudFront waits when trying to establish a connection to the\n\t\t\torigin. The minimum timeout is 1 second, the maximum is 10 seconds, and the default (if\n\t\t\tyou don't specify otherwise) is 10 seconds.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#origin-connection-timeout\">Origin Connection Timeout</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "number"
+        },
+        "OriginShield": {
+          "description": "<p>CloudFront Origin Shield. Using Origin Shield can help reduce the load on your\n\t\t\torigin.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html\">Using Origin Shield</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>",
+          "$ref": "#/definitions/OriginShield"
+        },
+        "OriginAccessControlId": {
+          "description": "<p>The unique identifier of an origin access control for this origin.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html\">Restricting access to an Amazon S3 origin</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "DomainName",
+        "Id"
+      ]
+    },
+    "CustomHeaders": {
+      "description": "<p>A complex type that contains the list of Custom Headers for each origin.</p>",
+      "type": "object",
+      "properties": {
+        "Quantity": {
+          "description": "<p>The number of custom headers, if any, for this distribution.</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>\n            <b>Optional</b>: A list that contains one\n\t\t\t\t<code>OriginCustomHeader</code> element for each custom header that you want CloudFront to\n\t\t\tforward to the origin. If Quantity is <code>0</code>, omit <code>Items</code>.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OriginCustomHeader"
+          }
+        }
+      },
+      "required": [
+        "Quantity"
+      ]
+    },
+    "OriginCustomHeader": {
+      "description": "<p>A complex type that contains <code>HeaderName</code> and <code>HeaderValue</code>\n\t\t\telements, if any, for this distribution.</p>",
+      "type": "object",
+      "properties": {
+        "HeaderName": {
+          "description": "<p>The name of a header that you want CloudFront to send to your origin. For more information,\n\t\t\tsee <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/forward-custom-headers.html\">Adding\n\t\t\t\tCustom Headers to Origin Requests</a> in the <i>\n\t\t\t\tAmazon CloudFront Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "HeaderValue": {
+          "description": "<p>The value for the header that you specified in the <code>HeaderName</code>\n\t\t\tfield.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "HeaderName",
+        "HeaderValue"
+      ]
+    },
+    "S3OriginConfig": {
+      "description": "<p>A complex type that contains information about the Amazon S3 origin. If the origin is a\n\t\t\tcustom origin or an S3 bucket that is configured as a website endpoint, use the\n\t\t\t\t<code>CustomOriginConfig</code> element instead.</p>",
+      "type": "object",
+      "properties": {
+        "OriginAccessIdentity": {
+          "description": "<note>\n            <p>If you're using origin access control (OAC) instead of origin access identity,\n\t\t\t\tspecify an empty <code>OriginAccessIdentity</code> element. For more information,\n\t\t\t\tsee <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-origin.html\">Restricting access to an Amazon Web Services</a> in the\n\t\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>\n         </note>\n         <p>The CloudFront origin access identity to associate with the origin. Use an origin access\n\t\t\tidentity to configure the origin so that viewers can <i>only</i> access\n\t\t\tobjects in an Amazon S3 bucket through CloudFront. The format of the value is:</p>\n         <p>\n            <code>origin-access-identity/cloudfront/ID-of-origin-access-identity</code>\n         </p>\n         <p>The <code>\n               <i>ID-of-origin-access-identity</i>\n            </code> is the value that CloudFront\n\t\t\treturned in the <code>ID</code> element when you created the origin access\n\t\t\tidentity.</p>\n         <p>If you want viewers to be able to access objects using either the CloudFront URL or the Amazon S3\n\t\t\tURL, specify an empty <code>OriginAccessIdentity</code> element.</p>\n         <p>To delete the origin access identity from an existing distribution, update the\n\t\t\tdistribution configuration and include an empty <code>OriginAccessIdentity</code>\n\t\t\telement.</p>\n         <p>To replace the origin access identity, update the distribution configuration and\n\t\t\tspecify the new origin access identity.</p>\n         <p>For more information about the origin access identity, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html\">Serving Private\n\t\t\t\tContent through CloudFront</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "OriginAccessIdentity"
+      ]
+    },
+    "CustomOriginConfig": {
+      "description": "<p>A custom origin. A custom origin is any origin that is <i>not</i> an\n\t\t\tAmazon S3 bucket, with one exception. An Amazon S3 bucket that is <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html\">configured with\n\t\t\t\tstatic website hosting</a>\n            <i>is</i> a custom origin.</p>",
+      "type": "object",
+      "properties": {
+        "HTTPPort": {
+          "description": "<p>The HTTP port that CloudFront uses to connect to the origin. Specify the HTTP port that the\n\t\t\torigin listens on.</p>",
+          "type": "number"
+        },
+        "HTTPSPort": {
+          "description": "<p>The HTTPS port that CloudFront uses to connect to the origin. Specify the HTTPS port that\n\t\t\tthe origin listens on.</p>",
+          "type": "number"
+        },
+        "OriginProtocolPolicy": {
+          "description": "<p>Specifies the protocol (HTTP or HTTPS) that CloudFront uses to connect to the origin. Valid\n\t\t\tvalues are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>http-only</code> – CloudFront always uses HTTP to connect to the\n\t\t\t\t\torigin.</p>\n            </li>\n            <li>\n               <p>\n                  <code>match-viewer</code> – CloudFront connects to the origin using the same\n\t\t\t\t\tprotocol that the viewer used to connect to CloudFront.</p>\n            </li>\n            <li>\n               <p>\n                  <code>https-only</code> – CloudFront always uses HTTPS to connect to the\n\t\t\t\t\torigin.</p>\n            </li>\n         </ul>",
+          "enum": [
+            "http-only",
+            "https-only",
+            "match-viewer"
+          ],
+          "type": "string"
+        },
+        "OriginSslProtocols": {
+          "description": "<p>Specifies the minimum SSL/TLS protocol that CloudFront uses when connecting to your origin\n\t\t\tover HTTPS. Valid values include <code>SSLv3</code>, <code>TLSv1</code>,\n\t\t\t\t<code>TLSv1.1</code>, and <code>TLSv1.2</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesOriginSSLProtocols\">Minimum Origin SSL Protocol</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "$ref": "#/definitions/OriginSslProtocols"
+        },
+        "OriginReadTimeout": {
+          "description": "<p>Specifies how long, in seconds, CloudFront waits for a response from the origin. This is\n\t\t\talso known as the <i>origin response timeout</i>. The minimum timeout is 1\n\t\t\tsecond, the maximum is 60 seconds, and the default (if you don't specify otherwise) is\n\t\t\t30 seconds.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesOriginResponseTimeout\">Origin Response Timeout</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "number"
+        },
+        "OriginKeepaliveTimeout": {
+          "description": "<p>Specifies how long, in seconds, CloudFront persists its connection to the origin. The\n\t\t\tminimum timeout is 1 second, the maximum is 60 seconds, and the default (if you don't\n\t\t\tspecify otherwise) is 5 seconds.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesOriginKeepaliveTimeout\">Origin Keep-alive Timeout</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "number"
+        }
+      },
+      "required": [
+        "HTTPPort",
+        "HTTPSPort",
+        "OriginProtocolPolicy"
+      ]
+    },
+    "OriginSslProtocols": {
+      "description": "<p>A complex type that contains information about the SSL/TLS protocols that CloudFront can use\n\t\t\twhen establishing an HTTPS connection with your origin.</p>",
+      "type": "object",
+      "properties": {
+        "Quantity": {
+          "description": "<p>The number of SSL/TLS protocols that you want to allow CloudFront to use when establishing\n\t\t\tan HTTPS connection with this origin.</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>A list that contains allowed SSL/TLS protocols for this distribution.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SslProtocol"
+          }
+        }
+      },
+      "required": [
+        "Items",
+        "Quantity"
+      ]
+    },
+    "SslProtocol": {
+      "enum": [
+        "SSLv3",
+        "TLSv1",
+        "TLSv1.1",
+        "TLSv1.2"
+      ],
+      "type": "string"
+    },
+    "OriginShield": {
+      "description": "<p>CloudFront Origin Shield.</p>\n         <p>Using Origin Shield can help reduce the load on your origin. For more information, see\n\t\t\t\t<a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html\">Using Origin Shield</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "Enabled": {
+          "description": "<p>A flag that specifies whether Origin Shield is enabled.</p>\n         <p>When it's enabled, CloudFront routes all requests through Origin Shield, which can help\n\t\t\tprotect your origin. When it's disabled, CloudFront might send requests directly to your\n\t\t\torigin from multiple edge locations or regional edge caches.</p>",
+          "type": "boolean"
+        },
+        "OriginShieldRegion": {
+          "description": "<p>The Amazon Web Services Region for Origin Shield.</p>\n         <p>Specify the Amazon Web Services Region that has the lowest latency to your origin. To specify a\n\t\t\tregion, use the region code, not the region name. For example, specify the US East\n\t\t\t(Ohio) region as <code>us-east-2</code>.</p>\n         <p>When you enable CloudFront Origin Shield, you must specify the Amazon Web Services Region for Origin\n\t\t\tShield. For the list of Amazon Web Services Regions that you can specify, and for help choosing the\n\t\t\tbest Region for your origin, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html#choose-origin-shield-region\">Choosing the Amazon Web Services Region for Origin Shield</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Enabled"
+      ]
+    },
+    "OriginGroups": {
+      "description": "<p>A complex data type for the origin groups specified for a distribution.</p>",
+      "type": "object",
+      "properties": {
+        "Quantity": {
+          "description": "<p>The number of origin groups.</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>The items (origin groups) in a distribution.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OriginGroup"
+          }
+        }
+      },
+      "required": [
+        "Quantity"
+      ]
+    },
+    "OriginGroup": {
+      "description": "<p>An origin group includes two origins (a primary origin and a second origin to failover to)\n\t\t\tand a failover criteria that you specify. You create an origin group to support origin\n\t\t\tfailover in  CloudFront. When you create or update a distribution, you can specify the\n\t\t\torigin group instead of a single origin, and CloudFront will failover from the primary\n\t\t\torigin to the second origin under the failover conditions that you've chosen.</p>",
+      "type": "object",
+      "properties": {
+        "Id": {
+          "description": "<p>The origin group's ID.</p>",
+          "type": "string"
+        },
+        "FailoverCriteria": {
+          "description": "<p>A complex type that contains information about the failover criteria for an origin\n\t\t\tgroup.</p>",
+          "$ref": "#/definitions/OriginGroupFailoverCriteria"
+        },
+        "Members": {
+          "description": "<p>A complex type that contains information about the origins in an origin group.</p>",
+          "$ref": "#/definitions/OriginGroupMembers"
+        }
+      },
+      "required": [
+        "FailoverCriteria",
+        "Id",
+        "Members"
+      ]
+    },
+    "OriginGroupFailoverCriteria": {
+      "description": "<p>A complex data type that includes information about the failover criteria for an\n\t\t\torigin group, including the status codes for which CloudFront will failover from the\n\t\t\tprimary origin to the second origin.</p>",
+      "type": "object",
+      "properties": {
+        "StatusCodes": {
+          "description": "<p>The status codes that, when returned from the primary origin, will trigger CloudFront to failover to the second origin.</p>",
+          "$ref": "#/definitions/StatusCodes"
+        }
+      },
+      "required": [
+        "StatusCodes"
+      ]
+    },
+    "StatusCodes": {
+      "description": "<p>A complex data type for the status codes that you specify that, when returned by a\n\t\t\tprimary origin, trigger CloudFront to failover to a second origin.</p>",
+      "type": "object",
+      "properties": {
+        "Quantity": {
+          "description": "<p>The number of status codes.</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>The items (status codes) for an origin group.</p>",
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        }
+      },
+      "required": [
+        "Items",
+        "Quantity"
+      ]
+    },
+    "OriginGroupMembers": {
+      "description": "<p>A complex data type for the origins included in an origin group.</p>",
+      "type": "object",
+      "properties": {
+        "Quantity": {
+          "description": "<p>The number of origins in an origin group.</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>Items (origins) in an origin group.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OriginGroupMember"
+          }
+        }
+      },
+      "required": [
+        "Items",
+        "Quantity"
+      ]
+    },
+    "OriginGroupMember": {
+      "description": "<p>An origin in an origin group.</p>",
+      "type": "object",
+      "properties": {
+        "OriginId": {
+          "description": "<p>The ID for an origin in an origin group.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "OriginId"
+      ]
+    },
+    "DefaultCacheBehavior": {
+      "description": "<p>A complex type that describes the default cache behavior if you don't specify a\n\t\t\t\t<code>CacheBehavior</code> element or if request URLs don't match any of the values\n\t\t\tof <code>PathPattern</code> in <code>CacheBehavior</code> elements. You must create\n\t\t\texactly one default cache behavior.</p>",
+      "type": "object",
+      "properties": {
+        "TargetOriginId": {
+          "description": "<p>The value of <code>ID</code> for the origin that you want CloudFront to route requests to\n\t\t\twhen they use the default cache behavior.</p>",
+          "type": "string"
+        },
+        "TrustedSigners": {
+          "description": "<important>\n            <p>We recommend using <code>TrustedKeyGroups</code> instead of\n\t\t\t\t\t<code>TrustedSigners</code>.</p>\n         </important>\n         <p>A list of Amazon Web Services account IDs whose public keys CloudFront can use to validate signed URLs or\n\t\t\tsigned cookies.</p>\n         <p>When a cache behavior contains trusted signers, CloudFront requires signed URLs or signed\n\t\t\tcookies for all requests that match the cache behavior. The URLs or cookies must be\n\t\t\tsigned with the private key of a CloudFront key pair in a trusted signer's Amazon Web Services account. The\n\t\t\tsigned URL or cookie contains information about which public key CloudFront should use to\n\t\t\tverify the signature. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html\">Serving private content</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "$ref": "#/definitions/TrustedSigners"
+        },
+        "TrustedKeyGroups": {
+          "description": "<p>A list of key groups that CloudFront can use to validate signed URLs or signed\n\t\t\tcookies.</p>\n         <p>When a cache behavior contains trusted key groups, CloudFront requires signed URLs or signed\n\t\t\tcookies for all requests that match the cache behavior. The URLs or cookies must be\n\t\t\tsigned with a private key whose corresponding public key is in the key group. The signed\n\t\t\tURL or cookie contains information about which public key CloudFront should use to verify the\n\t\t\tsignature. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html\">Serving private content</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "$ref": "#/definitions/TrustedKeyGroups"
+        },
+        "ViewerProtocolPolicy": {
+          "description": "<p>The protocol that viewers can use to access the files in the origin specified by\n\t\t\t\t<code>TargetOriginId</code> when a request matches the path pattern in\n\t\t\t\t<code>PathPattern</code>. You can specify the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>allow-all</code>: Viewers can use HTTP or HTTPS.</p>\n            </li>\n            <li>\n               <p>\n                  <code>redirect-to-https</code>: If a viewer submits an HTTP request, CloudFront\n\t\t\t\t\treturns an HTTP status code of 301 (Moved Permanently) to the viewer along with\n\t\t\t\t\tthe HTTPS URL. The viewer then resubmits the request using the new URL.</p>\n            </li>\n            <li>\n               <p>\n                  <code>https-only</code>: If a viewer sends an HTTP request, CloudFront returns an\n\t\t\t\t\tHTTP status code of 403 (Forbidden).</p>\n            </li>\n         </ul>\n         <p>For more information about requiring the HTTPS protocol, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-https-viewers-to-cloudfront.html\">Requiring HTTPS Between Viewers and  CloudFront</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>\n         <note>\n            <p>The only way to guarantee that viewers retrieve an object that was fetched from\n\t\t\t\tthe origin using HTTPS is never to use any other protocol to fetch the object. If\n\t\t\t\tyou have recently changed from HTTP to HTTPS, we recommend that you clear your\n\t\t\t\tobjects' cache because cached objects are protocol agnostic. That means that an edge\n\t\t\t\tlocation will return an object from the cache regardless of whether the current\n\t\t\t\trequest protocol matches the protocol used previously. For more information, see\n\t\t\t\t\t<a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html\">Managing Cache\n\t\t\t\t\tExpiration</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>\n         </note>",
+          "enum": [
+            "allow-all",
+            "https-only",
+            "redirect-to-https"
+          ],
+          "type": "string"
+        },
+        "AllowedMethods": {
+          "description": "<p>A complex type that controls which HTTP methods CloudFront processes and forwards to your\n\t\t\tAmazon S3 bucket or your custom origin. There are three choices:</p>\n         <ul>\n            <li>\n               <p>CloudFront forwards only <code>GET</code> and <code>HEAD</code> requests.</p>\n            </li>\n            <li>\n               <p>CloudFront forwards only <code>GET</code>, <code>HEAD</code>, and\n\t\t\t\t\t\t<code>OPTIONS</code> requests.</p>\n            </li>\n            <li>\n               <p>CloudFront forwards <code>GET, HEAD, OPTIONS, PUT, PATCH, POST</code>, and\n\t\t\t\t\t\t<code>DELETE</code> requests.</p>\n            </li>\n         </ul>\n         <p>If you pick the third choice, you may need to restrict access to your Amazon S3 bucket or\n\t\t\tto your custom origin so users can't perform operations that you don't want them to. For\n\t\t\texample, you might not want users to have permissions to delete objects from your\n\t\t\torigin.</p>",
+          "$ref": "#/definitions/AllowedMethods"
+        },
+        "SmoothStreaming": {
+          "description": "<p>Indicates whether you want to distribute media files in the Microsoft Smooth Streaming\n\t\t\tformat using the origin that is associated with this cache behavior. If so, specify\n\t\t\t\t<code>true</code>; if not, specify <code>false</code>. If you specify\n\t\t\t\t<code>true</code> for <code>SmoothStreaming</code>, you can still distribute other\n\t\t\tcontent using this cache behavior if the content matches the value of\n\t\t\t\t<code>PathPattern</code>.</p>",
+          "type": "boolean"
+        },
+        "Compress": {
+          "description": "<p>Whether you want CloudFront to automatically compress certain files for this cache behavior.\n\t\t\tIf so, specify <code>true</code>; if not, specify <code>false</code>. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html\">Serving\n\t\t\t\tCompressed Files</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "boolean"
+        },
+        "LambdaFunctionAssociations": {
+          "description": "<p>A complex type that contains zero or more Lambda@Edge function associations for a\n\t\t\tcache behavior.</p>",
+          "$ref": "#/definitions/LambdaFunctionAssociations"
+        },
+        "FunctionAssociations": {
+          "description": "<p>A list of CloudFront functions that are associated with this cache behavior. Your functions\n\t\t\tmust be published to the <code>LIVE</code> stage to associate them with a cache\n\t\t\tbehavior.</p>",
+          "$ref": "#/definitions/FunctionAssociations"
+        },
+        "FieldLevelEncryptionId": {
+          "description": "<p>The value of <code>ID</code> for the field-level encryption configuration that you\n\t\t\twant CloudFront to use for encrypting specific fields of data for the default cache\n\t\t\tbehavior.</p>",
+          "type": "string"
+        },
+        "RealtimeLogConfigArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the real-time log configuration that is attached to\n\t\t\tthis cache behavior. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/real-time-logs.html\">Real-time logs</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "CachePolicyId": {
+          "description": "<p>The unique identifier of the cache policy that is attached to the default cache\n\t\t\tbehavior. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy\">Creating cache policies</a> or <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html\">Using the managed cache policies</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>A <code>DefaultCacheBehavior</code> must include either a <code>CachePolicyId</code>\n\t\t\tor <code>ForwardedValues</code>. We recommend that you use a\n\t\t\t<code>CachePolicyId</code>.</p>",
+          "type": "string"
+        },
+        "OriginRequestPolicyId": {
+          "description": "<p>The unique identifier of the origin request policy that is attached to the default\n\t\t\tcache behavior. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy\">Creating origin request policies</a> or <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html\">Using the managed origin request policies</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "ResponseHeadersPolicyId": {
+          "description": "<p>The identifier for a response headers policy.</p>",
+          "type": "string"
+        },
+        "ForwardedValues": {
+          "description": "<p>This field is deprecated. We recommend that you use a cache policy or an origin\n\t\t\trequest policy instead of this field.</p>\n         <p>If you want to include values in the cache key, use a cache policy. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy\">Creating cache policies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>If you want to send values to the origin but not include them in the cache key, use an\n\t\t\torigin request policy. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy\">Creating origin request policies</a> in the\n\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>A complex type that specifies how CloudFront handles query strings, cookies, and HTTP\n\t\t\theaders.</p>",
+          "$ref": "#/definitions/ForwardedValues"
+        },
+        "MinTTL": {
+          "type": "number"
+        },
+        "DefaultTTL": {
+          "type": "number"
+        },
+        "MaxTTL": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "TargetOriginId",
+        "ViewerProtocolPolicy"
+      ]
+    },
+    "TrustedSigners": {
+      "description": "<p>A list of Amazon Web Services accounts whose public keys CloudFront can use to verify the signatures of\n\t\t\tsigned URLs and signed cookies.</p>",
+      "type": "object",
+      "properties": {
+        "Enabled": {
+          "description": "<p>This field is <code>true</code> if any of the Amazon Web Services accounts in the list are configured as\n\t\t\ttrusted signers. If not, this field is <code>false</code>.</p>",
+          "type": "boolean"
+        },
+        "Quantity": {
+          "description": "<p>The number of Amazon Web Services accounts in the list.</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>A list of Amazon Web Services account identifiers.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "Enabled",
+        "Quantity"
+      ]
+    },
+    "TrustedKeyGroups": {
+      "description": "<p>A list of key groups whose public keys CloudFront can use to verify the signatures of signed\n\t\t\tURLs and signed cookies.</p>",
+      "type": "object",
+      "properties": {
+        "Enabled": {
+          "description": "<p>This field is <code>true</code> if any of the key groups in the list have public keys\n\t\t\tthat CloudFront can use to verify the signatures of signed URLs and signed cookies. If not,\n\t\t\tthis field is <code>false</code>.</p>",
+          "type": "boolean"
+        },
+        "Quantity": {
+          "description": "<p>The number of key groups in the list.</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>A list of key groups identifiers.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "Enabled",
+        "Quantity"
+      ]
+    },
+    "AllowedMethods": {
+      "description": "<p>A complex type that controls which HTTP methods CloudFront processes and forwards to your\n\t\t\tAmazon S3 bucket or your custom origin. There are three choices:</p>\n         <ul>\n            <li>\n               <p>CloudFront forwards only <code>GET</code> and <code>HEAD</code> requests.</p>\n            </li>\n            <li>\n               <p>CloudFront forwards only <code>GET</code>, <code>HEAD</code>, and\n\t\t\t\t\t\t<code>OPTIONS</code> requests.</p>\n            </li>\n            <li>\n               <p>CloudFront forwards <code>GET, HEAD, OPTIONS, PUT, PATCH, POST</code>, and\n\t\t\t\t\t\t<code>DELETE</code> requests.</p>\n            </li>\n         </ul>\n         <p>If you pick the third choice, you may need to restrict access to your Amazon S3 bucket or\n\t\t\tto your custom origin so users can't perform operations that you don't want them to. For\n\t\t\texample, you might not want users to have permissions to delete objects from your\n\t\t\torigin.</p>",
+      "type": "object",
+      "properties": {
+        "Quantity": {
+          "description": "<p>The number of HTTP methods that you want CloudFront to forward to your origin. Valid values\n\t\t\tare 2 (for <code>GET</code> and <code>HEAD</code> requests), 3 (for <code>GET</code>,\n\t\t\t\t<code>HEAD</code>, and <code>OPTIONS</code> requests) and 7 (for <code>GET, HEAD,\n\t\t\t\tOPTIONS, PUT, PATCH, POST</code>, and <code>DELETE</code> requests).</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>A complex type that contains the HTTP methods that you want CloudFront to process and\n\t\t\tforward to your origin.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Method"
+          }
+        },
+        "CachedMethods": {
+          "description": "<p>A complex type that controls whether CloudFront caches the response to requests using the\n\t\t\tspecified HTTP methods. There are two choices:</p>\n         <ul>\n            <li>\n               <p>CloudFront caches responses to <code>GET</code> and <code>HEAD</code>\n\t\t\t\t\trequests.</p>\n            </li>\n            <li>\n               <p>CloudFront caches responses to <code>GET</code>, <code>HEAD</code>, and\n\t\t\t\t\t\t<code>OPTIONS</code> requests.</p>\n            </li>\n         </ul>\n         <p>If you pick the second choice for your Amazon S3 Origin, you may need to forward\n\t\t\tAccess-Control-Request-Method, Access-Control-Request-Headers, and Origin headers for\n\t\t\tthe responses to be cached correctly.</p>",
+          "$ref": "#/definitions/CachedMethods"
+        }
+      },
+      "required": [
+        "Items",
+        "Quantity"
+      ]
+    },
+    "Method": {
+      "enum": [
+        "DELETE",
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PATCH",
+        "POST",
+        "PUT"
+      ],
+      "type": "string"
+    },
+    "CachedMethods": {
+      "description": "<p>A complex type that controls whether CloudFront caches the response to requests using the\n\t\t\tspecified HTTP methods. There are two choices:</p>\n         <ul>\n            <li>\n               <p>CloudFront caches responses to <code>GET</code> and <code>HEAD</code>\n\t\t\t\t\trequests.</p>\n            </li>\n            <li>\n               <p>CloudFront caches responses to <code>GET</code>, <code>HEAD</code>, and\n\t\t\t\t\t\t<code>OPTIONS</code> requests.</p>\n            </li>\n         </ul>\n         <p>If you pick the second choice for your Amazon S3 Origin, you may need to forward\n\t\t\tAccess-Control-Request-Method, Access-Control-Request-Headers, and Origin headers for\n\t\t\tthe responses to be cached correctly.</p>",
+      "type": "object",
+      "properties": {
+        "Quantity": {
+          "description": "<p>The number of HTTP methods for which you want CloudFront to cache responses. Valid values\n\t\t\tare <code>2</code> (for caching responses to <code>GET</code> and <code>HEAD</code>\n\t\t\trequests) and <code>3</code> (for caching responses to <code>GET</code>,\n\t\t\t\t<code>HEAD</code>, and <code>OPTIONS</code> requests).</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>A complex type that contains the HTTP methods that you want CloudFront to cache responses\n\t\t\tto. Valid values for <code>CachedMethods</code> include <code>GET</code>, <code>HEAD</code>, and <code>OPTIONS</code>, depending on which caching option you choose. For more information, see the preceding section.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Method"
+          }
+        }
+      },
+      "required": [
+        "Items",
+        "Quantity"
+      ]
+    },
+    "LambdaFunctionAssociations": {
+      "description": "<p>A complex type that specifies a list of Lambda@Edge functions associations for a cache\n\t\t\tbehavior.</p>\n         <p>If you want to invoke one or more Lambda@Edge functions triggered by requests that\n\t\t\tmatch the <code>PathPattern</code> of the cache behavior, specify the applicable values\n\t\t\tfor <code>Quantity</code> and <code>Items</code>. Note that there can be up to 4\n\t\t\t\t<code>LambdaFunctionAssociation</code> items in this list (one for each possible\n\t\t\tvalue of <code>EventType</code>) and each <code>EventType</code> can be associated with\n\t\t\tonly one function.</p>\n         <p>If you don't want to invoke any Lambda@Edge functions for the requests that match\n\t\t\t\t<code>PathPattern</code>, specify <code>0</code> for <code>Quantity</code> and omit\n\t\t\t\t<code>Items</code>.</p>",
+      "type": "object",
+      "properties": {
+        "Quantity": {
+          "description": "<p>The number of Lambda@Edge function associations for this cache behavior.</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>\n            <b>Optional</b>: A complex type that contains\n\t\t\t\t<code>LambdaFunctionAssociation</code> items for this cache behavior. If\n\t\t\t\t<code>Quantity</code> is <code>0</code>, you can omit <code>Items</code>.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LambdaFunctionAssociation"
+          }
+        }
+      },
+      "required": [
+        "Quantity"
+      ]
+    },
+    "LambdaFunctionAssociation": {
+      "description": "<p>A complex type that contains a Lambda@Edge function association.</p>",
+      "type": "object",
+      "properties": {
+        "LambdaFunctionARN": {
+          "description": "<p>The ARN of the Lambda@Edge function. You must specify the ARN of a function version;\n\t\t\tyou can't specify an alias or $LATEST.</p>",
+          "type": "string"
+        },
+        "EventType": {
+          "description": "<p>Specifies the event type that triggers a Lambda@Edge function invocation. You can\n\t\t\tspecify the following values:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>viewer-request</code>: The function executes when CloudFront receives a\n\t\t\t\t\trequest from a viewer and before it checks to see whether the requested object\n\t\t\t\t\tis in the edge cache.</p>\n            </li>\n            <li>\n               <p>\n                  <code>origin-request</code>: The function executes only when CloudFront sends a\n\t\t\t\t\trequest to your origin. When the requested object is in the edge cache, the\n\t\t\t\t\tfunction doesn't execute.</p>\n            </li>\n            <li>\n               <p>\n                  <code>origin-response</code>: The function executes after CloudFront receives a\n\t\t\t\t\tresponse from the origin and before it caches the object in the response. When\n\t\t\t\t\tthe requested object is in the edge cache, the function doesn't execute.</p>\n            </li>\n            <li>\n               <p>\n                  <code>viewer-response</code>: The function executes before CloudFront returns the\n\t\t\t\t\trequested object to the viewer. The function executes regardless of whether the\n\t\t\t\t\tobject was already in the edge cache.</p>\n               <p>If the origin returns an HTTP status code other than HTTP 200 (OK), the\n\t\t\t\t\tfunction doesn't execute.</p>\n            </li>\n         </ul>",
+          "enum": [
+            "origin-request",
+            "origin-response",
+            "viewer-request",
+            "viewer-response"
+          ],
+          "type": "string"
+        },
+        "IncludeBody": {
+          "description": "<p>A flag that allows a Lambda@Edge function to have read access to the body content. For\n\t\t\tmore information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-include-body-access.html\">Accessing the Request Body by Choosing the Include Body Option</a> in the\n\t\t\tAmazon CloudFront Developer Guide.</p>",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "EventType",
+        "LambdaFunctionARN"
+      ]
+    },
+    "FunctionAssociations": {
+      "description": "<p>A list of CloudFront functions that are associated with a cache behavior in a CloudFront\n\t\t\tdistribution. Your functions must be published to the <code>LIVE</code> stage to\n\t\t\tassociate them with a cache behavior.</p>",
+      "type": "object",
+      "properties": {
+        "Quantity": {
+          "description": "<p>The number of CloudFront functions in the list.</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>The CloudFront functions that are associated with a cache behavior in a CloudFront distribution.\n\t\t\tYour functions must be published to the <code>LIVE</code> stage to associate them with a\n\t\t\tcache behavior.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FunctionAssociation"
+          }
+        }
+      },
+      "required": [
+        "Quantity"
+      ]
+    },
+    "FunctionAssociation": {
+      "description": "<p>A CloudFront function that is associated with a cache behavior in a CloudFront\n\t\t\tdistribution.</p>",
+      "type": "object",
+      "properties": {
+        "FunctionARN": {
+          "description": "<p>The Amazon Resource Name (ARN) of the function.</p>",
+          "type": "string"
+        },
+        "EventType": {
+          "description": "<p>The event type of the function, either <code>viewer-request</code> or\n\t\t\t\t<code>viewer-response</code>. You cannot use origin-facing event types\n\t\t\t\t(<code>origin-request</code> and <code>origin-response</code>) with a CloudFront\n\t\t\tfunction.</p>",
+          "enum": [
+            "origin-request",
+            "origin-response",
+            "viewer-request",
+            "viewer-response"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "EventType",
+        "FunctionARN"
+      ]
+    },
+    "ForwardedValues": {
+      "description": "<p>This field is deprecated. We recommend that you use a cache policy or an origin\n\t\t\trequest policy instead of this field.</p>\n         <p>If you want to include values in the cache key, use a cache policy. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy\">Creating cache policies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>If you want to send values to the origin but not include them in the cache key, use an\n\t\t\torigin request policy. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy\">Creating origin request policies</a> in the\n\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>A complex type that specifies how CloudFront handles query strings, cookies, and HTTP\n\t\t\theaders.</p>",
+      "type": "object",
+      "properties": {
+        "QueryString": {
+          "description": "<p>This field is deprecated. We recommend that you use a cache policy or an origin\n\t\t\trequest policy instead of this field.</p>\n         <p>If you want to include query strings in the cache key, use a cache policy. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy\">Creating cache policies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>If you want to send query strings to the origin but not include them in the cache key,\n\t\t\tuse an origin request policy. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy\">Creating origin request policies</a> in the\n\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>Indicates whether you want CloudFront to forward query strings to the origin that is\n\t\t\tassociated with this cache behavior and cache based on the query string parameters. CloudFront\n\t\t\tbehavior depends on the value of <code>QueryString</code> and on the values that you\n\t\t\tspecify for <code>QueryStringCacheKeys</code>, if any:</p>\n         <p>If you specify true for <code>QueryString</code> and you don't specify any values for\n\t\t\t\t<code>QueryStringCacheKeys</code>, CloudFront forwards all query string parameters to the\n\t\t\torigin and caches based on all query string parameters. Depending on how many query\n\t\t\tstring parameters and values you have, this can adversely affect performance because\n\t\t\tCloudFront must forward more requests to the origin.</p>\n         <p>If you specify true for <code>QueryString</code> and you specify one or more values\n\t\t\tfor <code>QueryStringCacheKeys</code>, CloudFront forwards all query string parameters to the\n\t\t\torigin, but it only caches based on the query string parameters that you specify.</p>\n         <p>If you specify false for <code>QueryString</code>, CloudFront doesn't forward any query\n\t\t\tstring parameters to the origin, and doesn't cache based on query string\n\t\t\tparameters.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/QueryStringParameters.html\">Configuring\n\t\t\t\tCloudFront to Cache Based on Query String Parameters</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "boolean"
+        },
+        "Cookies": {
+          "description": "<p>This field is deprecated. We recommend that you use a cache policy or an origin\n\t\t\trequest policy instead of this field.</p>\n         <p>If you want to include cookies in the cache key, use a cache policy. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy\">Creating cache policies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>If you want to send cookies to the origin but not include them in the cache key, use\n\t\t\tan origin request policy. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy\">Creating origin request policies</a> in the\n\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>A complex type that specifies whether you want CloudFront to forward cookies to the origin\n\t\t\tand, if so, which ones. For more information about forwarding cookies to the origin, see\n\t\t\t\t<a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html\">How CloudFront Forwards, Caches,\n\t\t\t\tand Logs Cookies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>",
+          "$ref": "#/definitions/CookiePreference"
+        },
+        "Headers": {
+          "description": "<p>This field is deprecated. We recommend that you use a cache policy or an origin\n\t\t\trequest policy instead of this field.</p>\n         <p>If you want to include headers in the cache key, use a cache policy. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy\">Creating cache policies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>If you want to send headers to the origin but not include them in the cache key, use\n\t\t\tan origin request policy. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy\">Creating origin request policies</a> in the\n\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>A complex type that specifies the <code>Headers</code>, if any, that you want CloudFront to\n\t\t\tforward to the origin for this cache behavior (whitelisted headers). For the headers\n\t\t\tthat you specify, CloudFront also caches separate versions of a specified object that is based\n\t\t\ton the header values in viewer requests.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/header-caching.html\"> Caching Content\n\t\t\t\tBased on Request Headers</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>",
+          "$ref": "#/definitions/Headers"
+        },
+        "QueryStringCacheKeys": {
+          "description": "<p>This field is deprecated. We recommend that you use a cache policy or an origin\n\t\t\trequest policy instead of this field.</p>\n         <p>If you want to include query strings in the cache key, use a cache policy. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy\">Creating cache policies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>If you want to send query strings to the origin but not include them in the cache key,\n\t\t\tuse an origin request policy. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy\">Creating origin request policies</a> in the\n\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>A complex type that contains information about the query string parameters that you\n\t\t\twant CloudFront to use for caching for this cache behavior.</p>",
+          "$ref": "#/definitions/QueryStringCacheKeys"
+        }
+      },
+      "required": [
+        "Cookies",
+        "QueryString"
+      ]
+    },
+    "CookiePreference": {
+      "description": "<p>This field is deprecated. We recommend that you use a cache policy or an origin\n\t\t\trequest policy instead of this field.</p>\n         <p>If you want to include cookies in the cache key, use <code>CookiesConfig</code> in a\n\t\t\tcache policy. See <code>CachePolicy</code>.</p>\n         <p>If you want to send cookies to the origin but not include them in the cache key, use\n\t\t\t\t<code>CookiesConfig</code> in an origin request policy. See\n\t\t\t\t<code>OriginRequestPolicy</code>.</p>\n         <p>A complex type that specifies whether you want CloudFront to forward cookies to the origin\n\t\t\tand, if so, which ones. For more information about forwarding cookies to the origin, see\n\t\t\t\t<a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html\">Caching Content Based on\n\t\t\t\tCookies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "Forward": {
+          "description": "<p>This field is deprecated. We recommend that you use a cache policy or an origin\n\t\t\trequest policy instead of this field.</p>\n         <p>If you want to include cookies in the cache key, use a cache policy. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy\">Creating cache policies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>If you want to send cookies to the origin but not include them in the cache key, use\n\t\t\torigin request policy. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy\">Creating origin request policies</a> in the\n\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>Specifies which cookies to forward to the origin for this cache behavior: all, none,\n\t\t\tor the list of cookies specified in the <code>WhitelistedNames</code> complex\n\t\t\ttype.</p>\n         <p>Amazon S3 doesn't process cookies. When the cache behavior is forwarding requests to an\n\t\t\tAmazon S3 origin, specify none for the <code>Forward</code> element.</p>",
+          "enum": [
+            "all",
+            "none",
+            "whitelist"
+          ],
+          "type": "string"
+        },
+        "WhitelistedNames": {
+          "description": "<p>This field is deprecated. We recommend that you use a cache policy or an origin\n\t\t\trequest policy instead of this field.</p>\n         <p>If you want to include cookies in the cache key, use a cache policy. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy\">Creating cache policies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>If you want to send cookies to the origin but not include them in the cache key, use\n\t\t\tan origin request policy. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy\">Creating origin request policies</a> in the\n\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>Required if you specify <code>whitelist</code> for the value of <code>Forward</code>.\n\t\t\tA complex type that specifies how many different cookies you want CloudFront to forward to the\n\t\t\torigin for this cache behavior and, if you want to forward selected cookies, the names\n\t\t\tof those cookies.</p>\n         <p>If you specify <code>all</code> or <code>none</code> for the value of\n\t\t\t\t<code>Forward</code>, omit <code>WhitelistedNames</code>. If you change the value of\n\t\t\t\t<code>Forward</code> from <code>whitelist</code> to <code>all</code> or\n\t\t\t\t<code>none</code> and you don't delete the <code>WhitelistedNames</code> element and\n\t\t\tits child elements, CloudFront deletes them automatically.</p>\n         <p>For the current limit on the number of cookie names that you can whitelist for each\n\t\t\tcache behavior, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/xrefaws_service_limits.html#limits_cloudfront\"> CloudFront\n\t\t\t\tLimits</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+          "$ref": "#/definitions/CookieNames"
+        }
+      },
+      "required": [
+        "Forward"
+      ]
+    },
+    "CookieNames": {
+      "description": "<p>Contains a list of cookie names.</p>",
+      "type": "object",
+      "properties": {
+        "Quantity": {
+          "description": "<p>The number of cookie names in the <code>Items</code> list.</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>A list of cookie names.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "Quantity"
+      ]
+    },
+    "Headers": {
+      "description": "<p>Contains a list of HTTP header names.</p>",
+      "type": "object",
+      "properties": {
+        "Quantity": {
+          "description": "<p>The number of header names in the <code>Items</code> list.</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>A list of HTTP header names.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "Quantity"
+      ]
+    },
+    "QueryStringCacheKeys": {
+      "description": "<p>This field is deprecated. We recommend that you use a cache policy or an origin\n\t\t\trequest policy instead of this field.</p>\n         <p>If you want to include query strings in the cache key, use\n\t\t\t\t<code>QueryStringsConfig</code> in a cache policy. See\n\t\t\t<code>CachePolicy</code>.</p>\n         <p>If you want to send query strings to the origin but not include them in the cache key,\n\t\t\tuse <code>QueryStringsConfig</code> in an origin request policy. See\n\t\t\t\t<code>OriginRequestPolicy</code>.</p>\n         <p>A complex type that contains information about the query string parameters that you\n\t\t\twant CloudFront to use for caching for a cache behavior.</p>",
+      "type": "object",
+      "properties": {
+        "Quantity": {
+          "description": "<p>The number of <code>whitelisted</code> query string parameters for a cache\n\t\t\tbehavior.</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>A list that contains the query string parameters that you want CloudFront to use as a basis\n\t\t\tfor caching for a cache behavior. If <code>Quantity</code> is 0, you can omit\n\t\t\t\t<code>Items</code>.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "Quantity"
+      ]
+    },
+    "CacheBehaviors": {
+      "description": "<p>A complex type that contains zero or more <code>CacheBehavior</code> elements.</p>",
+      "type": "object",
+      "properties": {
+        "Quantity": {
+          "description": "<p>The number of cache behaviors for this distribution.</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>Optional: A complex type that contains cache behaviors for this distribution. If\n\t\t\t\t<code>Quantity</code> is <code>0</code>, you can omit <code>Items</code>.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CacheBehavior"
+          }
+        }
+      },
+      "required": [
+        "Quantity"
+      ]
+    },
+    "CacheBehavior": {
+      "description": "<p>A complex type that describes how CloudFront processes requests.</p>\n         <p>You must create at least as many cache behaviors (including the default cache\n\t\t\tbehavior) as you have origins if you want CloudFront to serve objects from all of the origins.\n\t\t\tEach cache behavior specifies the one origin from which you want CloudFront to get objects. If\n\t\t\tyou have two origins and only the default cache behavior, the default cache behavior\n\t\t\twill cause CloudFront to get objects from one of the origins, but the other origin is never\n\t\t\tused.</p>\n         <p>For the current quota (formerly known as limit) on the number of cache behaviors that\n\t\t\tyou can add to a distribution, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-limits.html\">Quotas</a> in the\n\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>If you don't want to specify any cache behaviors, include only an empty\n\t\t\t\t<code>CacheBehaviors</code> element. Don't specify an empty individual\n\t\t\t\t<code>CacheBehavior</code> element, because this is invalid. For more information,\n\t\t\tsee <a href=\"https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CacheBehaviors.html\">CacheBehaviors</a>. </p>\n         <p>To delete all cache behaviors in an existing distribution, update the distribution\n\t\t\tconfiguration and include only an empty <code>CacheBehaviors</code> element.</p>\n         <p>To add, change, or remove one or more cache behaviors, update the distribution\n\t\t\tconfiguration and specify all of the cache behaviors that you want to include in the\n\t\t\tupdated distribution.</p>\n         <p>For more information about cache behaviors, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesCacheBehavior\">Cache Behavior Settings</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "PathPattern": {
+          "description": "<p>The pattern (for example, <code>images/*.jpg</code>) that specifies which requests to\n\t\t\tapply the behavior to. When CloudFront receives a viewer request, the requested path is\n\t\t\tcompared with path patterns in the order in which cache behaviors are listed in the\n\t\t\tdistribution.</p>\n         <note>\n            <p>You can optionally include a slash (<code>/</code>) at the beginning of the path\n\t\t\t\tpattern. For example, <code>/images/*.jpg</code>. CloudFront behavior is the same with or\n\t\t\t\twithout the leading <code>/</code>.</p>\n         </note>\n         <p>The path pattern for the default cache behavior is <code>*</code> and cannot be\n\t\t\tchanged. If the request for an object does not match the path pattern for any cache\n\t\t\tbehaviors, CloudFront applies the behavior in the default cache behavior.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesPathPattern\">Path Pattern</a> in the <i> Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "TargetOriginId": {
+          "description": "<p>The value of <code>ID</code> for the origin that you want CloudFront to route requests to\n\t\t\twhen they match this cache behavior.</p>",
+          "type": "string"
+        },
+        "TrustedSigners": {
+          "description": "<important>\n            <p>We recommend using <code>TrustedKeyGroups</code> instead of\n\t\t\t\t\t<code>TrustedSigners</code>.</p>\n         </important>\n         <p>A list of Amazon Web Services account IDs whose public keys CloudFront can use to validate signed URLs or\n\t\t\tsigned cookies.</p>\n         <p>When a cache behavior contains trusted signers, CloudFront requires signed URLs or signed\n\t\t\tcookies for all requests that match the cache behavior. The URLs or cookies must be\n\t\t\tsigned with the private key of a CloudFront key pair in the trusted signer's Amazon Web Services account.\n\t\t\tThe signed URL or cookie contains information about which public key CloudFront should use to\n\t\t\tverify the signature. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html\">Serving private content</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "$ref": "#/definitions/TrustedSigners"
+        },
+        "TrustedKeyGroups": {
+          "description": "<p>A list of key groups that CloudFront can use to validate signed URLs or signed\n\t\t\tcookies.</p>\n         <p>When a cache behavior contains trusted key groups, CloudFront requires signed URLs or signed\n\t\t\tcookies for all requests that match the cache behavior. The URLs or cookies must be\n\t\t\tsigned with a private key whose corresponding public key is in the key group. The signed\n\t\t\tURL or cookie contains information about which public key CloudFront should use to verify the\n\t\t\tsignature. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html\">Serving private content</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "$ref": "#/definitions/TrustedKeyGroups"
+        },
+        "ViewerProtocolPolicy": {
+          "description": "<p>The protocol that viewers can use to access the files in the origin specified by\n\t\t\t\t<code>TargetOriginId</code> when a request matches the path pattern in\n\t\t\t\t<code>PathPattern</code>. You can specify the following options:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>allow-all</code>: Viewers can use HTTP or HTTPS.</p>\n            </li>\n            <li>\n               <p>\n                  <code>redirect-to-https</code>: If a viewer submits an HTTP request, CloudFront\n\t\t\t\t\treturns an HTTP status code of 301 (Moved Permanently) to the viewer along with\n\t\t\t\t\tthe HTTPS URL. The viewer then resubmits the request using the new URL.</p>\n            </li>\n            <li>\n               <p>\n                  <code>https-only</code>: If a viewer sends an HTTP request, CloudFront returns an\n\t\t\t\t\tHTTP status code of 403 (Forbidden).</p>\n            </li>\n         </ul>\n         <p>For more information about requiring the HTTPS protocol, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-https-viewers-to-cloudfront.html\">Requiring HTTPS Between Viewers and  CloudFront</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>\n         <note>\n            <p>The only way to guarantee that viewers retrieve an object that was fetched from\n\t\t\t\tthe origin using HTTPS is never to use any other protocol to fetch the object. If\n\t\t\t\tyou have recently changed from HTTP to HTTPS, we recommend that you clear your\n\t\t\t\tobjects' cache because cached objects are protocol agnostic. That means that an edge\n\t\t\t\tlocation will return an object from the cache regardless of whether the current\n\t\t\t\trequest protocol matches the protocol used previously. For more information, see\n\t\t\t\t\t<a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html\">Managing Cache\n\t\t\t\t\tExpiration</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>\n         </note>",
+          "enum": [
+            "allow-all",
+            "https-only",
+            "redirect-to-https"
+          ],
+          "type": "string"
+        },
+        "AllowedMethods": {
+          "description": "<p>A complex type that controls which HTTP methods CloudFront processes and forwards to your\n\t\t\tAmazon S3 bucket or your custom origin. There are three choices:</p>\n         <ul>\n            <li>\n               <p>CloudFront forwards only <code>GET</code> and <code>HEAD</code> requests.</p>\n            </li>\n            <li>\n               <p>CloudFront forwards only <code>GET</code>, <code>HEAD</code>, and\n\t\t\t\t\t\t<code>OPTIONS</code> requests.</p>\n            </li>\n            <li>\n               <p>CloudFront forwards <code>GET, HEAD, OPTIONS, PUT, PATCH, POST</code>, and\n\t\t\t\t\t\t<code>DELETE</code> requests.</p>\n            </li>\n         </ul>\n         <p>If you pick the third choice, you may need to restrict access to your Amazon S3 bucket or\n\t\t\tto your custom origin so users can't perform operations that you don't want them to. For\n\t\t\texample, you might not want users to have permissions to delete objects from your\n\t\t\torigin.</p>",
+          "$ref": "#/definitions/AllowedMethods"
+        },
+        "SmoothStreaming": {
+          "description": "<p>Indicates whether you want to distribute media files in the Microsoft Smooth Streaming\n\t\t\tformat using the origin that is associated with this cache behavior. If so, specify\n\t\t\t\t<code>true</code>; if not, specify <code>false</code>. If you specify\n\t\t\t\t<code>true</code> for <code>SmoothStreaming</code>, you can still distribute other\n\t\t\tcontent using this cache behavior if the content matches the value of\n\t\t\t\t<code>PathPattern</code>.</p>",
+          "type": "boolean"
+        },
+        "Compress": {
+          "description": "<p>Whether you want CloudFront to automatically compress certain files for this cache behavior.\n\t\t\tIf so, specify true; if not, specify false. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html\">Serving\n\t\t\t\tCompressed Files</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "boolean"
+        },
+        "LambdaFunctionAssociations": {
+          "description": "<p>A complex type that contains zero or more Lambda@Edge function associations for a\n\t\t\tcache behavior.</p>",
+          "$ref": "#/definitions/LambdaFunctionAssociations"
+        },
+        "FunctionAssociations": {
+          "description": "<p>A list of CloudFront functions that are associated with this cache behavior. CloudFront functions\n\t\t\tmust be published to the <code>LIVE</code> stage to associate them with a cache\n\t\t\tbehavior.</p>",
+          "$ref": "#/definitions/FunctionAssociations"
+        },
+        "FieldLevelEncryptionId": {
+          "description": "<p>The value of <code>ID</code> for the field-level encryption configuration that you\n\t\t\twant CloudFront to use for encrypting specific fields of data for this cache behavior.</p>",
+          "type": "string"
+        },
+        "RealtimeLogConfigArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the real-time log configuration that is attached to\n\t\t\tthis cache behavior. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/real-time-logs.html\">Real-time logs</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "CachePolicyId": {
+          "description": "<p>The unique identifier of the cache policy that is attached to this cache behavior. For\n\t\t\tmore information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy\">Creating cache policies</a> or <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html\">Using the managed cache policies</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>A <code>CacheBehavior</code> must include either a <code>CachePolicyId</code> or\n\t\t\t\t<code>ForwardedValues</code>. We recommend that you use a\n\t\t\t<code>CachePolicyId</code>.</p>",
+          "type": "string"
+        },
+        "OriginRequestPolicyId": {
+          "description": "<p>The unique identifier of the origin request policy that is attached to this cache\n\t\t\tbehavior. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy\">Creating origin request policies</a> or <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html\">Using the managed origin request policies</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "string"
+        },
+        "ResponseHeadersPolicyId": {
+          "description": "<p>The identifier for a response headers policy.</p>",
+          "type": "string"
+        },
+        "ForwardedValues": {
+          "description": "<p>This field is deprecated. We recommend that you use a cache policy or an origin\n\t\t\trequest policy instead of this field.</p>\n         <p>If you want to include values in the cache key, use a cache policy. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy\">Creating cache policies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>If you want to send values to the origin but not include them in the cache key, use an\n\t\t\torigin request policy. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy\">Creating origin request policies</a> in the\n\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>\n         <p>A complex type that specifies how CloudFront handles query strings, cookies, and HTTP\n\t\t\theaders.</p>",
+          "$ref": "#/definitions/ForwardedValues"
+        },
+        "MinTTL": {
+          "type": "number"
+        },
+        "DefaultTTL": {
+          "type": "number"
+        },
+        "MaxTTL": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "PathPattern",
+        "TargetOriginId",
+        "ViewerProtocolPolicy"
+      ]
+    },
+    "CustomErrorResponses": {
+      "description": "<p>A complex type that controls:</p>\n         <ul>\n            <li>\n               <p>Whether CloudFront replaces HTTP status codes in the 4xx and 5xx range with custom\n\t\t\t\t\terror messages before returning the response to the viewer.</p>\n            </li>\n            <li>\n               <p>How long CloudFront caches HTTP status codes in the 4xx and 5xx range.</p>\n            </li>\n         </ul>\n         <p>For more information about custom error pages, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html\">Customizing\n\t\t\t\tError Responses</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "Quantity": {
+          "description": "<p>The number of HTTP status codes for which you want to specify a custom error page\n\t\t\tand/or a caching duration. If <code>Quantity</code> is <code>0</code>, you can omit\n\t\t\t\t<code>Items</code>.</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>A complex type that contains a <code>CustomErrorResponse</code> element for each HTTP\n\t\t\tstatus code for which you want to specify a custom error page and/or a caching duration.\n\t\t</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CustomErrorResponse"
+          }
+        }
+      },
+      "required": [
+        "Quantity"
+      ]
+    },
+    "CustomErrorResponse": {
+      "description": "<p>A complex type that controls:</p>\n         <ul>\n            <li>\n               <p>Whether CloudFront replaces HTTP status codes in the 4xx and 5xx range with custom\n\t\t\t\t\terror messages before returning the response to the viewer.</p>\n            </li>\n            <li>\n               <p>How long CloudFront caches HTTP status codes in the 4xx and 5xx range.</p>\n            </li>\n         </ul>\n         <p>For more information about custom error pages, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html\">Customizing\n\t\t\t\tError Responses</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "ErrorCode": {
+          "description": "<p>The HTTP status code for which you want to specify a custom error page and/or a\n\t\t\tcaching duration.</p>",
+          "type": "number"
+        },
+        "ResponsePagePath": {
+          "description": "<p>The path to the custom error page that you want CloudFront to return to a viewer when your\n\t\t\torigin returns the HTTP status code specified by <code>ErrorCode</code>, for example,\n\t\t\t\t<code>/4xx-errors/403-forbidden.html</code>. If you want to store your objects and\n\t\t\tyour custom error pages in different locations, your distribution must include a cache\n\t\t\tbehavior for which the following is true:</p>\n         <ul>\n            <li>\n               <p>The value of <code>PathPattern</code> matches the path to your custom error\n\t\t\t\t\tmessages. For example, suppose you saved custom error pages for 4xx errors in an\n\t\t\t\t\tAmazon S3 bucket in a directory named <code>/4xx-errors</code>. Your distribution\n\t\t\t\t\tmust include a cache behavior for which the path pattern routes requests for\n\t\t\t\t\tyour custom error pages to that location, for example,\n\t\t\t\t\t\t<code>/4xx-errors/*</code>.</p>\n            </li>\n            <li>\n               <p>The value of <code>TargetOriginId</code> specifies the value of the\n\t\t\t\t\t\t<code>ID</code> element for the origin that contains your custom error\n\t\t\t\t\tpages.</p>\n            </li>\n         </ul>\n         <p>If you specify a value for <code>ResponsePagePath</code>, you must also specify a\n\t\t\tvalue for <code>ResponseCode</code>.</p>\n         <p>We recommend that you store custom error pages in an Amazon S3 bucket. If you store custom\n\t\t\terror pages on an HTTP server and the server starts to return 5xx errors, CloudFront can't get\n\t\t\tthe files that you want to return to viewers because the origin server is\n\t\t\tunavailable.</p>",
+          "type": "string"
+        },
+        "ResponseCode": {
+          "description": "<p>The HTTP status code that you want CloudFront to return to the viewer along with the custom\n\t\t\terror page. There are a variety of reasons that you might want CloudFront to return a status\n\t\t\tcode different from the status code that your origin returned to CloudFront, for\n\t\t\texample:</p>\n         <ul>\n            <li>\n               <p>Some Internet devices (some firewalls and corporate proxies, for example)\n\t\t\t\t\tintercept HTTP 4xx and 5xx and prevent the response from being returned to the\n\t\t\t\t\tviewer. If you substitute <code>200</code>, the response typically won't be\n\t\t\t\t\tintercepted.</p>\n            </li>\n            <li>\n               <p>If you don't care about distinguishing among different client errors or server\n\t\t\t\t\terrors, you can specify <code>400</code> or <code>500</code> as the\n\t\t\t\t\t\t<code>ResponseCode</code> for all 4xx or 5xx errors.</p>\n            </li>\n            <li>\n               <p>You might want to return a <code>200</code> status code (OK) and static\n\t\t\t\t\twebsite so your customers don't know that your website is down.</p>\n            </li>\n         </ul>\n         <p>If you specify a value for <code>ResponseCode</code>, you must also specify a value\n\t\t\tfor <code>ResponsePagePath</code>.</p>",
+          "type": "string"
+        },
+        "ErrorCachingMinTTL": {
+          "description": "<p>The minimum amount of time, in seconds, that you want CloudFront to cache the HTTP status\n\t\t\tcode specified in <code>ErrorCode</code>. When this time period has elapsed, CloudFront\n\t\t\tqueries your origin to see whether the problem that caused the error has been resolved\n\t\t\tand the requested object is now available.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html\">Customizing\n\t\t\t\tError Responses</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>",
+          "type": "number"
+        }
+      },
+      "required": [
+        "ErrorCode"
+      ]
+    },
+    "ViewerCertificate": {
+      "description": "<p>A complex type that determines the distribution's SSL/TLS configuration for\n\t\t\tcommunicating with viewers.</p>\n         <p>If the distribution doesn't use <code>Aliases</code> (also known as alternate domain\n\t\t\tnames or CNAMEs)—that is, if the distribution uses the CloudFront domain name such as\n\t\t\t\t<code>d111111abcdef8.cloudfront.net</code>—set\n\t\t\t\t<code>CloudFrontDefaultCertificate</code> to <code>true</code> and leave all other\n\t\t\tfields empty.</p>\n         <p>If the distribution uses <code>Aliases</code> (alternate domain names or CNAMEs), use\n\t\t\tthe fields in this type to specify the following settings:</p>\n         <ul>\n            <li>\n               <p>Which viewers the distribution accepts HTTPS connections from: only viewers\n\t\t\t\t\tthat support <a href=\"https://en.wikipedia.org/wiki/Server_Name_Indication\">server name indication (SNI)</a> (recommended), or all viewers\n\t\t\t\t\tincluding those that don't support SNI.</p>\n               <ul>\n                  <li>\n                     <p>To accept HTTPS connections from only viewers that support SNI, set\n\t\t\t\t\t\t\t\t<code>SSLSupportMethod</code> to <code>sni-only</code>. This is\n\t\t\t\t\t\t\trecommended. Most browsers and clients support SNI. </p>\n                  </li>\n                  <li>\n                     <p>To accept HTTPS connections from all viewers, including those that\n\t\t\t\t\t\t\tdon't support SNI, set <code>SSLSupportMethod</code> to\n\t\t\t\t\t\t\t<code>vip</code>. This is not recommended, and results in additional\n\t\t\t\t\t\t\tmonthly charges from CloudFront.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>The minimum SSL/TLS protocol version that the distribution can use to\n\t\t\t\t\tcommunicate with viewers. To specify a minimum version, choose a value for\n\t\t\t\t\t\t<code>MinimumProtocolVersion</code>. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValues-security-policy\">Security Policy</a> in the\n\t\t\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>\n            </li>\n            <li>\n               <p>The location of the SSL/TLS certificate, <a href=\"https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html\">Certificate Manager\n\t\t\t\t\t\t(ACM)</a> (recommended) or <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html\">Identity and Access Management (IAM)</a>. You specify the location by\n\t\t\t\t\tsetting a value in one of the following fields (not both):</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ACMCertificateArn</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>IAMCertificateId</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>All distributions support HTTPS connections from viewers. To require viewers to use\n\t\t\tHTTPS only, or to redirect them from HTTP to HTTPS, use\n\t\t\t\t<code>ViewerProtocolPolicy</code> in the <code>CacheBehavior</code> or\n\t\t\t\t<code>DefaultCacheBehavior</code>. To specify how CloudFront should use SSL/TLS to\n\t\t\tcommunicate with your custom origin, use <code>CustomOriginConfig</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-https.html\">Using HTTPS with CloudFront</a> and <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-https-alternate-domain-names.html\"> Using Alternate Domain Names and HTTPS</a> in the\n\t\t\t\t<i>Amazon CloudFront Developer Guide</i>.</p>",
+      "type": "object",
+      "properties": {
+        "CloudFrontDefaultCertificate": {
+          "description": "<p>If the distribution uses the CloudFront domain name such as\n\t\t\t\t<code>d111111abcdef8.cloudfront.net</code>, set this field to\n\t\t\t<code>true</code>.</p>\n         <p>If the distribution uses <code>Aliases</code> (alternate domain names or CNAMEs), set\n\t\t\tthis field to <code>false</code> and specify values for the following fields:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ACMCertificateArn</code> or <code>IAMCertificateId</code> (specify a\n\t\t\t\t\tvalue for one, not both)</p>\n            </li>\n            <li>\n               <p>\n                  <code>MinimumProtocolVersion</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>SSLSupportMethod</code>\n               </p>\n            </li>\n         </ul>",
+          "type": "boolean"
+        },
+        "IAMCertificateId": {
+          "description": "<p>If the distribution uses <code>Aliases</code> (alternate domain names or CNAMEs) and\n\t\t\tthe SSL/TLS certificate is stored in <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html\">Identity and Access Management (IAM)</a>, provide the ID of the IAM certificate.</p>\n         <p>If you specify an IAM certificate ID, you must also specify values for\n\t\t\t\t<code>MinimumProtocolVersion</code> and <code>SSLSupportMethod</code>. </p>",
+          "type": "string"
+        },
+        "ACMCertificateArn": {
+          "description": "<p>If the distribution uses <code>Aliases</code> (alternate domain names or CNAMEs) and\n\t\t\tthe SSL/TLS certificate is stored in <a href=\"https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html\">Certificate Manager (ACM)</a>, provide the Amazon Resource Name\n\t\t\t(ARN) of the ACM certificate. CloudFront only supports ACM certificates in the US East\n\t\t\t(N. Virginia) Region (<code>us-east-1</code>).</p>\n         <p>If you specify an ACM certificate ARN, you must also specify values for\n\t\t\t\t<code>MinimumProtocolVersion</code> and <code>SSLSupportMethod</code>.</p>",
+          "type": "string"
+        },
+        "SSLSupportMethod": {
+          "enum": [
+            "sni-only",
+            "static-ip",
+            "vip"
+          ],
+          "description": "<p>If the distribution uses <code>Aliases</code> (alternate domain names or CNAMEs),\n\t\t\tspecify which viewers the distribution accepts HTTPS connections from.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>sni-only</code> – The distribution accepts HTTPS connections from only\n\t\t\t\t\tviewers that support <a href=\"https://en.wikipedia.org/wiki/Server_Name_Indication\">server name\n\t\t\t\t\t\tindication (SNI)</a>. This is recommended. Most browsers and clients\n\t\t\t\t\tsupport SNI.</p>\n            </li>\n            <li>\n               <p>\n                  <code>vip</code> – The distribution accepts HTTPS connections from all viewers\n\t\t\t\t\tincluding those that don't support SNI. This is not recommended, and results in\n\t\t\t\t\tadditional monthly charges from CloudFront.</p>\n            </li>\n            <li>\n               <p>\n                  <code>static-ip</code> - Do not specify this value unless your distribution\n\t\t\t\t\thas been enabled for this feature by the CloudFront team. If you have a use case\n\t\t\t\t\tthat requires static IP addresses for a distribution, contact CloudFront through\n\t\t\t\t\tthe <a href=\"https://console.aws.amazon.com/support/home\">Amazon Web Services Support Center</a>.</p>\n            </li>\n         </ul>\n         <p>If the distribution uses the CloudFront domain name such as\n\t\t\t\t<code>d111111abcdef8.cloudfront.net</code>, don't set a value for this field.</p>",
+          "type": "string"
+        },
+        "MinimumProtocolVersion": {
+          "enum": [
+            "SSLv3",
+            "TLSv1",
+            "TLSv1.1_2016",
+            "TLSv1.2_2018",
+            "TLSv1.2_2019",
+            "TLSv1.2_2021",
+            "TLSv1_2016"
+          ],
+          "description": "<p>If the distribution uses <code>Aliases</code> (alternate domain names or CNAMEs),\n\t\t\tspecify the security policy that you want CloudFront to use for HTTPS connections with\n\t\t\tviewers. The security policy determines two settings:</p>\n         <ul>\n            <li>\n               <p>The minimum SSL/TLS protocol that CloudFront can use to communicate with\n\t\t\t\t\tviewers.</p>\n            </li>\n            <li>\n               <p>The ciphers that CloudFront can use to encrypt the content that it returns to\n\t\t\t\t\tviewers.</p>\n            </li>\n         </ul>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValues-security-policy\">Security Policy</a> and <a href=\"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html#secure-connections-supported-ciphers\">Supported Protocols and Ciphers Between Viewers and\n\t\t\t\tCloudFront</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>\n         <note>\n            <p>On the CloudFront console, this setting is called <b>Security\n\t\t\t\t\tPolicy</b>.</p>\n         </note>\n         <p>When you're using SNI only (you set <code>SSLSupportMethod</code> to\n\t\t\t\t<code>sni-only</code>), you must specify <code>TLSv1</code> or higher.</p>\n         <p>If the distribution uses the CloudFront domain name such as\n\t\t\t\t<code>d111111abcdef8.cloudfront.net</code> (you set\n\t\t\t\t<code>CloudFrontDefaultCertificate</code> to <code>true</code>), CloudFront automatically\n\t\t\tsets the security policy to <code>TLSv1</code> regardless of the value that you set\n\t\t\there.</p>",
+          "type": "string"
+        },
+        "Certificate": {
+          "type": "string"
+        },
+        "CertificateSource": {
+          "enum": [
+            "acm",
+            "cloudfront",
+            "iam"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "Restrictions": {
+      "description": "<p>A complex type that identifies ways in which you want to restrict distribution of your\n\t\t\tcontent.</p>",
+      "type": "object",
+      "properties": {
+        "GeoRestriction": {
+          "description": "<p>A complex type that controls the countries in which your content is distributed. CloudFront\n\t\t\tdetermines the location of your users using <code>MaxMind</code> GeoIP databases.</p>",
+          "$ref": "#/definitions/GeoRestriction"
+        }
+      },
+      "required": [
+        "GeoRestriction"
+      ]
+    },
+    "GeoRestriction": {
+      "description": "<p>A complex type that controls the countries in which your content is distributed. CloudFront\n\t\t\tdetermines the location of your users using <code>MaxMind</code> GeoIP databases.\n\t\t</p>",
+      "type": "object",
+      "properties": {
+        "RestrictionType": {
+          "description": "<p>The method that you want to use to restrict distribution of your content by\n\t\t\tcountry:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>none</code>: No geo restriction is enabled, meaning access to content is\n\t\t\t\t\tnot restricted by client geo location.</p>\n            </li>\n            <li>\n               <p>\n                  <code>blacklist</code>: The <code>Location</code> elements specify the\n\t\t\t\t\tcountries in which you don't want CloudFront to distribute your content.</p>\n            </li>\n            <li>\n               <p>\n                  <code>whitelist</code>: The <code>Location</code> elements specify the\n\t\t\t\t\tcountries in which you want CloudFront to distribute your content.</p>\n            </li>\n         </ul>",
+          "enum": [
+            "blacklist",
+            "none",
+            "whitelist"
+          ],
+          "type": "string"
+        },
+        "Quantity": {
+          "description": "<p>When geo restriction is <code>enabled</code>, this is the number of countries in your\n\t\t\t\t<code>whitelist</code> or <code>blacklist</code>. Otherwise, when it is not enabled,\n\t\t\t\t<code>Quantity</code> is <code>0</code>, and you can omit <code>Items</code>.</p>",
+          "type": "number"
+        },
+        "Items": {
+          "description": "<p>A complex type that contains a <code>Location</code> element for each country in\n\t\t\twhich you want CloudFront either to distribute your content (<code>whitelist</code>) or not\n\t\t\tdistribute your content (<code>blacklist</code>).</p>\n         <p>The <code>Location</code> element is a two-letter, uppercase country code for a\n\t\t\tcountry that you want to include in your <code>blacklist</code> or\n\t\t\t\t<code>whitelist</code>. Include one <code>Location</code> element for each\n\t\t\tcountry.</p>\n         <p>CloudFront and <code>MaxMind</code> both use <code>ISO 3166</code> country codes. For the\n\t\t\tcurrent list of countries and the corresponding codes, see <code>ISO\n\t\t\t\t3166-1-alpha-2</code> code on the <i>International Organization for\n\t\t\t\tStandardization</i> website. You can also refer to the country list on the\n\t\t\tCloudFront console, which includes both country names and codes.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "Quantity",
+        "RestrictionType"
+      ]
+    },
+    "AliasICPRecordal": {
+      "description": "<p>Amazon Web Services services in China customers must file for an Internet Content Provider (ICP)\n\t\t\trecordal if they want to serve content publicly on an alternate domain name, also known\n\t\t\tas a CNAME, that they've added to CloudFront. AliasICPRecordal provides the ICP recordal\n\t\t\tstatus for CNAMEs associated with distributions. The status is returned in the CloudFront\n\t\t\tresponse; you can't configure it yourself.</p>\n         <p>For more information about ICP recordals, see <a href=\"https://docs.amazonaws.cn/en_us/aws/latest/userguide/accounts-and-credentials.html\"> Signup, Accounts, and Credentials</a> in <i>Getting Started with Amazon Web Services\n\t\t\t\tservices in China</i>.</p>",
+      "type": "object",
+      "properties": {
+        "CNAME": {
+          "description": "<p>A domain name associated with a distribution.</p>",
+          "type": "string"
+        },
+        "ICPRecordalStatus": {
+          "enum": [
+            "APPROVED",
+            "PENDING",
+            "SUSPENDED"
+          ],
+          "description": "<p>The Internet Content Provider (ICP) recordal status for a CNAME. The ICPRecordalStatus\n\t\t\tis set to APPROVED for all CNAMEs (aliases) in regions outside of China.</p>\n         <p>The status values returned are the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>APPROVED</b> indicates that the associated CNAME\n\t\t\t\t\thas a valid ICP recordal number. Multiple CNAMEs can be associated with a\n\t\t\t\t\tdistribution, and CNAMEs can correspond to different ICP recordals. To be marked\n\t\t\t\t\tas APPROVED, that is, valid to use with China region, a CNAME must have one ICP\n\t\t\t\t\trecordal number associated with it.</p>\n            </li>\n            <li>\n               <p>\n                  <b>SUSPENDED</b> indicates that the associated CNAME\n\t\t\t\t\tdoes not have a valid ICP recordal number.</p>\n            </li>\n            <li>\n               <p>\n                  <b>PENDING</b> indicates that CloudFront can't determine\n\t\t\t\t\tthe ICP recordal status of the CNAME associated with the distribution because\n\t\t\t\t\tthere was an error in trying to determine the status. You can try again to see\n\t\t\t\t\tif the error is resolved in which case CloudFront returns an APPROVED or SUSPENDED\n\t\t\t\t\tstatus.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        }
+      }
+    },
+    "FileSystemDescription": {
+      "description": "<p>A description of the file system.</p>",
+      "type": "object",
+      "properties": {
+        "OwnerId": {
+          "description": "<p>The Amazon Web Services account that created the file system.</p>",
+          "type": "string"
+        },
+        "CreationToken": {
+          "description": "<p>The opaque string specified in the request.</p>",
+          "type": "string"
+        },
+        "FileSystemId": {
+          "description": "<p>The ID of the file system, assigned by Amazon EFS.</p>",
+          "type": "string"
+        },
+        "FileSystemArn": {
+          "description": "<p>The Amazon Resource Name (ARN) for the EFS file system, in the format\n          <code>arn:aws:elasticfilesystem:<i>region</i>:<i>account-id</i>:file-system/<i>file-system-id</i>\n            </code>.\n      Example with sample data:\n        <code>arn:aws:elasticfilesystem:us-west-2:1111333322228888:file-system/fs-01234567</code>\n         </p>",
+          "type": "string"
+        },
+        "CreationTime": {
+          "description": "<p>The time that the file system was created, in seconds (since\n      1970-01-01T00:00:00Z).</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "LifeCycleState": {
+          "description": "<p>The lifecycle phase of the file system.</p>",
+          "enum": [
+            "available",
+            "creating",
+            "deleted",
+            "deleting",
+            "error",
+            "updating"
+          ],
+          "type": "string"
+        },
+        "Name": {
+          "description": "<p>You can add tags to a file system, including a <code>Name</code> tag. For more\n      information, see <a>CreateFileSystem</a>. If the file system has a <code>Name</code> tag, Amazon EFS returns\n      the value in this field. </p>",
+          "type": "string"
+        },
+        "NumberOfMountTargets": {
+          "description": "<p>The current number of mount targets that the file system has. For more information, see <a>CreateMountTarget</a>.</p>",
+          "type": "number"
+        },
+        "SizeInBytes": {
+          "description": "<p>The latest known metered size (in bytes) of data stored in the file system, in its\n        <code>Value</code> field, and the time at which that size was determined in its\n        <code>Timestamp</code> field. The <code>Timestamp</code> value is the integer number of\n      seconds since 1970-01-01T00:00:00Z. The <code>SizeInBytes</code> value doesn't represent\n      the size of a consistent snapshot of the file system, but it is eventually consistent when\n      there are no writes to the file system. That is, <code>SizeInBytes</code> represents actual\n      size only if the file system is not modified for a period longer than a couple of hours.\n      Otherwise, the value is not the exact size that the file system was at any point in time.\n    </p>",
+          "$ref": "#/definitions/FileSystemSize"
+        },
+        "PerformanceMode": {
+          "description": "<p>The Performance mode of the file system.</p>",
+          "enum": [
+            "generalPurpose",
+            "maxIO"
+          ],
+          "type": "string"
+        },
+        "Encrypted": {
+          "description": "<p>A Boolean value that, if true, indicates that the file system is encrypted.</p>",
+          "type": "boolean"
+        },
+        "KmsKeyId": {
+          "description": "<p>The ID of an KMS key used to protect the encrypted file system.</p>",
+          "type": "string"
+        },
+        "ThroughputMode": {
+          "enum": [
+            "bursting",
+            "elastic",
+            "provisioned"
+          ],
+          "description": "<p>Displays the file system's throughput mode. For more information, see\n      <a href=\"https://docs.aws.amazon.com/efs/latest/ug/performance.html#throughput-modes\">Throughput modes</a>\n      in the <i>Amazon EFS User Guide</i>.\n    </p>",
+          "type": "string"
+        },
+        "ProvisionedThroughputInMibps": {
+          "description": "<p>The amount of provisioned throughput, measured in MiBps, for the file system. Valid for\n      file systems using <code>ThroughputMode</code> set to <code>provisioned</code>.</p>",
+          "type": "number"
+        },
+        "AvailabilityZoneName": {
+          "description": "<p>Describes the Amazon Web Services Availability Zone in which the file system is located, and is\n      valid only for One Zone file systems. For more information, see <a href=\"https://docs.aws.amazon.com/efs/latest/ug/storage-classes.html\">Using EFS storage\n        classes</a> in the <i>Amazon EFS User Guide</i>.</p>",
+          "type": "string"
+        },
+        "AvailabilityZoneId": {
+          "description": "<p>The unique and consistent identifier of the Availability Zone in which the file system is\n      located, and is valid only for One Zone file systems. For example,\n        <code>use1-az1</code> is an Availability Zone ID for the us-east-1 Amazon Web Services Region, and\n      it has the same location in every Amazon Web Services account.</p>",
+          "type": "string"
+        },
+        "Tags": {
+          "description": "<p>The tags associated with the file system, presented as an array of <code>Tag</code>\n      objects.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag_3"
+          }
+        },
+        "FileSystemProtection": {
+          "description": "<p>Describes the protection on the file system. </p>",
+          "$ref": "#/definitions/FileSystemProtectionDescription"
+        }
+      },
+      "required": [
+        "CreationTime",
+        "CreationToken",
+        "FileSystemId",
+        "LifeCycleState",
+        "NumberOfMountTargets",
+        "OwnerId",
+        "PerformanceMode",
+        "SizeInBytes",
+        "Tags"
+      ]
+    },
+    "FileSystemSize": {
+      "description": "<p>The latest known metered size (in bytes) of data stored in the file system, in its\n        <code>Value</code> field, and the time at which that size was determined in its\n        <code>Timestamp</code> field. The value doesn't represent the size of a consistent\n      snapshot of the file system, but it is eventually consistent when there are no writes to the\n      file system. That is, the value represents the actual size only if the file system is not\n      modified for a period longer than a couple of hours. Otherwise, the value is not necessarily\n      the exact size the file system was at any instant in time.</p>",
+      "type": "object",
+      "properties": {
+        "Value": {
+          "description": "<p>The latest known metered size (in bytes) of data stored in the file system.</p>",
+          "type": "number"
+        },
+        "Timestamp": {
+          "description": "<p>The time at which the size of data, returned in the <code>Value</code> field, was\n      determined. The value is the integer number of seconds since 1970-01-01T00:00:00Z.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "ValueInIA": {
+          "description": "<p>The latest known metered size (in bytes) of data stored in the Infrequent Access storage\n      class.</p>",
+          "type": "number"
+        },
+        "ValueInStandard": {
+          "description": "<p>The latest known metered size (in bytes) of data stored in the Standard\n      storage class.</p>",
+          "type": "number"
+        },
+        "ValueInArchive": {
+          "description": "<p>The latest known metered size (in bytes) of data stored in the Archive\n      storage class.</p>",
+          "type": "number"
+        }
+      },
+      "required": [
+        "Value"
+      ]
+    },
+    "Tag_3": {
+      "description": "<p>A tag is a key-value pair. Allowed characters are letters, white space, and numbers that\n      can be represented in UTF-8, and the following characters:<code> + - = . _ : /</code>.</p>",
+      "type": "object",
+      "properties": {
+        "Key": {
+          "description": "<p>The tag key (String). The key can't start with <code>aws:</code>.</p>",
+          "type": "string"
+        },
+        "Value": {
+          "description": "<p>The value of the tag key.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Key",
+        "Value"
+      ]
+    },
+    "FileSystemProtectionDescription": {
+      "description": "<p>Describes the protection on a file system. </p>",
+      "type": "object",
+      "properties": {
+        "ReplicationOverwriteProtection": {
+          "enum": [
+            "DISABLED",
+            "ENABLED",
+            "REPLICATING"
+          ],
+          "description": "<p>The status of the file system's replication overwrite protection.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ENABLED</code> – The file system cannot be used as the destination file\n          system in a replication configuration. The file system is writeable. Replication overwrite\n          protection is <code>ENABLED</code> by default. </p>\n            </li>\n            <li>\n               <p>\n                  <code>DISABLED</code> – The file system can be used as the destination file\n          system in a replication configuration. The file system is read-only and can only be\n          modified by EFS replication.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REPLICATING</code> – The file system is being used as the destination\n          file system in a replication configuration. The file system is read-only and is only\n          modified only by EFS replication.</p>\n            </li>\n         </ul>\n         <p>If the replication configuration is deleted, the file system's replication overwrite\n      protection is re-enabled, the file system becomes writeable.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Partial<Record<QueueAttributeName,string>>": {
+      "type": "object",
+      "properties": {
+        "All": {
+          "type": "string"
+        },
+        "ApproximateNumberOfMessages": {
+          "type": "string"
+        },
+        "ApproximateNumberOfMessagesDelayed": {
+          "type": "string"
+        },
+        "ApproximateNumberOfMessagesNotVisible": {
+          "type": "string"
+        },
+        "ContentBasedDeduplication": {
+          "type": "string"
+        },
+        "CreatedTimestamp": {
+          "type": "string"
+        },
+        "DeduplicationScope": {
+          "type": "string"
+        },
+        "DelaySeconds": {
+          "type": "string"
+        },
+        "FifoQueue": {
+          "type": "string"
+        },
+        "FifoThroughputLimit": {
+          "type": "string"
+        },
+        "KmsDataKeyReusePeriodSeconds": {
+          "type": "string"
+        },
+        "KmsMasterKeyId": {
+          "type": "string"
+        },
+        "LastModifiedTimestamp": {
+          "type": "string"
+        },
+        "MaximumMessageSize": {
+          "type": "string"
+        },
+        "MessageRetentionPeriod": {
+          "type": "string"
+        },
+        "Policy": {
+          "type": "string"
+        },
+        "QueueArn": {
+          "type": "string"
+        },
+        "ReceiveMessageWaitTimeSeconds": {
+          "type": "string"
+        },
+        "RedriveAllowPolicy": {
+          "type": "string"
+        },
+        "RedrivePolicy": {
+          "type": "string"
+        },
+        "SqsManagedSseEnabled": {
+          "type": "string"
+        },
+        "VisibilityTimeout": {
+          "type": "string"
+        }
+      }
+    },
+    "CacheCluster": {
+      "description": "<p>Contains all of the attributes of a specific cluster.</p>",
+      "type": "object",
+      "properties": {
+        "CacheClusterId": {
+          "description": "<p>The user-supplied identifier of the cluster. This identifier is a unique key that\n            identifies a cluster.</p>",
+          "type": "string"
+        },
+        "ConfigurationEndpoint": {
+          "description": "<p>Represents a Memcached cluster endpoint which can be used by an application to connect\n            to any node in the cluster. The configuration endpoint will always have\n                <code>.cfg</code> in it.</p>\n         <p>Example: <code>mem-3.9dvc4r<u>.cfg</u>.usw2.cache.amazonaws.com:11211</code>\n         </p>",
+          "$ref": "#/definitions/Endpoint_1"
+        },
+        "ClientDownloadLandingPage": {
+          "description": "<p>The URL of the web page where you can download the latest ElastiCache client\n            library.</p>",
+          "type": "string"
+        },
+        "CacheNodeType": {
+          "description": "<p>The name of the compute and memory capacity node type for the cluster.</p>\n         <p>The following node types are supported by ElastiCache. Generally speaking, the current\n            generation types provide more memory and computational power at lower cost when compared\n            to their equivalent previous generation counterparts.</p>\n         <ul>\n            <li>\n               <p>General purpose:</p>\n               <ul>\n                  <li>\n                     <p>Current generation: </p>\n                     <p>\n                        <b>M7g node types</b>:\n    \t\t\t\t\t<code>cache.m7g.large</code>,\n    \t\t\t\t\t<code>cache.m7g.xlarge</code>,\n    \t\t\t\t\t<code>cache.m7g.2xlarge</code>,\n    \t\t\t\t\t<code>cache.m7g.4xlarge</code>,\n    \t\t\t\t\t<code>cache.m7g.8xlarge</code>,\n    \t\t\t\t\t<code>cache.m7g.12xlarge</code>,\n    \t\t\t\t\t<code>cache.m7g.16xlarge</code>\n                     </p>\n                     <note>\n                        <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a>\n                        </p>\n                     </note>\n                     <p>\n                        <b>M6g node types</b> (available only for Redis OSS engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward):\n\n\t\t\t\t\t \t<code>cache.m6g.large</code>,\n\t\t\t\t\t\t\t<code>cache.m6g.xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.m6g.2xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.m6g.4xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.m6g.8xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.m6g.12xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.m6g.16xlarge</code>\n                     </p>\n                     <p>\n                        <b>M5 node types:</b>\n                        <code>cache.m5.large</code>,\n    \t\t\t\t\t\t<code>cache.m5.xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m5.2xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m5.4xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m5.12xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m5.24xlarge</code>\n                     </p>\n                     <p>\n                        <b>M4 node types:</b>\n                        <code>cache.m4.large</code>,\n    \t\t\t\t\t\t<code>cache.m4.xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m4.2xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m4.4xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m4.10xlarge</code>\n                     </p>\n                     <p>\n                        <b>T4g node types</b> (available only for Redis OSS engine version 5.0.6 onward and Memcached engine version 1.5.16 onward):\n\t\t\t\t\t        <code>cache.t4g.micro</code>,\n\t\t\t\t\t        <code>cache.t4g.small</code>,\n\t\t\t\t\t        <code>cache.t4g.medium</code>\n                     </p>\n                     <p>\n                        <b>T3 node types:</b>\n                        <code>cache.t3.micro</code>,\n    \t\t\t\t\t\t<code>cache.t3.small</code>,\n    \t\t\t\t\t\t<code>cache.t3.medium</code>\n                     </p>\n                     <p>\n                        <b>T2 node types:</b>\n                        <code>cache.t2.micro</code>,\n    \t\t\t\t\t\t<code>cache.t2.small</code>,\n    \t\t\t\t\t\t<code>cache.t2.medium</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>Previous generation: (not recommended. Existing clusters are still supported but creation of new clusters is not supported for these types.)</p>\n                     <p>\n                        <b>T1 node types:</b>\n                        <code>cache.t1.micro</code>\n                     </p>\n                     <p>\n                        <b>M1 node types:</b>\n                        <code>cache.m1.small</code>,\n\t\t\t\t\t\t   <code>cache.m1.medium</code>,\n\t\t\t\t\t\t   <code>cache.m1.large</code>,\n\t\t\t\t\t\t   <code>cache.m1.xlarge</code>\n                     </p>\n                     <p>\n                        <b>M3 node types:</b>\n                        <code>cache.m3.medium</code>,\n    \t\t\t\t\t\t<code>cache.m3.large</code>,\n    \t\t\t\t\t\t<code>cache.m3.xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m3.2xlarge</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Compute optimized:</p>\n               <ul>\n                  <li>\n                     <p>Previous generation: (not recommended. Existing clusters are still supported but creation of new clusters is not supported for these types.)</p>\n                     <p>\n                        <b>C1 node types:</b>\n                        <code>cache.c1.xlarge</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Memory optimized:</p>\n               <ul>\n                  <li>\n                     <p>Current generation: </p>\n                     <p>\n                        <b>R7g node types</b>:\n\t\t\t\t\t\t\t<code>cache.r7g.large</code>,\n\t\t\t\t\t\t\t<code>cache.r7g.xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r7g.2xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r7g.4xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r7g.8xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r7g.12xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r7g.16xlarge</code>\n                     </p>\n                     <note>\n                        <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a>\n                        </p>\n                     </note>\n                     <p>\n                        <b>R6g node types</b> (available only for Redis OSS engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward):\n\t\t\t\t\t\t\t<code>cache.r6g.large</code>,\n\t\t\t\t\t\t\t<code>cache.r6g.xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r6g.2xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r6g.4xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r6g.8xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r6g.12xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r6g.16xlarge</code>\n                     </p>\n                     <p>\n                        <b>R5 node types:</b>\n                        <code>cache.r5.large</code>,\n    \t\t\t\t\t   <code>cache.r5.xlarge</code>,\n    \t\t\t\t\t   <code>cache.r5.2xlarge</code>,\n    \t\t\t\t\t   <code>cache.r5.4xlarge</code>,\n    \t\t\t\t\t   <code>cache.r5.12xlarge</code>,\n    \t\t\t\t\t   <code>cache.r5.24xlarge</code>\n                     </p>\n                     <p>\n                        <b>R4 node types:</b>\n                        <code>cache.r4.large</code>,\n    \t\t\t\t\t   <code>cache.r4.xlarge</code>,\n    \t\t\t\t\t   <code>cache.r4.2xlarge</code>,\n    \t\t\t\t\t   <code>cache.r4.4xlarge</code>,\n    \t\t\t\t\t   <code>cache.r4.8xlarge</code>,\n    \t\t\t\t\t   <code>cache.r4.16xlarge</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>Previous generation: (not recommended. Existing clusters are still supported but creation of new clusters is not supported for these types.)</p>\n                     <p>\n                        <b>M2 node types:</b>\n                        <code>cache.m2.xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m2.2xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m2.4xlarge</code>\n                     </p>\n                     <p>\n                        <b>R3 node types:</b>\n                        <code>cache.r3.large</code>,\n    \t\t\t\t\t\t<code>cache.r3.xlarge</code>,\n    \t\t\t\t\t\t<code>cache.r3.2xlarge</code>,\n    \t\t\t\t\t\t<code>cache.r3.4xlarge</code>,\n    \t\t\t\t\t\t<code>cache.r3.8xlarge</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>\n            <b>Additional node type info</b>\n         </p>\n         <ul>\n            <li>\n               <p>All current generation instance types are created in Amazon VPC by\n                    default.</p>\n            </li>\n            <li>\n               <p>Valkey or Redis OSS append-only files (AOF) are not supported for T1 or T2 instances.</p>\n            </li>\n            <li>\n               <p>Valkey or Redis OSS Multi-AZ with automatic failover is not supported on T1\n                    instances.</p>\n            </li>\n            <li>\n               <p>The configuration variables <code>appendonly</code> and\n                        <code>appendfsync</code> are not supported on Valkey, or on Redis OSS version 2.8.22 and\n                    later.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "Engine": {
+          "description": "<p>The name of the cache engine (<code>memcached</code> or <code>redis</code>) to be used\n            for this cluster.</p>",
+          "type": "string"
+        },
+        "EngineVersion": {
+          "description": "<p>The version of the cache engine that is used in this cluster.</p>",
+          "type": "string"
+        },
+        "CacheClusterStatus": {
+          "description": "<p>The current state of this cluster, one of the following values:\n            <code>available</code>, <code>creating</code>, <code>deleted</code>,\n                <code>deleting</code>, <code>incompatible-network</code>, <code>modifying</code>,\n                <code>rebooting cluster nodes</code>, <code>restore-failed</code>, or\n                <code>snapshotting</code>.</p>",
+          "type": "string"
+        },
+        "NumCacheNodes": {
+          "description": "<p>The number of cache nodes in the cluster.</p>\n         <p>For clusters running Valkey or Redis OSS, this value must be 1. For clusters running Memcached, this\n            value must be between 1 and 40.</p>",
+          "type": "number"
+        },
+        "PreferredAvailabilityZone": {
+          "description": "<p>The name of the Availability Zone in which the cluster is located or \"Multiple\" if the\n            cache nodes are located in different Availability Zones.</p>",
+          "type": "string"
+        },
+        "PreferredOutpostArn": {
+          "description": "<p>The outpost ARN in which the cache cluster is created.</p>",
+          "type": "string"
+        },
+        "CacheClusterCreateTime": {
+          "description": "<p>The date and time when the cluster was created.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "PreferredMaintenanceWindow": {
+          "description": "<p>Specifies the weekly time range during which maintenance on the cluster is performed.\n            It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The\n            minimum maintenance window is a 60 minute period.</p>\n         <p>Valid values for <code>ddd</code> are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>sun</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>mon</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>tue</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>wed</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>thu</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>fri</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>sat</code>\n               </p>\n            </li>\n         </ul>\n         <p>Example: <code>sun:23:00-mon:01:30</code>\n         </p>",
+          "type": "string"
+        },
+        "PendingModifiedValues": {
+          "description": "<p>A group of settings that are applied to the cluster in the future, or that are\n            currently being applied.</p>",
+          "$ref": "#/definitions/PendingModifiedValues_1"
+        },
+        "NotificationConfiguration": {
+          "description": "<p>Describes a notification topic and its status. Notification topics are used for\n            publishing ElastiCache events to subscribers using Amazon Simple Notification Service\n            (SNS). </p>",
+          "$ref": "#/definitions/NotificationConfiguration"
+        },
+        "CacheSecurityGroups": {
+          "description": "<p>A list of cache security group elements, composed of name and status\n            sub-elements.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CacheSecurityGroupMembership"
+          }
+        },
+        "CacheParameterGroup": {
+          "description": "<p>Status of the cache parameter group.</p>",
+          "$ref": "#/definitions/CacheParameterGroupStatus"
+        },
+        "CacheSubnetGroupName": {
+          "description": "<p>The name of the cache subnet group associated with the cluster.</p>",
+          "type": "string"
+        },
+        "CacheNodes": {
+          "description": "<p>A list of cache nodes that are members of the cluster.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CacheNode"
+          }
+        },
+        "AutoMinorVersionUpgrade": {
+          "description": "<p> If you are running Valkey or Redis OSS engine version 6.0 or later, set this parameter to yes if\n            you want to opt-in to the next auto minor version upgrade campaign. This parameter is\n            disabled for previous versions.  </p>",
+          "type": "boolean"
+        },
+        "SecurityGroups": {
+          "description": "<p>A list of VPC Security Groups associated with the cluster.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecurityGroupMembership"
+          }
+        },
+        "ReplicationGroupId": {
+          "description": "<p>The replication group to which this cluster belongs. If this field is empty, the\n            cluster is not associated with any replication group.</p>",
+          "type": "string"
+        },
+        "SnapshotRetentionLimit": {
+          "description": "<p>The number of days for which ElastiCache retains automatic cluster snapshots before\n            deleting them. For example, if you set <code>SnapshotRetentionLimit</code> to 5, a\n            snapshot that was taken today is retained for 5 days before being deleted.</p>\n         <important>\n            <p> If the value of SnapshotRetentionLimit is set to zero (0), backups are turned\n                off.</p>\n         </important>",
+          "type": "number"
+        },
+        "SnapshotWindow": {
+          "description": "<p>The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot\n            of your cluster.</p>\n         <p>Example: <code>05:00-09:00</code>\n         </p>",
+          "type": "string"
+        },
+        "AuthTokenEnabled": {
+          "description": "<p>A flag that enables using an <code>AuthToken</code> (password) when issuing Valkey or Redis OSS\n            commands.</p>\n         <p>Default: <code>false</code>\n         </p>",
+          "type": "boolean"
+        },
+        "AuthTokenLastModifiedDate": {
+          "description": "<p>The date the auth token was last modified</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "TransitEncryptionEnabled": {
+          "description": "<p>A flag that enables in-transit encryption when set to <code>true</code>.</p>\n         <p>\n            <b>Required:</b> Only available when creating a replication\n            group in an Amazon VPC using Redis OSS version <code>3.2.6</code>, <code>4.x</code> or\n            later.</p>\n         <p>Default: <code>false</code>\n         </p>",
+          "type": "boolean"
+        },
+        "AtRestEncryptionEnabled": {
+          "description": "<p>A flag that enables encryption at-rest when set to <code>true</code>.</p>\n         <p>You cannot modify the value of <code>AtRestEncryptionEnabled</code> after the cluster\n            is created. To enable at-rest encryption on a cluster you must set\n                <code>AtRestEncryptionEnabled</code> to <code>true</code> when you create a\n            cluster.</p>\n         <p>\n            <b>Required:</b> Only available when creating a replication\n            group in an Amazon VPC using Redis OSS version <code>3.2.6</code>, <code>4.x</code> or\n            later.</p>\n         <p>Default: <code>false</code>\n         </p>",
+          "type": "boolean"
+        },
+        "ARN": {
+          "description": "<p>The ARN (Amazon Resource Name) of the cache cluster.</p>",
+          "type": "string"
+        },
+        "ReplicationGroupLogDeliveryEnabled": {
+          "description": "<p>A boolean value indicating whether log delivery is enabled for the replication\n            group.</p>",
+          "type": "boolean"
+        },
+        "LogDeliveryConfigurations": {
+          "description": "<p>Returns the destination, format and type of the logs.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LogDeliveryConfiguration"
+          }
+        },
+        "NetworkType": {
+          "enum": [
+            "dual_stack",
+            "ipv4",
+            "ipv6"
+          ],
+          "description": "<p>Must be either <code>ipv4</code> | <code>ipv6</code> | <code>dual_stack</code>. IPv6\n            is supported for workloads using Valkey 7.2 and above, Redis OSS engine version 6.2\n            and above or Memcached engine version 1.6.6 and above on all instances built on the <a href=\"http://aws.amazon.com/ec2/nitro/\">Nitro system</a>.</p>",
+          "type": "string"
+        },
+        "IpDiscovery": {
+          "enum": [
+            "ipv4",
+            "ipv6"
+          ],
+          "description": "<p>The network type associated with the cluster, either <code>ipv4</code> |\n                <code>ipv6</code>. IPv6 is supported for workloads using Valkey 7.2 and above, Redis OSS engine version 6.2\n            and above or Memcached engine version 1.6.6 and above on all instances built on the <a href=\"http://aws.amazon.com/ec2/nitro/\">Nitro system</a>.</p>",
+          "type": "string"
+        },
+        "TransitEncryptionMode": {
+          "enum": [
+            "preferred",
+            "required"
+          ],
+          "description": "<p>A setting that allows you to migrate your clients to use in-transit encryption, with\n            no downtime.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Endpoint_1": {
+      "description": "<p>Represents the information required for client programs to connect to a cache\n            node. This value is read-only.</p>",
+      "type": "object",
+      "properties": {
+        "Address": {
+          "description": "<p>The DNS hostname of the cache node.</p>",
+          "type": "string"
+        },
+        "Port": {
+          "description": "<p>The port number that the cache engine is listening on.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "PendingModifiedValues_1": {
+      "description": "<p>A group of settings that are applied to the cluster in the future, or that are\n            currently being applied.</p>",
+      "type": "object",
+      "properties": {
+        "NumCacheNodes": {
+          "description": "<p>The new number of cache nodes for the cluster.</p>\n         <p>For clusters running Valkey or Redis OSS, this value must be 1. For clusters running Memcached, this\n            value must be between 1 and 40.</p>",
+          "type": "number"
+        },
+        "CacheNodeIdsToRemove": {
+          "description": "<p>A list of cache node IDs that are being removed (or will be removed) from the cluster.\n            A node ID is a 4-digit numeric identifier (0001, 0002, etc.).</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "EngineVersion": {
+          "description": "<p>The new cache engine version that the cluster runs.</p>",
+          "type": "string"
+        },
+        "CacheNodeType": {
+          "description": "<p>The cache node type that this cluster or replication group is scaled to.</p>",
+          "type": "string"
+        },
+        "AuthTokenStatus": {
+          "enum": [
+            "ROTATING",
+            "SETTING"
+          ],
+          "description": "<p>The auth token status</p>",
+          "type": "string"
+        },
+        "LogDeliveryConfigurations": {
+          "description": "<p>The log delivery configurations being modified </p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PendingLogDeliveryConfiguration"
+          }
+        },
+        "TransitEncryptionEnabled": {
+          "description": "<p>A flag that enables in-transit encryption when set to true.</p>",
+          "type": "boolean"
+        },
+        "TransitEncryptionMode": {
+          "enum": [
+            "preferred",
+            "required"
+          ],
+          "description": "<p>A setting that allows you to migrate your clients to use in-transit encryption, with\n            no downtime.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "PendingLogDeliveryConfiguration": {
+      "description": "<p>The log delivery configurations being modified </p>",
+      "type": "object",
+      "properties": {
+        "LogType": {
+          "enum": [
+            "engine-log",
+            "slow-log"
+          ],
+          "description": "<p>Refers to <a href=\"https://redis.io/commands/slowlog\">slow-log</a> or\n            engine-log..</p>",
+          "type": "string"
+        },
+        "DestinationType": {
+          "enum": [
+            "cloudwatch-logs",
+            "kinesis-firehose"
+          ],
+          "description": "<p>Returns the destination type, either CloudWatch Logs or Kinesis Data Firehose.</p>",
+          "type": "string"
+        },
+        "DestinationDetails": {
+          "description": "<p>Configuration details of either a CloudWatch Logs destination or Kinesis Data Firehose\n            destination.</p>",
+          "$ref": "#/definitions/DestinationDetails"
+        },
+        "LogFormat": {
+          "enum": [
+            "json",
+            "text"
+          ],
+          "description": "<p>Returns the log format, either JSON or TEXT</p>",
+          "type": "string"
+        }
+      }
+    },
+    "DestinationDetails": {
+      "description": "<p>Configuration details of either a CloudWatch Logs destination or Kinesis Data Firehose\n            destination.</p>",
+      "type": "object",
+      "properties": {
+        "CloudWatchLogsDetails": {
+          "description": "<p>The configuration details of the CloudWatch Logs destination.</p>",
+          "$ref": "#/definitions/CloudWatchLogsDestinationDetails"
+        },
+        "KinesisFirehoseDetails": {
+          "description": "<p>The configuration details of the Kinesis Data Firehose destination.</p>",
+          "$ref": "#/definitions/KinesisFirehoseDestinationDetails"
+        }
+      }
+    },
+    "CloudWatchLogsDestinationDetails": {
+      "description": "<p>The configuration details of the CloudWatch Logs destination.</p>",
+      "type": "object",
+      "properties": {
+        "LogGroup": {
+          "description": "<p>The name of the CloudWatch Logs log group.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "KinesisFirehoseDestinationDetails": {
+      "description": "<p>The configuration details of the Kinesis Data Firehose destination.</p>",
+      "type": "object",
+      "properties": {
+        "DeliveryStream": {
+          "description": "<p>The name of the Kinesis Data Firehose delivery stream.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "NotificationConfiguration": {
+      "description": "<p>Describes a notification topic and its status. Notification topics are used for\n            publishing ElastiCache events to subscribers using Amazon Simple Notification Service\n            (SNS).</p>",
+      "type": "object",
+      "properties": {
+        "TopicArn": {
+          "description": "<p>The Amazon Resource Name (ARN) that identifies the topic.</p>",
+          "type": "string"
+        },
+        "TopicStatus": {
+          "description": "<p>The current state of the topic.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "CacheSecurityGroupMembership": {
+      "description": "<p>Represents a cluster's status within a particular cache security group.</p>",
+      "type": "object",
+      "properties": {
+        "CacheSecurityGroupName": {
+          "description": "<p>The name of the cache security group.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "description": "<p>The membership status in the cache security group. The status changes when a cache\n            security group is modified, or when the cache security groups assigned to a cluster are\n            modified.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "CacheParameterGroupStatus": {
+      "description": "<p>Status of the cache parameter group.</p>",
+      "type": "object",
+      "properties": {
+        "CacheParameterGroupName": {
+          "description": "<p>The name of the cache parameter group.</p>",
+          "type": "string"
+        },
+        "ParameterApplyStatus": {
+          "description": "<p>The status of parameter updates.</p>",
+          "type": "string"
+        },
+        "CacheNodeIdsToReboot": {
+          "description": "<p>A list of the cache node IDs which need to be rebooted for parameter changes to be\n            applied. A node ID is a numeric identifier (0001, 0002, etc.).</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "CacheNode": {
+      "description": "<p>Represents an individual cache node within a cluster. Each cache node runs its own\n            instance of the cluster's protocol-compliant caching software - either Memcached, Valkey or Redis OSS.</p>\n         <p>The following node types are supported by ElastiCache. Generally speaking, the current\n            generation types provide more memory and computational power at lower cost when compared\n            to their equivalent previous generation counterparts.</p>\n         <ul>\n            <li>\n               <p>General purpose:</p>\n               <ul>\n                  <li>\n                     <p>Current generation: </p>\n                     <p>\n                        <b>M7g node types</b>:\n    \t\t\t\t\t<code>cache.m7g.large</code>,\n    \t\t\t\t\t<code>cache.m7g.xlarge</code>,\n    \t\t\t\t\t<code>cache.m7g.2xlarge</code>,\n    \t\t\t\t\t<code>cache.m7g.4xlarge</code>,\n    \t\t\t\t\t<code>cache.m7g.8xlarge</code>,\n    \t\t\t\t\t<code>cache.m7g.12xlarge</code>,\n    \t\t\t\t\t<code>cache.m7g.16xlarge</code>\n                     </p>\n                     <note>\n                        <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a>\n                        </p>\n                     </note>\n                     <p>\n                        <b>M6g node types</b> (available only for Redis OSS engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward):\n\n\t\t\t\t\t \t<code>cache.m6g.large</code>,\n\t\t\t\t\t\t\t<code>cache.m6g.xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.m6g.2xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.m6g.4xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.m6g.8xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.m6g.12xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.m6g.16xlarge</code>\n                     </p>\n                     <p>\n                        <b>M5 node types:</b>\n                        <code>cache.m5.large</code>,\n    \t\t\t\t\t\t<code>cache.m5.xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m5.2xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m5.4xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m5.12xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m5.24xlarge</code>\n                     </p>\n                     <p>\n                        <b>M4 node types:</b>\n                        <code>cache.m4.large</code>,\n    \t\t\t\t\t\t<code>cache.m4.xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m4.2xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m4.4xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m4.10xlarge</code>\n                     </p>\n                     <p>\n                        <b>T4g node types</b> (available only for Redis OSS engine version 5.0.6 onward and Memcached engine version 1.5.16 onward):\n\t\t\t\t\t        <code>cache.t4g.micro</code>,\n\t\t\t\t\t        <code>cache.t4g.small</code>,\n\t\t\t\t\t        <code>cache.t4g.medium</code>\n                     </p>\n                     <p>\n                        <b>T3 node types:</b>\n                        <code>cache.t3.micro</code>,\n    \t\t\t\t\t\t<code>cache.t3.small</code>,\n    \t\t\t\t\t\t<code>cache.t3.medium</code>\n                     </p>\n                     <p>\n                        <b>T2 node types:</b>\n                        <code>cache.t2.micro</code>,\n    \t\t\t\t\t\t<code>cache.t2.small</code>,\n    \t\t\t\t\t\t<code>cache.t2.medium</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>Previous generation: (not recommended. Existing clusters are still supported but creation of new clusters is not supported for these types.)</p>\n                     <p>\n                        <b>T1 node types:</b>\n                        <code>cache.t1.micro</code>\n                     </p>\n                     <p>\n                        <b>M1 node types:</b>\n                        <code>cache.m1.small</code>,\n\t\t\t\t\t\t   <code>cache.m1.medium</code>,\n\t\t\t\t\t\t   <code>cache.m1.large</code>,\n\t\t\t\t\t\t   <code>cache.m1.xlarge</code>\n                     </p>\n                     <p>\n                        <b>M3 node types:</b>\n                        <code>cache.m3.medium</code>,\n    \t\t\t\t\t\t<code>cache.m3.large</code>,\n    \t\t\t\t\t\t<code>cache.m3.xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m3.2xlarge</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Compute optimized:</p>\n               <ul>\n                  <li>\n                     <p>Previous generation: (not recommended. Existing clusters are still supported but creation of new clusters is not supported for these types.)</p>\n                     <p>\n                        <b>C1 node types:</b>\n                        <code>cache.c1.xlarge</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Memory optimized:</p>\n               <ul>\n                  <li>\n                     <p>Current generation: </p>\n                     <p>\n                        <b>R7g node types</b>:\n\t\t\t\t\t\t\t<code>cache.r7g.large</code>,\n\t\t\t\t\t\t\t<code>cache.r7g.xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r7g.2xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r7g.4xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r7g.8xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r7g.12xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r7g.16xlarge</code>\n                     </p>\n                     <note>\n                        <p>For region availability, see <a href=\"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion\">Supported Node Types</a>\n                        </p>\n                     </note>\n                     <p>\n                        <b>R6g node types</b> (available only for Redis OSS engine version 5.0.6 onward and for Memcached engine version 1.5.16 onward):\n\t\t\t\t\t\t\t<code>cache.r6g.large</code>,\n\t\t\t\t\t\t\t<code>cache.r6g.xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r6g.2xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r6g.4xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r6g.8xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r6g.12xlarge</code>,\n\t\t\t\t\t\t\t<code>cache.r6g.16xlarge</code>\n                     </p>\n                     <p>\n                        <b>R5 node types:</b>\n                        <code>cache.r5.large</code>,\n    \t\t\t\t\t   <code>cache.r5.xlarge</code>,\n    \t\t\t\t\t   <code>cache.r5.2xlarge</code>,\n    \t\t\t\t\t   <code>cache.r5.4xlarge</code>,\n    \t\t\t\t\t   <code>cache.r5.12xlarge</code>,\n    \t\t\t\t\t   <code>cache.r5.24xlarge</code>\n                     </p>\n                     <p>\n                        <b>R4 node types:</b>\n                        <code>cache.r4.large</code>,\n    \t\t\t\t\t   <code>cache.r4.xlarge</code>,\n    \t\t\t\t\t   <code>cache.r4.2xlarge</code>,\n    \t\t\t\t\t   <code>cache.r4.4xlarge</code>,\n    \t\t\t\t\t   <code>cache.r4.8xlarge</code>,\n    \t\t\t\t\t   <code>cache.r4.16xlarge</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>Previous generation: (not recommended. Existing clusters are still supported but creation of new clusters is not supported for these types.)</p>\n                     <p>\n                        <b>M2 node types:</b>\n                        <code>cache.m2.xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m2.2xlarge</code>,\n    \t\t\t\t\t\t<code>cache.m2.4xlarge</code>\n                     </p>\n                     <p>\n                        <b>R3 node types:</b>\n                        <code>cache.r3.large</code>,\n    \t\t\t\t\t\t<code>cache.r3.xlarge</code>,\n    \t\t\t\t\t\t<code>cache.r3.2xlarge</code>,\n    \t\t\t\t\t\t<code>cache.r3.4xlarge</code>,\n    \t\t\t\t\t\t<code>cache.r3.8xlarge</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>\n            <b>Additional node type info</b>\n         </p>\n         <ul>\n            <li>\n               <p>All current generation instance types are created in Amazon VPC by\n                    default.</p>\n            </li>\n            <li>\n               <p>Valkey or Redis OSS append-only files (AOF) are not supported for T1 or T2 instances.</p>\n            </li>\n            <li>\n               <p>Valkey or Redis OSS Multi-AZ with automatic failover is not supported on T1\n                    instances.</p>\n            </li>\n            <li>\n               <p>The configuration variables <code>appendonly</code> and\n                        <code>appendfsync</code> are not supported on Valkey, or on Redis OSS version 2.8.22 and\n                    later.</p>\n            </li>\n         </ul>",
+      "type": "object",
+      "properties": {
+        "CacheNodeId": {
+          "description": "<p>The cache node identifier. A node ID is a numeric identifier (0001, 0002, etc.). The\n            combination of cluster ID and node ID uniquely identifies every cache node used in a\n            customer's Amazon account.</p>",
+          "type": "string"
+        },
+        "CacheNodeStatus": {
+          "description": "<p>The current state of this cache node, one of the following values:\n                <code>available</code>, <code>creating</code>, <code>rebooting</code>, or\n                <code>deleting</code>.</p>",
+          "type": "string"
+        },
+        "CacheNodeCreateTime": {
+          "description": "<p>The date and time when the cache node was created.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "Endpoint": {
+          "description": "<p>The hostname for connecting to this cache node.</p>",
+          "$ref": "#/definitions/Endpoint_1"
+        },
+        "ParameterGroupStatus": {
+          "description": "<p>The status of the parameter group applied to this cache node.</p>",
+          "type": "string"
+        },
+        "SourceCacheNodeId": {
+          "description": "<p>The ID of the primary node to which this read replica node is synchronized. If this\n            field is empty, this node is not associated with a primary cluster.</p>",
+          "type": "string"
+        },
+        "CustomerAvailabilityZone": {
+          "description": "<p>The Availability Zone where this node was created and now resides.</p>",
+          "type": "string"
+        },
+        "CustomerOutpostArn": {
+          "description": "<p>The customer outpost ARN of the cache node.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "SecurityGroupMembership": {
+      "description": "<p>Represents a single cache security group and its status.</p>",
+      "type": "object",
+      "properties": {
+        "SecurityGroupId": {
+          "description": "<p>The identifier of the cache security group.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "description": "<p>The status of the cache security group membership. The status changes whenever a cache\n            security group is modified, or when the cache security groups assigned to a cluster are\n            modified.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "LogDeliveryConfiguration": {
+      "description": "<p>Returns the destination, format and type of the logs. </p>",
+      "type": "object",
+      "properties": {
+        "LogType": {
+          "enum": [
+            "engine-log",
+            "slow-log"
+          ],
+          "description": "<p>Refers to <a href=\"https://redis.io/commands/slowlog\">slow-log</a> or\n            engine-log.</p>",
+          "type": "string"
+        },
+        "DestinationType": {
+          "enum": [
+            "cloudwatch-logs",
+            "kinesis-firehose"
+          ],
+          "description": "<p>Returns the destination type, either <code>cloudwatch-logs</code> or\n                <code>kinesis-firehose</code>.</p>",
+          "type": "string"
+        },
+        "DestinationDetails": {
+          "description": "<p>Configuration details of either a CloudWatch Logs destination or Kinesis Data Firehose\n            destination.</p>",
+          "$ref": "#/definitions/DestinationDetails"
+        },
+        "LogFormat": {
+          "enum": [
+            "json",
+            "text"
+          ],
+          "description": "<p>Returns the log format, either JSON or TEXT.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "enum": [
+            "active",
+            "disabling",
+            "enabling",
+            "error",
+            "modifying"
+          ],
+          "description": "<p>Returns the log delivery configuration status. Values are one of <code>enabling</code>\n            | <code>disabling</code> | <code>modifying</code> | <code>active</code> |\n                <code>error</code>\n         </p>",
+          "type": "string"
+        },
+        "Message": {
+          "description": "<p>Returns an error message for the log delivery configuration.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Cluster_2": {
+      "description": "<p>Describes a cluster.</p>",
+      "type": "object",
+      "properties": {
+        "ClusterIdentifier": {
+          "description": "<p>The unique identifier of the cluster.</p>",
+          "type": "string"
+        },
+        "NodeType": {
+          "description": "<p>The node type for the nodes in the cluster.</p>",
+          "type": "string"
+        },
+        "ClusterStatus": {
+          "description": "<p> The current state of the cluster. Possible values are the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>available</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>available, prep-for-resize</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>available, resize-cleanup</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>cancelling-resize</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>creating</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>deleting</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>final-snapshot</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>hardware-failure</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>incompatible-hsm</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>incompatible-network</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>incompatible-parameters</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>incompatible-restore</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>modifying</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>paused</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>rebooting</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>renaming</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>resizing</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>rotating-keys</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>storage-full</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>updating-hsm</code>\n               </p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "ClusterAvailabilityStatus": {
+          "description": "<p>The availability status of the cluster for queries. Possible values are the following:</p>\n         <ul>\n            <li>\n               <p>Available - The cluster is available for queries. </p>\n            </li>\n            <li>\n               <p>Unavailable - The cluster is not available for queries.</p>\n            </li>\n            <li>\n               <p>Maintenance - The cluster is intermittently available for queries due to maintenance activities.</p>\n            </li>\n            <li>\n               <p>Modifying - The cluster is intermittently available for queries due to changes that modify the cluster.</p>\n            </li>\n            <li>\n               <p>Failed - The cluster failed and is not available for queries.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "ModifyStatus": {
+          "description": "<p>The status of a modify operation, if any, initiated for the cluster.</p>",
+          "type": "string"
+        },
+        "MasterUsername": {
+          "description": "<p>The admin user name for the cluster. This name is used to connect to the database\n            that is specified in the <b>DBName</b> parameter. </p>",
+          "type": "string"
+        },
+        "DBName": {
+          "description": "<p>The name of the initial database that was created when the cluster was created.\n            This same name is returned for the life of the cluster. If an initial database was not\n            specified, a database named <code>dev</code>dev was created by default. </p>",
+          "type": "string"
+        },
+        "Endpoint": {
+          "description": "<p>The connection endpoint.</p>",
+          "$ref": "#/definitions/Endpoint_2"
+        },
+        "ClusterCreateTime": {
+          "description": "<p>The date and time that the cluster was created.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "AutomatedSnapshotRetentionPeriod": {
+          "description": "<p>The number of days that automatic cluster snapshots are retained.</p>",
+          "type": "number"
+        },
+        "ManualSnapshotRetentionPeriod": {
+          "description": "<p>The default number of days to retain a manual snapshot. If the value is -1, the\n            snapshot is retained indefinitely. This setting doesn't change the retention period\n            of existing snapshots.</p>\n         <p>The value must be either -1 or an integer between 1 and 3,653.</p>",
+          "type": "number"
+        },
+        "ClusterSecurityGroups": {
+          "description": "<p>A list of cluster security group that are associated with the cluster. Each\n            security group is represented by an element that contains\n                <code>ClusterSecurityGroup.Name</code> and <code>ClusterSecurityGroup.Status</code>\n            subelements. </p>\n         <p>Cluster security groups are used when the cluster is not created in an Amazon\n            Virtual Private Cloud (VPC). Clusters that are created in a VPC use VPC security groups,\n            which are listed by the <b>VpcSecurityGroups</b> parameter.\n        </p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClusterSecurityGroupMembership"
+          }
+        },
+        "VpcSecurityGroups": {
+          "description": "<p>A list of Amazon Virtual Private Cloud (Amazon VPC) security groups that are\n            associated with the cluster. This parameter is returned only if the cluster is in a\n            VPC.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VpcSecurityGroupMembership_1"
+          }
+        },
+        "ClusterParameterGroups": {
+          "description": "<p>The list of cluster parameter groups that are associated with this cluster. Each\n            parameter group in the list is returned with its status.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClusterParameterGroupStatus"
+          }
+        },
+        "ClusterSubnetGroupName": {
+          "description": "<p>The name of the subnet group that is associated with the cluster. This parameter is\n            valid only when the cluster is in a VPC.</p>",
+          "type": "string"
+        },
+        "VpcId": {
+          "description": "<p>The identifier of the VPC the cluster is in, if the cluster is in a VPC.</p>",
+          "type": "string"
+        },
+        "AvailabilityZone": {
+          "description": "<p>The name of the Availability Zone in which the cluster is located.</p>",
+          "type": "string"
+        },
+        "PreferredMaintenanceWindow": {
+          "description": "<p>The weekly time range, in Universal Coordinated Time (UTC), during which system\n            maintenance can occur.</p>",
+          "type": "string"
+        },
+        "PendingModifiedValues": {
+          "description": "<p>A value that, if present, indicates that changes to the cluster are pending.\n            Specific pending changes are identified by subelements.</p>",
+          "$ref": "#/definitions/PendingModifiedValues_2"
+        },
+        "ClusterVersion": {
+          "description": "<p>The version ID of the Amazon Redshift engine that is running on the cluster.</p>",
+          "type": "string"
+        },
+        "AllowVersionUpgrade": {
+          "description": "<p>A boolean value that, if <code>true</code>, indicates that major version upgrades\n            will be applied automatically to the cluster during the maintenance window. </p>",
+          "type": "boolean"
+        },
+        "NumberOfNodes": {
+          "description": "<p>The number of compute nodes in the cluster.</p>",
+          "type": "number"
+        },
+        "PubliclyAccessible": {
+          "description": "<p>A boolean value that, if <code>true</code>, indicates that the cluster can be\n            accessed from a public network.</p>",
+          "type": "boolean"
+        },
+        "Encrypted": {
+          "description": "<p>A boolean value that, if <code>true</code>, indicates that data in the cluster is\n            encrypted at rest.</p>",
+          "type": "boolean"
+        },
+        "RestoreStatus": {
+          "description": "<p>A value that describes the status of a cluster restore action. This parameter\n            returns null if the cluster was not created by restoring a snapshot.</p>",
+          "$ref": "#/definitions/RestoreStatus"
+        },
+        "DataTransferProgress": {
+          "description": "<p></p>",
+          "$ref": "#/definitions/DataTransferProgress"
+        },
+        "HsmStatus": {
+          "description": "<p>A value that reports whether the Amazon Redshift cluster has finished applying any\n            hardware security module (HSM) settings changes specified in a modify cluster\n            command.</p>\n         <p>Values: active, applying</p>",
+          "$ref": "#/definitions/HsmStatus"
+        },
+        "ClusterSnapshotCopyStatus": {
+          "description": "<p>A value that returns the destination region and retention period that are\n            configured for cross-region snapshot copy.</p>",
+          "$ref": "#/definitions/ClusterSnapshotCopyStatus"
+        },
+        "ClusterPublicKey": {
+          "description": "<p>The public key for the cluster.</p>",
+          "type": "string"
+        },
+        "ClusterNodes": {
+          "description": "<p>The nodes in the cluster.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClusterNode"
+          }
+        },
+        "ElasticIpStatus": {
+          "description": "<p>The status of the elastic IP (EIP) address.</p>",
+          "$ref": "#/definitions/ElasticIpStatus"
+        },
+        "ClusterRevisionNumber": {
+          "description": "<p>The specific revision number of the database in the cluster.</p>",
+          "type": "string"
+        },
+        "Tags": {
+          "description": "<p>The list of tags for the cluster.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag_4"
+          }
+        },
+        "KmsKeyId": {
+          "description": "<p>The Key Management Service (KMS) key ID of the encryption key used to\n            encrypt data in the cluster.</p>",
+          "type": "string"
+        },
+        "EnhancedVpcRouting": {
+          "description": "<p>An option that specifies whether to create the cluster with enhanced VPC routing\n            enabled. To create a cluster that uses enhanced VPC routing, the cluster must be in a\n            VPC. For more information, see <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/enhanced-vpc-routing.html\">Enhanced VPC Routing</a> in\n            the Amazon Redshift Cluster Management Guide.</p>\n         <p>If this option is <code>true</code>, enhanced VPC routing is enabled. </p>\n         <p>Default: false</p>",
+          "type": "boolean"
+        },
+        "IamRoles": {
+          "description": "<p>A list of Identity and Access Management (IAM) roles that can be used by the\n            cluster to access other Amazon Web Services services.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClusterIamRole"
+          }
+        },
+        "PendingActions": {
+          "description": "<p>Cluster operations that are waiting to be started.</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "MaintenanceTrackName": {
+          "description": "<p>The name of the maintenance track for the cluster.</p>",
+          "type": "string"
+        },
+        "ElasticResizeNumberOfNodeOptions": {
+          "description": "<p>The number of nodes that you can resize the cluster to with the elastic resize method.\n        </p>",
+          "type": "string"
+        },
+        "DeferredMaintenanceWindows": {
+          "description": "<p>Describes a group of <code>DeferredMaintenanceWindow</code> objects.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeferredMaintenanceWindow"
+          }
+        },
+        "SnapshotScheduleIdentifier": {
+          "description": "<p>A unique identifier for the cluster snapshot schedule.</p>",
+          "type": "string"
+        },
+        "SnapshotScheduleState": {
+          "enum": [
+            "ACTIVE",
+            "FAILED",
+            "MODIFYING"
+          ],
+          "description": "<p>The current state of the cluster snapshot schedule.</p>",
+          "type": "string"
+        },
+        "ExpectedNextSnapshotScheduleTime": {
+          "description": "<p>The date and time when the next snapshot is expected to be taken for clusters with a valid snapshot schedule and backups enabled. </p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "ExpectedNextSnapshotScheduleTimeStatus": {
+          "description": "<p> The status of next expected snapshot for clusters having a valid snapshot schedule and backups enabled.  Possible values are the following:</p>\n         <ul>\n            <li>\n               <p>OnTrack - The next snapshot is expected to be taken on time. </p>\n            </li>\n            <li>\n               <p>Pending - The next snapshot is pending to be taken. </p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "NextMaintenanceWindowStartTime": {
+          "description": "<p>The date and time in UTC when system maintenance can begin.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "ResizeInfo": {
+          "description": "<p>Returns the following:</p>\n         <ul>\n            <li>\n               <p>AllowCancelResize: a boolean value indicating if the resize operation can be\n                    cancelled.</p>\n            </li>\n            <li>\n               <p>ResizeType: Returns ClassicResize</p>\n            </li>\n         </ul>",
+          "$ref": "#/definitions/ResizeInfo"
+        },
+        "AvailabilityZoneRelocationStatus": {
+          "description": "<p>Describes the status of the Availability Zone relocation operation.</p>",
+          "type": "string"
+        },
+        "ClusterNamespaceArn": {
+          "description": "<p>The namespace Amazon Resource Name (ARN) of the cluster.</p>",
+          "type": "string"
+        },
+        "TotalStorageCapacityInMegaBytes": {
+          "description": "<p>The total storage capacity of the cluster in megabytes. </p>",
+          "type": "number"
+        },
+        "AquaConfiguration": {
+          "description": "<p>This field is retired. Amazon Redshift automatically determines whether to use AQUA (Advanced Query Accelerator).</p>",
+          "$ref": "#/definitions/AquaConfiguration"
+        },
+        "DefaultIamRoleArn": {
+          "description": "<p>The Amazon Resource Name (ARN) for the IAM role set as default for the cluster.</p>",
+          "type": "string"
+        },
+        "ReservedNodeExchangeStatus": {
+          "description": "<p>The status of the reserved-node exchange request. Statuses include in-progress and requested.</p>",
+          "$ref": "#/definitions/ReservedNodeExchangeStatus"
+        },
+        "CustomDomainName": {
+          "description": "<p>The custom domain name associated with the cluster.</p>",
+          "type": "string"
+        },
+        "CustomDomainCertificateArn": {
+          "description": "<p>The certificate Amazon Resource Name (ARN) for the custom domain name.</p>",
+          "type": "string"
+        },
+        "CustomDomainCertificateExpiryDate": {
+          "description": "<p>The expiration date for the certificate associated with the custom domain name.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "MasterPasswordSecretArn": {
+          "description": "<p>The Amazon Resource Name (ARN) for the cluster's admin user credentials secret.</p>",
+          "type": "string"
+        },
+        "MasterPasswordSecretKmsKeyId": {
+          "description": "<p>The ID of the Key Management Service (KMS) key used to encrypt and store the cluster's admin credentials secret.</p>",
+          "type": "string"
+        },
+        "IpAddressType": {
+          "description": "<p>The IP address type for the cluster. Possible values are <code>ipv4</code> and <code>dualstack</code>.</p>",
+          "type": "string"
+        },
+        "MultiAZ": {
+          "description": "<p>A boolean value that, if true, indicates that the cluster is deployed in two Availability Zones.</p>",
+          "type": "string"
+        },
+        "MultiAZSecondary": {
+          "description": "<p>The secondary compute unit of a cluster, if Multi-AZ deployment is turned on.</p>",
+          "$ref": "#/definitions/SecondaryClusterInfo"
+        }
+      }
+    },
+    "Endpoint_2": {
+      "description": "<p>Describes a connection endpoint.</p>",
+      "type": "object",
+      "properties": {
+        "Address": {
+          "description": "<p>The DNS address of the Cluster.</p>",
+          "type": "string"
+        },
+        "Port": {
+          "description": "<p>The port that the database engine is listening on.</p>",
+          "type": "number"
+        },
+        "VpcEndpoints": {
+          "description": "<p>Describes a connection endpoint.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VpcEndpoint_1"
+          }
+        }
+      }
+    },
+    "VpcEndpoint_1": {
+      "description": "<p>The connection endpoint for connecting to an Amazon Redshift cluster through the proxy.</p>",
+      "type": "object",
+      "properties": {
+        "VpcEndpointId": {
+          "description": "<p>The connection endpoint ID for connecting an Amazon Redshift cluster through the proxy.</p>",
+          "type": "string"
+        },
+        "VpcId": {
+          "description": "<p>The VPC identifier that the endpoint is associated. </p>",
+          "type": "string"
+        },
+        "NetworkInterfaces": {
+          "description": "<p>One or more network interfaces of the endpoint. Also known as an interface endpoint. </p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkInterface_2"
+          }
+        }
+      }
+    },
+    "NetworkInterface_2": {
+      "description": "<p>Describes a network interface. </p>",
+      "type": "object",
+      "properties": {
+        "NetworkInterfaceId": {
+          "description": "<p>The network interface identifier. </p>",
+          "type": "string"
+        },
+        "SubnetId": {
+          "description": "<p>The subnet identifier. </p>",
+          "type": "string"
+        },
+        "PrivateIpAddress": {
+          "description": "<p>The IPv4 address of the network interface within the subnet. </p>",
+          "type": "string"
+        },
+        "AvailabilityZone": {
+          "description": "<p>The Availability Zone. </p>",
+          "type": "string"
+        },
+        "Ipv6Address": {
+          "description": "<p>The IPv6 address of the network interface within the subnet. </p>",
+          "type": "string"
+        }
+      }
+    },
+    "ClusterSecurityGroupMembership": {
+      "description": "<p>Describes a cluster security group.</p>",
+      "type": "object",
+      "properties": {
+        "ClusterSecurityGroupName": {
+          "description": "<p>The name of the cluster security group.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "description": "<p>The status of the cluster security group.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "VpcSecurityGroupMembership_1": {
+      "description": "<p>Describes the members of a VPC security group.</p>",
+      "type": "object",
+      "properties": {
+        "VpcSecurityGroupId": {
+          "description": "<p>The identifier of the VPC security group.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "description": "<p>The status of the VPC security group.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ClusterParameterGroupStatus": {
+      "description": "<p>Describes the status of a parameter group.</p>",
+      "type": "object",
+      "properties": {
+        "ParameterGroupName": {
+          "description": "<p>The name of the cluster parameter group.</p>",
+          "type": "string"
+        },
+        "ParameterApplyStatus": {
+          "description": "<p>The status of parameter updates.</p>",
+          "type": "string"
+        },
+        "ClusterParameterStatusList": {
+          "description": "<p>The list of parameter statuses.</p>\n         <p>\nFor more information about parameters and parameter groups, go to\n<a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-parameter-groups.html\">Amazon Redshift Parameter Groups</a>\nin the <i>Amazon Redshift Cluster Management Guide</i>.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClusterParameterStatus"
+          }
+        }
+      }
+    },
+    "ClusterParameterStatus": {
+      "description": "<p>Describes the status of a parameter group.</p>",
+      "type": "object",
+      "properties": {
+        "ParameterName": {
+          "description": "<p>The name of the parameter.</p>",
+          "type": "string"
+        },
+        "ParameterApplyStatus": {
+          "description": "<p>The status of the parameter that indicates whether the parameter is in sync with\n            the database, waiting for a cluster reboot, or encountered an error when being\n            applied.</p>\n         <p>The following are possible statuses and descriptions.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>in-sync</code>: The parameter value is in sync with the\n                    database.</p>\n            </li>\n            <li>\n               <p>\n                  <code>pending-reboot</code>: The parameter value will be applied after the\n                    cluster reboots.</p>\n            </li>\n            <li>\n               <p>\n                  <code>applying</code>: The parameter value is being applied to the\n                    database.</p>\n            </li>\n            <li>\n               <p>\n                  <code>invalid-parameter</code>: Cannot apply the parameter value because it has\n                    an invalid value or syntax.</p>\n            </li>\n            <li>\n               <p>\n                  <code>apply-deferred</code>: The parameter contains static property changes. The\n                    changes are deferred until the cluster reboots.</p>\n            </li>\n            <li>\n               <p>\n                  <code>apply-error</code>: Cannot connect to the cluster. The parameter change\n                    will be applied after the cluster reboots.</p>\n            </li>\n            <li>\n               <p>\n                  <code>unknown-error</code>: Cannot apply the parameter change right now. The\n                    change will be applied after the cluster reboots.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        },
+        "ParameterApplyErrorDescription": {
+          "description": "<p>The error that prevented the parameter from being applied to the\n            database.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "PendingModifiedValues_2": {
+      "description": "<p>Describes cluster attributes that are in a pending state. A change to one or more\n            the attributes was requested and is in progress or will be applied.</p>",
+      "type": "object",
+      "properties": {
+        "MasterUserPassword": {
+          "description": "<p>The pending or in-progress change of the admin user password for the\n            cluster.</p>",
+          "type": "string"
+        },
+        "NodeType": {
+          "description": "<p>The pending or in-progress change of the cluster's node type.</p>",
+          "type": "string"
+        },
+        "NumberOfNodes": {
+          "description": "<p>The pending or in-progress change of the number of nodes in the cluster.</p>",
+          "type": "number"
+        },
+        "ClusterType": {
+          "description": "<p>The pending or in-progress change of the cluster type.</p>",
+          "type": "string"
+        },
+        "ClusterVersion": {
+          "description": "<p>The pending or in-progress change of the service version.</p>",
+          "type": "string"
+        },
+        "AutomatedSnapshotRetentionPeriod": {
+          "description": "<p>The pending or in-progress change of the automated snapshot retention\n            period.</p>",
+          "type": "number"
+        },
+        "ClusterIdentifier": {
+          "description": "<p>The pending or in-progress change of the new identifier for the cluster.</p>",
+          "type": "string"
+        },
+        "PubliclyAccessible": {
+          "description": "<p>The pending or in-progress change of the ability to connect to the cluster from the\n            public network.</p>",
+          "type": "boolean"
+        },
+        "EnhancedVpcRouting": {
+          "description": "<p>An option that specifies whether to create the cluster with enhanced VPC routing\n            enabled. To create a cluster that uses enhanced VPC routing, the cluster must be in a\n            VPC. For more information, see <a href=\"https://docs.aws.amazon.com/redshift/latest/mgmt/enhanced-vpc-routing.html\">Enhanced VPC Routing</a> in\n            the Amazon Redshift Cluster Management Guide.</p>\n         <p>If this option is <code>true</code>, enhanced VPC routing is enabled. </p>\n         <p>Default: false</p>",
+          "type": "boolean"
+        },
+        "MaintenanceTrackName": {
+          "description": "<p>The name of the maintenance track that the cluster will change to during the next\n            maintenance window.</p>",
+          "type": "string"
+        },
+        "EncryptionType": {
+          "description": "<p>The encryption type for a cluster. Possible values are: KMS and None. </p>",
+          "type": "string"
+        }
+      }
+    },
+    "RestoreStatus": {
+      "description": "<p>Describes the status of a cluster restore action. Returns null if the cluster was\n            not created by restoring a snapshot.</p>",
+      "type": "object",
+      "properties": {
+        "Status": {
+          "description": "<p>The status of the restore action. Returns starting, restoring, completed, or\n            failed.</p>",
+          "type": "string"
+        },
+        "CurrentRestoreRateInMegaBytesPerSecond": {
+          "description": "<p>The number of megabytes per second being transferred from the backup storage.\n            Returns the average rate for a completed backup.\n            This field is only updated when you restore to DC2 node types. </p>",
+          "type": "number"
+        },
+        "SnapshotSizeInMegaBytes": {
+          "description": "<p>The size of the set of snapshot data used to restore the cluster.\n            This field is only updated when you restore to DC2 node types. </p>",
+          "type": "number"
+        },
+        "ProgressInMegaBytes": {
+          "description": "<p>The number of megabytes that have been transferred from snapshot storage.\n            This field is only updated when you restore to DC2 node types. </p>",
+          "type": "number"
+        },
+        "ElapsedTimeInSeconds": {
+          "description": "<p>The amount of time an in-progress restore has been running, or the amount of time\n            it took a completed restore to finish.\n            This field is only updated when you restore to DC2 node types. </p>",
+          "type": "number"
+        },
+        "EstimatedTimeToCompletionInSeconds": {
+          "description": "<p>The estimate of the time remaining before the restore will complete. Returns 0 for\n            a completed restore.\n            This field is only updated when you restore to DC2 node types. </p>",
+          "type": "number"
+        }
+      }
+    },
+    "DataTransferProgress": {
+      "description": "<p>Describes the status of a cluster while it is in the process of resizing with an\n            incremental resize.</p>",
+      "type": "object",
+      "properties": {
+        "Status": {
+          "description": "<p>Describes the status of the cluster. While the transfer is in progress the status is\n                <code>transferringdata</code>.</p>",
+          "type": "string"
+        },
+        "CurrentRateInMegaBytesPerSecond": {
+          "description": "<p>Describes the data transfer rate in MB's per second.</p>",
+          "type": "number"
+        },
+        "TotalDataInMegaBytes": {
+          "description": "<p>Describes the total amount of data to be transfered in megabytes.</p>",
+          "type": "number"
+        },
+        "DataTransferredInMegaBytes": {
+          "description": "<p>Describes the total amount of data that has been transfered in MB's.</p>",
+          "type": "number"
+        },
+        "EstimatedTimeToCompletionInSeconds": {
+          "description": "<p>Describes the estimated number of seconds remaining to complete the transfer.</p>",
+          "type": "number"
+        },
+        "ElapsedTimeInSeconds": {
+          "description": "<p>Describes the number of seconds that have elapsed during the data transfer.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "HsmStatus": {
+      "description": "<p>Describes the status of changes to HSM settings.</p>",
+      "type": "object",
+      "properties": {
+        "HsmClientCertificateIdentifier": {
+          "description": "<p>Specifies the name of the HSM client certificate the Amazon Redshift cluster uses to\n            retrieve the data encryption keys stored in an HSM.</p>",
+          "type": "string"
+        },
+        "HsmConfigurationIdentifier": {
+          "description": "<p>Specifies the name of the HSM configuration that contains the information the\n            Amazon Redshift cluster can use to retrieve and store keys in an HSM.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "description": "<p>Reports whether the Amazon Redshift cluster has finished applying any HSM settings\n            changes specified in a modify cluster command.</p>\n         <p>Values: active, applying</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ClusterSnapshotCopyStatus": {
+      "description": "<p>Returns the destination region and retention period that are configured for\n            cross-region snapshot copy.</p>",
+      "type": "object",
+      "properties": {
+        "DestinationRegion": {
+          "description": "<p>The destination region that snapshots are automatically copied to when cross-region\n            snapshot copy is enabled.</p>",
+          "type": "string"
+        },
+        "RetentionPeriod": {
+          "description": "<p>The number of days that automated snapshots are retained in the destination region\n            after they are copied from a source region.</p>",
+          "type": "number"
+        },
+        "ManualSnapshotRetentionPeriod": {
+          "description": "<p>The number of days that automated snapshots are retained in the destination region\n            after they are copied from a source region. If the value is -1, the manual snapshot is\n            retained indefinitely. </p>\n         <p>The value must be either -1 or an integer between 1 and 3,653.</p>",
+          "type": "number"
+        },
+        "SnapshotCopyGrantName": {
+          "description": "<p>The name of the snapshot copy grant.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ClusterNode": {
+      "description": "<p>The identifier of a node in a cluster.</p>",
+      "type": "object",
+      "properties": {
+        "NodeRole": {
+          "description": "<p>Whether the node is a leader node or a compute node.</p>",
+          "type": "string"
+        },
+        "PrivateIPAddress": {
+          "description": "<p>The private IP address of a node within a cluster.</p>",
+          "type": "string"
+        },
+        "PublicIPAddress": {
+          "description": "<p>The public IP address of a node within a cluster.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ElasticIpStatus": {
+      "description": "<p>Describes the status of the elastic IP (EIP) address.</p>",
+      "type": "object",
+      "properties": {
+        "ElasticIp": {
+          "description": "<p>The elastic IP (EIP) address for the cluster.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "description": "<p>The status of the elastic IP (EIP) address.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "Tag_4": {
+      "description": "<p>A tag consisting of a name/value pair for a resource.</p>",
+      "type": "object",
+      "properties": {
+        "Key": {
+          "description": "<p>The key, or name, for the resource tag.</p>",
+          "type": "string"
+        },
+        "Value": {
+          "description": "<p>The value for the resource tag.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ClusterIamRole": {
+      "description": "<p>An Identity and Access Management (IAM) role that can be used by the associated\n            Amazon Redshift cluster to access other Amazon Web Services services.</p>",
+      "type": "object",
+      "properties": {
+        "IamRoleArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the IAM role, for example,\n                <code>arn:aws:iam::123456789012:role/RedshiftCopyUnload</code>. </p>",
+          "type": "string"
+        },
+        "ApplyStatus": {
+          "description": "<p>A value that describes the status of the IAM role's association with an Amazon\n            Redshift cluster.</p>\n         <p>The following are possible statuses and descriptions.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>in-sync</code>: The role is available for use by the cluster.</p>\n            </li>\n            <li>\n               <p>\n                  <code>adding</code>: The role is in the process of being associated with the\n                    cluster.</p>\n            </li>\n            <li>\n               <p>\n                  <code>removing</code>: The role is in the process of being disassociated with\n                    the cluster.</p>\n            </li>\n         </ul>",
+          "type": "string"
+        }
+      }
+    },
+    "DeferredMaintenanceWindow": {
+      "description": "<p>Describes a deferred maintenance window</p>",
+      "type": "object",
+      "properties": {
+        "DeferMaintenanceIdentifier": {
+          "description": "<p>A unique identifier for the maintenance window.</p>",
+          "type": "string"
+        },
+        "DeferMaintenanceStartTime": {
+          "description": "<p> A timestamp for the beginning of the time period when we defer maintenance.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "DeferMaintenanceEndTime": {
+          "description": "<p> A timestamp for the end of the time period when we defer maintenance.</p>",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "ResizeInfo": {
+      "description": "<p>Describes a resize operation.</p>",
+      "type": "object",
+      "properties": {
+        "ResizeType": {
+          "description": "<p>Returns the value <code>ClassicResize</code>.</p>",
+          "type": "string"
+        },
+        "AllowCancelResize": {
+          "description": "<p>A boolean value indicating if the resize operation can be cancelled.</p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "AquaConfiguration": {
+      "description": "<p>The operation that uses this structure is retired. Amazon Redshift automatically determines whether to use AQUA (Advanced Query Accelerator).</p>",
+      "type": "object",
+      "properties": {
+        "AquaStatus": {
+          "enum": [
+            "applying",
+            "disabled",
+            "enabled"
+          ],
+          "description": "<p>This field is retired. Amazon Redshift automatically determines whether to use AQUA (Advanced Query Accelerator).</p>",
+          "type": "string"
+        },
+        "AquaConfigurationStatus": {
+          "enum": [
+            "auto",
+            "disabled",
+            "enabled"
+          ],
+          "description": "<p>This field is retired. Amazon Redshift automatically determines whether to use AQUA (Advanced Query Accelerator).</p>",
+          "type": "string"
+        }
+      }
+    },
+    "ReservedNodeExchangeStatus": {
+      "description": "<p>Reserved-node status details, such as the source reserved-node\n            identifier, the target reserved-node identifier, the node type, the node count, and\n            other details.</p>",
+      "type": "object",
+      "properties": {
+        "ReservedNodeExchangeRequestId": {
+          "description": "<p>The identifier of the reserved-node exchange request.</p>",
+          "type": "string"
+        },
+        "Status": {
+          "enum": [
+            "FAILED",
+            "IN_PROGRESS",
+            "PENDING",
+            "REQUESTED",
+            "RETRYING",
+            "SUCCEEDED"
+          ],
+          "description": "<p>The status of the reserved-node exchange request. Statuses include in-progress and requested.</p>",
+          "type": "string"
+        },
+        "RequestTime": {
+          "description": "<p>A date and time that indicate when the reserved-node exchange was requested.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "SourceReservedNodeId": {
+          "description": "<p>The identifier of the source reserved node.</p>",
+          "type": "string"
+        },
+        "SourceReservedNodeType": {
+          "description": "<p>The source reserved-node type, for example ra3.4xlarge.</p>",
+          "type": "string"
+        },
+        "SourceReservedNodeCount": {
+          "description": "<p>The source reserved-node count in the cluster.</p>",
+          "type": "number"
+        },
+        "TargetReservedNodeOfferingId": {
+          "description": "<p>The identifier of the target reserved node offering.</p>",
+          "type": "string"
+        },
+        "TargetReservedNodeType": {
+          "description": "<p>The node type of the target reserved node, for example ra3.4xlarge.</p>",
+          "type": "string"
+        },
+        "TargetReservedNodeCount": {
+          "description": "<p>The count of target reserved nodes in the cluster.</p>",
+          "type": "number"
+        }
+      }
+    },
+    "SecondaryClusterInfo": {
+      "description": "<p>The AvailabilityZone and ClusterNodes information of the secondary compute unit.</p>",
+      "type": "object",
+      "properties": {
+        "AvailabilityZone": {
+          "description": "<p>The name of the Availability Zone in which the secondary compute unit of the cluster is located.</p>",
+          "type": "string"
+        },
+        "ClusterNodes": {
+          "description": "<p>The nodes in the secondary compute unit.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClusterNode"
+          }
+        }
+      }
+    },
+    "MetricAlarm": {
+      "description": "<p>The details about a metric alarm.</p>",
+      "type": "object",
+      "properties": {
+        "AlarmName": {
+          "description": "<p>The name of the alarm.</p>",
+          "type": "string"
+        },
+        "AlarmArn": {
+          "description": "<p>The Amazon Resource Name (ARN) of the alarm.</p>",
+          "type": "string"
+        },
+        "AlarmDescription": {
+          "description": "<p>The description of the alarm.</p>",
+          "type": "string"
+        },
+        "AlarmConfigurationUpdatedTimestamp": {
+          "description": "<p>The time stamp of the last update to the alarm configuration.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "ActionsEnabled": {
+          "description": "<p>Indicates whether actions should be executed during any changes to the alarm state.</p>",
+          "type": "boolean"
+        },
+        "OKActions": {
+          "description": "<p>The actions to execute when this alarm transitions to the <code>OK</code> state\n\t\t\tfrom any other state. Each action is specified as an Amazon Resource Name (ARN).</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AlarmActions": {
+          "description": "<p>The actions to execute when this alarm transitions to the <code>ALARM</code> state\n\t\t\tfrom any other state. Each action is specified as an Amazon Resource Name (ARN).</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "InsufficientDataActions": {
+          "description": "<p>The actions to execute when this alarm transitions to the <code>INSUFFICIENT_DATA</code> state\n\t\t\tfrom any other state. Each action is specified as an Amazon Resource Name (ARN).</p>",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "StateValue": {
+          "enum": [
+            "ALARM",
+            "INSUFFICIENT_DATA",
+            "OK"
+          ],
+          "description": "<p>The state value for the alarm.</p>",
+          "type": "string"
+        },
+        "StateReason": {
+          "description": "<p>An explanation for the alarm state, in text format.</p>",
+          "type": "string"
+        },
+        "StateReasonData": {
+          "description": "<p>An explanation for the alarm state, in JSON format.</p>",
+          "type": "string"
+        },
+        "StateUpdatedTimestamp": {
+          "description": "<p>The time stamp of the last update to the value of either the\n\t\t\t<code>StateValue</code> or <code>EvaluationState</code> parameters.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "MetricName": {
+          "description": "<p>The name of the metric associated with the alarm, if this is an alarm\n\t\tbased on a single metric.</p>",
+          "type": "string"
+        },
+        "Namespace": {
+          "description": "<p>The namespace of the metric associated with the alarm.</p>",
+          "type": "string"
+        },
+        "Statistic": {
+          "enum": [
+            "Average",
+            "Maximum",
+            "Minimum",
+            "SampleCount",
+            "Sum"
+          ],
+          "description": "<p>The statistic for the metric associated with the alarm, other than percentile.\n\t\t    For percentile statistics, use <code>ExtendedStatistic</code>.</p>",
+          "type": "string"
+        },
+        "ExtendedStatistic": {
+          "description": "<p>The percentile statistic for the metric associated with the alarm. Specify a value between\n\t\t\tp0.0 and p100.</p>",
+          "type": "string"
+        },
+        "Dimensions": {
+          "description": "<p>The dimensions for the metric associated with the alarm.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Dimension"
+          }
+        },
+        "Period": {
+          "description": "<p>The period, in seconds, over which the statistic is applied.</p>",
+          "type": "number"
+        },
+        "Unit": {
+          "enum": [
+            "Bits",
+            "Bits/Second",
+            "Bytes",
+            "Bytes/Second",
+            "Count",
+            "Count/Second",
+            "Gigabits",
+            "Gigabits/Second",
+            "Gigabytes",
+            "Gigabytes/Second",
+            "Kilobits",
+            "Kilobits/Second",
+            "Kilobytes",
+            "Kilobytes/Second",
+            "Megabits",
+            "Megabits/Second",
+            "Megabytes",
+            "Megabytes/Second",
+            "Microseconds",
+            "Milliseconds",
+            "None",
+            "Percent",
+            "Seconds",
+            "Terabits",
+            "Terabits/Second",
+            "Terabytes",
+            "Terabytes/Second"
+          ],
+          "description": "<p>The unit of the metric associated with the alarm.</p>",
+          "type": "string"
+        },
+        "EvaluationPeriods": {
+          "description": "<p>The number of periods over which data is compared to the specified threshold.</p>",
+          "type": "number"
+        },
+        "DatapointsToAlarm": {
+          "description": "<p>The number of data points that must be breaching to trigger the alarm.</p>",
+          "type": "number"
+        },
+        "Threshold": {
+          "description": "<p>The value to compare with the specified statistic.</p>",
+          "type": "number"
+        },
+        "ComparisonOperator": {
+          "enum": [
+            "GreaterThanOrEqualToThreshold",
+            "GreaterThanThreshold",
+            "GreaterThanUpperThreshold",
+            "LessThanLowerOrGreaterThanUpperThreshold",
+            "LessThanLowerThreshold",
+            "LessThanOrEqualToThreshold",
+            "LessThanThreshold"
+          ],
+          "description": "<p>The arithmetic operation to use when comparing the specified\n\t\t\tstatistic and threshold. The specified statistic value is used as the first operand.</p>",
+          "type": "string"
+        },
+        "TreatMissingData": {
+          "description": "<p>Sets how this alarm is to handle missing data points. The valid values\n        \tare <code>breaching</code>, <code>notBreaching</code>, <code>ignore</code>, and\n        \t<code>missing</code>. For more information, see\n        \t<a href=\"https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-missing-data\">Configuring how CloudWatch alarms treat missing data</a>.</p>\n         <p>If this parameter is omitted, the default\n        \tbehavior of <code>missing</code> is used.</p>",
+          "type": "string"
+        },
+        "EvaluateLowSampleCountPercentile": {
+          "description": "<p>Used only for alarms based on percentiles. If <code>ignore</code>, the alarm state does not change\n\t\t\tduring periods with too few data points to be statistically significant. If <code>evaluate</code> or this\n\t\t\tparameter is not used, the alarm is always evaluated and possibly changes state no matter\n\t\t\thow many data points are available.</p>",
+          "type": "string"
+        },
+        "Metrics": {
+          "description": "<p>An array of MetricDataQuery structures, used in an alarm based on a\n\t\t\tmetric math expression. Each structure either retrieves a\n\t\t\tmetric or performs a math expression.\n\n\t\t\tOne item in the Metrics array is the math expression that the alarm watches.\n\t\t\tThis expression by designated by having <code>ReturnData</code> set to\n\t\t\ttrue.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MetricDataQuery"
+          }
+        },
+        "ThresholdMetricId": {
+          "description": "<p>In an alarm based on an anomaly detection model, this is the ID of the\n\t\t\t<code>ANOMALY_DETECTION_BAND</code> function\n\t\t\tused as the threshold for the alarm.</p>",
+          "type": "string"
+        },
+        "EvaluationState": {
+          "enum": "",
+          "description": "<p>If the value of this field is\n\t<code>PARTIAL_DATA</code>, the alarm is being evaluated based on only partial data. This happens if the\n\tquery used for the alarm returns more than 10,000 metrics. For\n\tmore information, see\n\t\t<a href=\"https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Create_Metrics_Insights_Alarm.html\">Create alarms on Metrics Insights queries</a>.</p>",
+          "const": "PARTIAL_DATA",
+          "type": "string"
+        },
+        "StateTransitionedTimestamp": {
+          "description": "<p>The date and time that the alarm's <code>StateValue</code> most recently changed.</p>",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "Dimension": {
+      "description": "<p>A dimension is a name/value pair that is part of the identity of a metric. Because dimensions are part of the unique\n\t\t\tidentifier for a metric, whenever you add a unique name/value pair to one of\n\t\t\tyour metrics, you are creating a new variation of that metric. For example, many Amazon EC2 metrics publish\n\t\t<code>InstanceId</code> as a dimension name, and the actual instance ID as the value for that dimension.</p>\n         <p>You\n\t\tcan assign up to 30 dimensions to a metric.</p>",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "<p>The name of the dimension. Dimension names must contain only ASCII characters, must include\n\t\t\tat least one non-whitespace character, and cannot start with a colon (<code>:</code>).\n\t\t\tASCII\n\t\t\tcontrol characters are not supported as part of dimension names.</p>",
+          "type": "string"
+        },
+        "Value": {
+          "description": "<p>The value of the dimension. Dimension values must contain only ASCII characters and must include\n\t\t\tat least one non-whitespace character. ASCII\n\t\t\tcontrol characters are not supported as part of dimension values.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Name",
+        "Value"
+      ]
+    },
+    "MetricDataQuery": {
+      "description": "<p>This structure is used in both <code>GetMetricData</code> and <code>PutMetricAlarm</code>. The supported\n\t\t\tuse of this structure is different for those two operations.</p>\n         <p>When used in <code>GetMetricData</code>, it indicates the metric data to return, and whether this call is just retrieving\n\t\t\ta batch set of data for one metric, or is performing a Metrics Insights query or a math expression. A\n\t\t\tsingle <code>GetMetricData</code> call can include up to 500 <code>MetricDataQuery</code>\n\t\t\tstructures.</p>\n         <p>When used in <code>PutMetricAlarm</code>, it enables you to create an alarm based on a\n\t\t\tmetric math expression. Each <code>MetricDataQuery</code> in the array specifies either\n\t\t\ta metric to retrieve, or a math expression to be performed on retrieved metrics. A\n\t\t\tsingle <code>PutMetricAlarm</code> call can include up to 20\n\t\t\t\t<code>MetricDataQuery</code> structures in the array. The 20 structures can include\n\t\t\tas many as 10 structures that contain a <code>MetricStat</code> parameter to retrieve a\n\t\t\tmetric, and as many as 10 structures that contain the <code>Expression</code> parameter\n\t\t\tto perform a math expression. Of those <code>Expression</code> structures, one must have <code>true</code>\n\t\tas the value for <code>ReturnData</code>. The result of this expression is the value the alarm watches.</p>\n         <p>Any expression used in a <code>PutMetricAlarm</code>\n\t\t\toperation must return a single time series. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html#metric-math-syntax\">Metric Math Syntax and Functions</a> in the <i>Amazon CloudWatch User\n\t\t\t\tGuide</i>.</p>\n         <p>Some of the parameters of this structure also have different uses whether you are using this structure in a <code>GetMetricData</code>\n\t\t\toperation or a <code>PutMetricAlarm</code> operation. These differences are explained in the following parameter list.</p>",
+      "type": "object",
+      "properties": {
+        "Id": {
+          "description": "<p>A short name used to tie this object to the results in the response. This name must be\n\t\t\tunique within a single call to <code>GetMetricData</code>. If you are performing math\n\t\t\texpressions on this set of data, this name represents that data and can serve as a\n\t\t\tvariable in the mathematical expression. The valid characters are letters, numbers, and\n\t\t\tunderscore. The first character must be a lowercase letter.</p>",
+          "type": "string"
+        },
+        "MetricStat": {
+          "description": "<p>The metric to be returned, along with statistics, period, and units. Use this parameter only if this object is retrieving a metric\n\t\t\tand not performing a math expression on returned data.</p>\n         <p>Within one MetricDataQuery object, you must specify either\n\t\t\t<code>Expression</code> or <code>MetricStat</code> but not both.</p>",
+          "$ref": "#/definitions/MetricStat"
+        },
+        "Expression": {
+          "description": "<p>This field can contain either a Metrics Insights query, or a metric math expression to be performed on the\n\t\t\treturned data. For more information about Metrics Insights queries, see\n\t\t\t<a href=\"https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch-metrics-insights-querylanguage\">Metrics Insights query components and syntax</a> in the\n\t\t\t<i>Amazon CloudWatch User Guide</i>.</p>\n         <p>A math expression\n\t\t\tcan use the <code>Id</code> of the other metrics or queries to refer to those metrics, and can also use\n\t\t\tthe <code>Id</code> of other\n\t\t\texpressions to use the result of those expressions. For more information about metric math expressions, see\n\t\t\t<a href=\"https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html#metric-math-syntax\">Metric Math Syntax and Functions</a> in the\n\t\t\t<i>Amazon CloudWatch User Guide</i>.</p>\n         <p>Within each MetricDataQuery object, you must specify either\n\t\t\t<code>Expression</code> or <code>MetricStat</code> but not both.</p>",
+          "type": "string"
+        },
+        "Label": {
+          "description": "<p>A human-readable label for this metric or expression. This is especially useful\n\t\t\tif this is an expression, so that you know\n\t\t\twhat the value represents. If the metric or expression is shown in a\n\t\t\tCloudWatch dashboard widget, the label is shown. If Label is omitted, CloudWatch\n\t\t\tgenerates a default.</p>\n         <p>You can put dynamic expressions into a label, so that it is more descriptive.\n\t\t\tFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/graph-dynamic-labels.html\">Using Dynamic Labels</a>.</p>",
+          "type": "string"
+        },
+        "ReturnData": {
+          "description": "<p>When used in <code>GetMetricData</code>, this option indicates whether to return the\n\t\t\ttimestamps and raw data values of this metric. If you are performing this call just to\n\t\t\tdo math expressions and do not also need the raw data returned, you can specify\n\t\t\t\t<code>false</code>. If you omit this, the default of <code>true</code> is\n\t\t\tused.</p>\n         <p>When used in <code>PutMetricAlarm</code>, specify <code>true</code> for the one expression result to use as the alarm. For all\n\t\tother metrics and expressions in the same <code>PutMetricAlarm</code> operation, specify <code>ReturnData</code> as False.</p>",
+          "type": "boolean"
+        },
+        "Period": {
+          "description": "<p>The granularity, in seconds, of the returned data points. For metrics with regular resolution, a\n\t\t\tperiod can be as short as one minute (60 seconds) and must be a multiple of 60.\n\t\t\tFor high-resolution metrics that are collected at intervals of less than one minute,\n\t\t\tthe period can be 1, 5, 10, 30, 60, or any multiple of 60. High-resolution metrics are those metrics\n\t\t\tstored by a <code>PutMetricData</code> operation that includes a <code>StorageResolution of 1 second</code>.</p>",
+          "type": "number"
+        },
+        "AccountId": {
+          "description": "<p>The ID of the account where the metrics are located.</p>\n         <p>If you are performing a <code>GetMetricData</code> operation in a monitoring account, use this to specify\n\t\t\twhich account to retrieve this metric from.</p>\n         <p>If you are performing a <code>PutMetricAlarm</code> operation, use this to specify\n\t\t\twhich account contains the metric that the alarm is watching.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Id"
+      ]
+    },
+    "MetricStat": {
+      "description": "<p>This structure defines the metric to be returned, along with the statistics, period, and units.</p>",
+      "type": "object",
+      "properties": {
+        "Metric": {
+          "description": "<p>The metric to return, including the metric name, namespace, and dimensions.</p>",
+          "$ref": "#/definitions/Metric"
+        },
+        "Period": {
+          "description": "<p>The granularity, in seconds, of the returned data points. For metrics with regular resolution, a period can\n\t\t\tbe as short as one minute (60 seconds) and must be a multiple of 60. For high-resolution metrics that are collected\n\t\t\tat intervals of less than one minute, the period can be 1, 5, 10, 30, 60, or any multiple of 60. High-resolution metrics\n\t\t\tare those metrics stored by a <code>PutMetricData</code> call that includes a <code>StorageResolution</code> of 1 second.</p>\n         <p>If the <code>StartTime</code> parameter specifies a time stamp that is greater than\n\t\t\t\t3 hours ago, you must specify the period as follows or no data points in that time range is returned:</p>\n         <ul>\n            <li>\n               <p>Start time between 3 hours and 15 days ago - Use a multiple of 60 seconds (1 minute).</p>\n            </li>\n            <li>\n               <p>Start time between 15 and 63 days ago - Use a multiple of 300 seconds (5 minutes).</p>\n            </li>\n            <li>\n               <p>Start time greater than 63 days ago - Use a multiple of 3600 seconds (1 hour).</p>\n            </li>\n         </ul>",
+          "type": "number"
+        },
+        "Stat": {
+          "description": "<p>The statistic to return. It can include any CloudWatch statistic or extended statistic.</p>",
+          "type": "string"
+        },
+        "Unit": {
+          "enum": [
+            "Bits",
+            "Bits/Second",
+            "Bytes",
+            "Bytes/Second",
+            "Count",
+            "Count/Second",
+            "Gigabits",
+            "Gigabits/Second",
+            "Gigabytes",
+            "Gigabytes/Second",
+            "Kilobits",
+            "Kilobits/Second",
+            "Kilobytes",
+            "Kilobytes/Second",
+            "Megabits",
+            "Megabits/Second",
+            "Megabytes",
+            "Megabytes/Second",
+            "Microseconds",
+            "Milliseconds",
+            "None",
+            "Percent",
+            "Seconds",
+            "Terabits",
+            "Terabits/Second",
+            "Terabytes",
+            "Terabytes/Second"
+          ],
+          "description": "<p>When you are using a <code>Put</code> operation, this defines what unit you want to use when storing the metric.</p>\n         <p>In a <code>Get</code> operation, if you omit <code>Unit</code> then all data that was collected with any unit is returned, along with the corresponding units that were specified\n\t\t\twhen the data was reported to CloudWatch. If you specify a unit, the operation returns only data that was collected with that unit specified.\n\t\t\tIf you specify a unit that does not match the data collected, the results of the operation are null. CloudWatch does not perform unit conversions.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Metric",
+        "Period",
+        "Stat"
+      ]
+    },
+    "Metric": {
+      "description": "<p>Represents a specific metric.</p>",
+      "type": "object",
+      "properties": {
+        "Namespace": {
+          "description": "<p>The namespace of the metric.</p>",
+          "type": "string"
+        },
+        "MetricName": {
+          "description": "<p>The name of the metric. This is a required field.</p>",
+          "type": "string"
+        },
+        "Dimensions": {
+          "description": "<p>The dimensions for the metric.</p>",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Dimension"
+          }
+        }
+      }
+    },
+    "MetricStreamEntry": {
+      "description": "<p>This structure contains the configuration information about one metric stream.</p>",
+      "type": "object",
+      "properties": {
+        "Arn": {
+          "description": "<p>The ARN of the metric stream.</p>",
+          "type": "string"
+        },
+        "CreationDate": {
+          "description": "<p>The date that the metric stream was originally created.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "LastUpdateDate": {
+          "description": "<p>The date that the configuration of this metric stream was most recently updated.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "Name": {
+          "description": "<p>The name of the metric stream.</p>",
+          "type": "string"
+        },
+        "FirehoseArn": {
+          "description": "<p>The ARN of the Kinesis Firehose devlivery stream that is used for this metric stream.</p>",
+          "type": "string"
+        },
+        "State": {
+          "description": "<p>The current state of this stream. Valid values are <code>running</code> and <code>stopped</code>.</p>",
+          "type": "string"
+        },
+        "OutputFormat": {
+          "enum": [
+            "json",
+            "opentelemetry0.7",
+            "opentelemetry1.0"
+          ],
+          "description": "<p>The output format of this metric stream. Valid values are\n\t\t\t<code>json</code>, <code>opentelemetry1.0</code>,\n\t\t\tand <code>opentelemetry0.7</code>.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "NamedQuery": {
+      "description": "<p>A query, where <code>QueryString</code> contains the SQL statements that make up the\n            query.</p>",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "<p>The query name.</p>",
+          "type": "string"
+        },
+        "Description": {
+          "description": "<p>The query description.</p>",
+          "type": "string"
+        },
+        "Database": {
+          "description": "<p>The database to which the query belongs.</p>",
+          "type": "string"
+        },
+        "QueryString": {
+          "description": "<p>The SQL statements that make up the query.</p>",
+          "type": "string"
+        },
+        "NamedQueryId": {
+          "description": "<p>The unique identifier of the query.</p>",
+          "type": "string"
+        },
+        "WorkGroup": {
+          "description": "<p>The name of the workgroup that contains the named query.</p>",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Database",
+        "Name",
+        "QueryString"
+      ]
+    },
+    "HostedZone": {
+      "description": "<p>A complex type that contains general information about the hosted zone.</p>",
+      "type": "object",
+      "properties": {
+        "Id": {
+          "description": "<p>The ID that Amazon Route 53 assigned to the hosted zone when you created it.</p>",
+          "type": "string"
+        },
+        "Name": {
+          "description": "<p>The name of the domain. For public hosted zones, this is the name that you have\n\t\t\tregistered with your DNS registrar.</p>\n         <p>For information about how to specify characters other than <code>a-z</code>,\n\t\t\t\t<code>0-9</code>, and <code>-</code> (hyphen) and how to specify internationalized\n\t\t\tdomain names, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateHostedZone.html\">CreateHostedZone</a>.</p>",
+          "type": "string"
+        },
+        "CallerReference": {
+          "description": "<p>The value that you specified for <code>CallerReference</code> when you created the\n\t\t\thosted zone.</p>",
+          "type": "string"
+        },
+        "Config": {
+          "description": "<p>A complex type that includes the <code>Comment</code> and <code>PrivateZone</code>\n\t\t\telements. If you omitted the <code>HostedZoneConfig</code> and <code>Comment</code>\n\t\t\telements from the request, the <code>Config</code> and <code>Comment</code> elements\n\t\t\tdon't appear in the response.</p>",
+          "$ref": "#/definitions/HostedZoneConfig"
+        },
+        "ResourceRecordSetCount": {
+          "description": "<p>The number of resource record sets in the hosted zone.</p>",
+          "type": "number"
+        },
+        "LinkedService": {
+          "description": "<p>If the hosted zone was created by another service, the service that created the hosted\n\t\t\tzone. When a hosted zone is created by another service, you can't edit or delete it\n\t\t\tusing Route 53. </p>",
+          "$ref": "#/definitions/LinkedService"
+        }
+      },
+      "required": [
+        "CallerReference",
+        "Id",
+        "Name"
+      ]
+    },
+    "HostedZoneConfig": {
+      "description": "<p>A complex type that contains an optional comment about your hosted zone. If you don't\n\t\t\twant to specify a comment, omit both the <code>HostedZoneConfig</code> and\n\t\t\t\t<code>Comment</code> elements.</p>",
+      "type": "object",
+      "properties": {
+        "Comment": {
+          "description": "<p>Any comments that you want to include about the hosted zone.</p>",
+          "type": "string"
+        },
+        "PrivateZone": {
+          "description": "<p>A value that indicates whether this is a private hosted zone.</p>",
+          "type": "boolean"
+        }
+      }
+    },
+    "LinkedService": {
+      "description": "<p>If a health check or hosted zone was created by another service,\n\t\t\t\t<code>LinkedService</code> is a complex type that describes the service that created\n\t\t\tthe resource. When a resource is created by another service, you can't edit or delete it\n\t\t\tusing Amazon Route 53. </p>",
+      "type": "object",
+      "properties": {
+        "ServicePrincipal": {
+          "description": "<p>If the health check or hosted zone was created by another service, the service that\n\t\t\tcreated the resource. When a resource is created by another service, you can't edit or\n\t\t\tdelete it using Amazon Route 53. </p>",
+          "type": "string"
+        },
+        "Description": {
+          "description": "<p>If the health check or hosted zone was created by another service, an optional\n\t\t\tdescription that can be provided by the other service. When a resource is created by\n\t\t\tanother service, you can't edit or delete it using Amazon Route 53. </p>",
+          "type": "string"
+        }
+      }
+    },
+    "Bucket": {
+      "description": "<p> In terms of implementation, a Bucket is a resource.  </p>",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "<p>The name of the bucket.</p>",
+          "type": "string"
+        },
+        "CreationDate": {
+          "description": "<p>Date the bucket was created. This date can change when making changes to your bucket,\n         such as editing its bucket policy.</p>",
+          "type": "string",
+          "format": "date-time"
+        },
+        "BucketRegion": {
+          "description": "<p>\n            <code>BucketRegion</code> indicates the Amazon Web Services region where the bucket is located. If the request contains at least one valid parameter, it is included in the response.</p>",
+          "type": "string"
+        }
+      }
+    },
+    "AwsTags": {
+      "type": "object"
+    },
+    "AwsScanJobMetadata": {
+      "type": "object",
+      "properties": {
+        "account": {
+          "type": "string"
+        },
+        "regions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "startedAt": {
+          "type": "string"
+        },
+        "finishedAt": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "account",
+        "finishedAt",
+        "regions",
+        "startedAt"
+      ]
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/scripts/common/schema-utils.ts
+++ b/scripts/common/schema-utils.ts
@@ -79,29 +79,24 @@ export function getExistingVersions(): string[] {
 
 // Function to save the schema
 export function saveSchema(schema: TJS.Definition, docVersion: string) {
-	const fileName = `miro-cloudview-aws-v${docVersion}.json`
-	const outputPath = path.resolve(schemasDir, fileName)
-
 	// Ensure schemas directory exists
 	if (!fs.existsSync(schemasDir)) {
 		fs.mkdirSync(schemasDir, {recursive: true})
 	}
 
+	const fileName = `miro-cloudview-aws-v${docVersion}.json`
+	const latestFileName = 'miro-cloudview-aws-latest.json'
+
+	const outputPath = path.resolve(schemasDir, fileName)
+	const latestPath = path.resolve(schemasDir, latestFileName)
+
+	// Write the schema to the file with the version
 	fs.writeFileSync(outputPath, JSON.stringify(schema, null, 2))
 
-	// Update the 'miro-cloudview-aws-latest.json' symlink
-	const latestLinkName = 'miro-cloudview-aws-latest.json'
-	const latestPath = path.resolve(schemasDir, latestLinkName)
+	// Write the latest schema to the 'latest' file
+	fs.writeFileSync(latestPath, JSON.stringify(schema, null, 2))
 
-	// Remove existing symlink if it exists
-	if (fs.existsSync(latestPath)) {
-		fs.unlinkSync(latestPath)
-	}
-
-	// Create a new symlink pointing to the latest versioned schema file
-	fs.symlinkSync(fileName, latestPath)
-
-	console.log(`Saved schema as ${fileName} and updated symlink ${latestLinkName}`)
+	console.log(`Saved schema as ${fileName} and updated ${latestFileName}`)
 }
 
 // Function to hash an object

--- a/scripts/validate-json-schema.ts
+++ b/scripts/validate-json-schema.ts
@@ -21,7 +21,7 @@ try {
 
 	if (newSchemaHash !== existingSchemaHash) {
 		throw new Error(
-			'Error: The generated schema does not match the committed schema.\nPlease run "npm run generate-json-schema" and commit the changes.',
+			'Error: The generated schema does not match the committed schema.\nPlease run "npm run json-schema:generate" and commit the changes.',
 		)
 	}
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,5 +8,5 @@
 		"declaration": true,
 		"declarationMap": true
 	},
-	"exclude": ["tests"]
+	"exclude": ["tests", "scripts", "node_modules"]
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -9,5 +9,5 @@
 		"declaration": true,
 		"declarationMap": true
 	},
-	"exclude": ["tests"]
+	"exclude": ["tests", "scripts", "node_modules"]
 }


### PR DESCRIPTION
This PR includes the following changes:
- Fixed the build error
- script commands are `npm run json-schema:generate` and `npm run json-schema:validate`
- Latest schema is now written as text instead of being symlinked, making it easier to track changes in the diff viewer