### PR TITLE
fix: correct AWS resource type filter mapping for tagging API

### DIFF
--- a/.changeset/ten-bags-work.md
+++ b/.changeset/ten-bags-work.md
@@ -1,0 +1,5 @@
+---
+"@mirohq/cloud-data-import": patch
+---
+
+fix: correct AWS resource type filter mapping for tagging API

--- a/src/aws-app/main.ts
+++ b/src/aws-app/main.ts
@@ -72,9 +72,13 @@ export default async () => {
 	const tags = discoveredTags.results
 
 	// aggregate errors
-	const errors = discoveredResources.reduce((acc, {errors}) => {
+	const resourceErrors = discoveredResources.reduce((acc, {errors}) => {
 		return [...acc, ...errors]
 	}, [] as AwsScannerError[])
+
+	const tagErrors = discoveredTags.errors
+
+	const errors = [...resourceErrors, ...tagErrors]
 
 	// create output
 	const output: AwsCliAppOutput = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -80,3 +80,25 @@ export enum AwsServices {
 	ROUTE53_HOSTED_ZONES = 'route53:hosted-zone',
 	CLOUDFRONT_DISTRIBUTIONS = 'cloudfront:distribution',
 }
+
+/**
+ * Maps AWS service enum values to their corresponding resource type filter strings.
+ * In most cases, the filter string is the same as the service enum value. However, some services have exceptions.
+ */
+export const awsServiceToFilterServiceCode: Record<AwsServices, string> = {
+	...Object.values(AwsServices).reduce(
+		(acc, service) => {
+			acc[service] = service
+			return acc
+		},
+		{} as Record<AwsServices, string>,
+	),
+	[AwsServices.ELBV1_LOAD_BALANCERS]: 'elasticloadbalancing:loadbalancer',
+	[AwsServices.ELBV2_LOAD_BALANCERS]: 'elasticloadbalancing:loadbalancer',
+	[AwsServices.ELBV2_TARGET_GROUPS]: 'elasticloadbalancing:targetgroup',
+	[AwsServices.S3_BUCKETS]: 's3',
+	[AwsServices.CLOUDWATCH_METRIC_ALARMS]: 'cloudwatch:alarm',
+	[AwsServices.EFS_FILE_SYSTEMS]: 'elasticfilesystem:filesystem',
+	[AwsServices.RDS_INSTANCES]: 'rds:db',
+	[AwsServices.ROUTE53_HOSTED_ZONES]: 'route53:hostedzone',
+}

--- a/src/scanners/scan-functions/aws/tags.ts
+++ b/src/scanners/scan-functions/aws/tags.ts
@@ -2,6 +2,25 @@ import {GetResourcesCommand, ResourceGroupsTaggingAPIClient} from '@aws-sdk/clie
 import {AwsCredentials, AwsScannerError, AwsScannerResult, AwsTags, RateLimiter} from '@/types'
 import {AwsServices} from '@/constants'
 
+/**
+ * Maps AWS service enum values to their corresponding resource type filter strings
+ * for services where the filter name differs from the service enum value.
+ *
+ * While most AWS services can use their enum values directly as resource type filters
+ * in the Resource Groups Tagging API, some services require specific filter strings.
+ * This mapping only contains those exceptions that need special handling.
+ */
+const serviceFilterNameExceptions: Partial<Record<AwsServices, string>> = {
+	[AwsServices.ELBV1_LOAD_BALANCERS]: 'elasticloadbalancing:loadbalancer',
+	[AwsServices.ELBV2_LOAD_BALANCERS]: 'elasticloadbalancing:loadbalancer',
+	[AwsServices.ELBV2_TARGET_GROUPS]: 'elasticloadbalancing:targetgroup',
+	[AwsServices.S3_BUCKETS]: 's3',
+	[AwsServices.CLOUDWATCH_METRIC_ALARMS]: 'cloudwatch:alarm',
+	[AwsServices.EFS_FILE_SYSTEMS]: 'elasticfilesystem:filesystem',
+	[AwsServices.RDS_INSTANCES]: 'rds:db',
+	[AwsServices.ROUTE53_HOSTED_ZONES]: 'route53:hostedzone',
+}
+
 export async function getAvailableTags(
 	services: AwsServices[],
 	credentials: AwsCredentials,
@@ -14,12 +33,14 @@ export async function getAvailableTags(
 	const tags: AwsTags = {}
 	const errors: AwsScannerError[] = []
 
-	for (const service of services) {
+	const resourceTypes = [...new Set(services.map((service) => serviceFilterNameExceptions[service] ?? service))]
+
+	for (const resourceType of resourceTypes) {
 		try {
 			let nextToken: string | undefined
 			do {
 				const command = new GetResourcesCommand({
-					ResourceTypeFilters: [service],
+					ResourceTypeFilters: [resourceType],
 					PaginationToken: nextToken,
 				})
 
@@ -44,9 +65,9 @@ export async function getAvailableTags(
 				nextToken = response.PaginationToken
 			} while (nextToken)
 		} catch (error) {
-			if (error instanceof Error && error.message.includes('Unsupported service=')) {
+			if (error instanceof Error) {
 				errors.push({
-					service: `tags-${service}`,
+					service: `tags-${resourceType}`,
 					message: error.message,
 				})
 			}

--- a/src/scanners/scan-functions/aws/tags.ts
+++ b/src/scanners/scan-functions/aws/tags.ts
@@ -1,25 +1,6 @@
 import {GetResourcesCommand, ResourceGroupsTaggingAPIClient} from '@aws-sdk/client-resource-groups-tagging-api'
 import {AwsCredentials, AwsScannerError, AwsScannerResult, AwsTags, RateLimiter} from '@/types'
-import {AwsServices} from '@/constants'
-
-/**
- * Maps AWS service enum values to their corresponding resource type filter strings
- * for services where the filter name differs from the service enum value.
- *
- * While most AWS services can use their enum values directly as resource type filters
- * in the Resource Groups Tagging API, some services require specific filter strings.
- * This mapping only contains those exceptions that need special handling.
- */
-const serviceFilterNameExceptions: Partial<Record<AwsServices, string>> = {
-	[AwsServices.ELBV1_LOAD_BALANCERS]: 'elasticloadbalancing:loadbalancer',
-	[AwsServices.ELBV2_LOAD_BALANCERS]: 'elasticloadbalancing:loadbalancer',
-	[AwsServices.ELBV2_TARGET_GROUPS]: 'elasticloadbalancing:targetgroup',
-	[AwsServices.S3_BUCKETS]: 's3',
-	[AwsServices.CLOUDWATCH_METRIC_ALARMS]: 'cloudwatch:alarm',
-	[AwsServices.EFS_FILE_SYSTEMS]: 'elasticfilesystem:filesystem',
-	[AwsServices.RDS_INSTANCES]: 'rds:db',
-	[AwsServices.ROUTE53_HOSTED_ZONES]: 'route53:hostedzone',
-}
+import {AwsServices, awsServiceToFilterServiceCode} from '@/constants'
 
 export async function getAvailableTags(
 	services: AwsServices[],
@@ -33,14 +14,14 @@ export async function getAvailableTags(
 	const tags: AwsTags = {}
 	const errors: AwsScannerError[] = []
 
-	const resourceTypes = [...new Set(services.map((service) => serviceFilterNameExceptions[service] ?? service))]
+	const serviceCodes = [...new Set(services.map((service) => awsServiceToFilterServiceCode[service] ?? service))]
 
-	for (const resourceType of resourceTypes) {
+	for (const serviceCode of serviceCodes) {
 		try {
 			let nextToken: string | undefined
 			do {
 				const command = new GetResourcesCommand({
-					ResourceTypeFilters: [resourceType],
+					ResourceTypeFilters: [serviceCode],
 					PaginationToken: nextToken,
 				})
 
@@ -67,7 +48,7 @@ export async function getAvailableTags(
 		} catch (error) {
 			if (error instanceof Error) {
 				errors.push({
-					service: `tags-${resourceType}`,
+					service: `tags-${serviceCode}`,
 					message: error.message,
 				})
 			}


### PR DESCRIPTION
In this PR I fix incorrect resource type filter names used for certain AWS services when querying the Resource Groups Tagging API.

The tags errors were not showing up in the output, and there is a fix for that in this PR too.