### PR TITLE
Fix subpath type definitions for older TypeScript resolution

### DIFF
--- a/.changeset/sour-geese-switch.md
+++ b/.changeset/sour-geese-switch.md
@@ -1,0 +1,5 @@
+---
+"@mirohq/cloud-data-import": patch
+---
+
+Subpath type definitions are now compatible with older TypeScript configs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mirohq/cloud-data-import",
-	"version": "0.12.4",
+	"version": "0.12.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mirohq/cloud-data-import",
-			"version": "0.12.4",
+			"version": "0.12.5",
 			"license": "MIT",
 			"dependencies": {
 				"@aws-sdk/client-athena": "^3.723.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mirohq/cloud-data-import",
-	"version": "0.12.4",
+	"version": "0.12.5",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"module": "dist/esm/index.js",
@@ -21,6 +21,16 @@
 			"require": "./dist/constants.js",
 			"import": "./dist/esm/constants.js",
 			"types": "./dist/constants.d.ts"
+		}
+	},
+	"typesVersions": {
+		"*": {
+			"constants": [
+				"dist/esm/constants.d.ts"
+			],
+			"*": [
+				"dist/esm/index.d.ts"
+			]
 		}
 	},
 	"publishConfig": {


### PR DESCRIPTION
This PR updates how subpath type definitions are exposed in `package.json` to ensure compatibility with older TypeScript configurations. We’ve added a `typesVersions` field so that importing `@mirohq/cloud-data-import/constants` (and other subpaths) works in projects that cannot use `moduleResolution: "node16"` or newer.