### PR TITLE
Exported constants for non-Node.js environments

### DIFF
--- a/.changeset/warm-llamas-sniff.md
+++ b/.changeset/warm-llamas-sniff.md
@@ -1,0 +1,5 @@
+---
+"@mirohq/cloud-data-import": patch
+---
+
+exported constansts to enable constants usage outside Node.js environments

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
 			"require": "./dist/index.js",
 			"import": "./dist/esm/index.js",
 			"types": "./dist/index.d.ts"
+		},
+		"./constants": {
+			"require": "./dist/constants.js",
+			"import": "./dist/esm/constants.js",
+			"types": "./dist/constants.d.ts"
 		}
 	},
 	"publishConfig": {


### PR DESCRIPTION
In this PR, I'm exporting constants so it can be used outside of Node.js environments. an example of using it would be:

```
import {awsRegionIds} from '@mirohq/cloud-data-import/constants'
```