### PR TITLE
feat: Add `opensearch-domains` Scanner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mirohq/cloud-data-import",
-	"version": "0.12.5",
+	"version": "0.12.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mirohq/cloud-data-import",
-			"version": "0.12.5",
+			"version": "0.12.7",
 			"license": "MIT",
 			"dependencies": {
 				"@aws-sdk/client-athena": "^3.723.0",
@@ -23,6 +23,7 @@
 				"@aws-sdk/client-elastic-load-balancing-v2": "^3.723.0",
 				"@aws-sdk/client-elasticache": "^3.723.0",
 				"@aws-sdk/client-lambda": "^3.723.0",
+				"@aws-sdk/client-opensearch": "^3.723.0",
 				"@aws-sdk/client-rds": "^3.725.0",
 				"@aws-sdk/client-redshift": "3.723.0",
 				"@aws-sdk/client-resource-explorer-2": "^3.723.0",
@@ -1064,6 +1065,426 @@
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/@aws-sdk/client-opensearch": {
+			"version": "3.782.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-opensearch/-/client-opensearch-3.782.0.tgz",
+			"integrity": "sha512-pKRjoOIHC+Srw5GqLBuaq63mCKzo2+IFSWU4hRS/P/nESeR2UksvaGmLmZHDEs+S7k5LWNRIuswweW5cGUUA3Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.775.0",
+				"@aws-sdk/credential-provider-node": "3.782.0",
+				"@aws-sdk/middleware-host-header": "3.775.0",
+				"@aws-sdk/middleware-logger": "3.775.0",
+				"@aws-sdk/middleware-recursion-detection": "3.775.0",
+				"@aws-sdk/middleware-user-agent": "3.782.0",
+				"@aws-sdk/region-config-resolver": "3.775.0",
+				"@aws-sdk/types": "3.775.0",
+				"@aws-sdk/util-endpoints": "3.782.0",
+				"@aws-sdk/util-user-agent-browser": "3.775.0",
+				"@aws-sdk/util-user-agent-node": "3.782.0",
+				"@smithy/config-resolver": "^4.1.0",
+				"@smithy/core": "^3.2.0",
+				"@smithy/fetch-http-handler": "^5.0.2",
+				"@smithy/hash-node": "^4.0.2",
+				"@smithy/invalid-dependency": "^4.0.2",
+				"@smithy/middleware-content-length": "^4.0.2",
+				"@smithy/middleware-endpoint": "^4.1.0",
+				"@smithy/middleware-retry": "^4.1.0",
+				"@smithy/middleware-serde": "^4.0.3",
+				"@smithy/middleware-stack": "^4.0.2",
+				"@smithy/node-config-provider": "^4.0.2",
+				"@smithy/node-http-handler": "^4.0.4",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/smithy-client": "^4.2.0",
+				"@smithy/types": "^4.2.0",
+				"@smithy/url-parser": "^4.0.2",
+				"@smithy/util-base64": "^4.0.0",
+				"@smithy/util-body-length-browser": "^4.0.0",
+				"@smithy/util-body-length-node": "^4.0.0",
+				"@smithy/util-defaults-mode-browser": "^4.0.8",
+				"@smithy/util-defaults-mode-node": "^4.0.8",
+				"@smithy/util-endpoints": "^3.0.2",
+				"@smithy/util-middleware": "^4.0.2",
+				"@smithy/util-retry": "^4.0.2",
+				"@smithy/util-utf8": "^4.0.0",
+				"@types/uuid": "^9.0.1",
+				"tslib": "^2.6.2",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/client-sso": {
+			"version": "3.782.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.782.0.tgz",
+			"integrity": "sha512-5GlJBejo8wqMpSSEKb45WE82YxI2k73YuebjLH/eWDNQeE6VI5Bh9lA1YQ7xNkLLH8hIsb0pSfKVuwh0VEzVrg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.775.0",
+				"@aws-sdk/middleware-host-header": "3.775.0",
+				"@aws-sdk/middleware-logger": "3.775.0",
+				"@aws-sdk/middleware-recursion-detection": "3.775.0",
+				"@aws-sdk/middleware-user-agent": "3.782.0",
+				"@aws-sdk/region-config-resolver": "3.775.0",
+				"@aws-sdk/types": "3.775.0",
+				"@aws-sdk/util-endpoints": "3.782.0",
+				"@aws-sdk/util-user-agent-browser": "3.775.0",
+				"@aws-sdk/util-user-agent-node": "3.782.0",
+				"@smithy/config-resolver": "^4.1.0",
+				"@smithy/core": "^3.2.0",
+				"@smithy/fetch-http-handler": "^5.0.2",
+				"@smithy/hash-node": "^4.0.2",
+				"@smithy/invalid-dependency": "^4.0.2",
+				"@smithy/middleware-content-length": "^4.0.2",
+				"@smithy/middleware-endpoint": "^4.1.0",
+				"@smithy/middleware-retry": "^4.1.0",
+				"@smithy/middleware-serde": "^4.0.3",
+				"@smithy/middleware-stack": "^4.0.2",
+				"@smithy/node-config-provider": "^4.0.2",
+				"@smithy/node-http-handler": "^4.0.4",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/smithy-client": "^4.2.0",
+				"@smithy/types": "^4.2.0",
+				"@smithy/url-parser": "^4.0.2",
+				"@smithy/util-base64": "^4.0.0",
+				"@smithy/util-body-length-browser": "^4.0.0",
+				"@smithy/util-body-length-node": "^4.0.0",
+				"@smithy/util-defaults-mode-browser": "^4.0.8",
+				"@smithy/util-defaults-mode-node": "^4.0.8",
+				"@smithy/util-endpoints": "^3.0.2",
+				"@smithy/util-middleware": "^4.0.2",
+				"@smithy/util-retry": "^4.0.2",
+				"@smithy/util-utf8": "^4.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/core": {
+			"version": "3.775.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.775.0.tgz",
+			"integrity": "sha512-8vpW4WihVfz0DX+7WnnLGm3GuQER++b0IwQG35JlQMlgqnc44M//KbJPsIHA0aJUJVwJAEShgfr5dUbY8WUzaA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/core": "^3.2.0",
+				"@smithy/node-config-provider": "^4.0.2",
+				"@smithy/property-provider": "^4.0.2",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/signature-v4": "^5.0.2",
+				"@smithy/smithy-client": "^4.2.0",
+				"@smithy/types": "^4.2.0",
+				"@smithy/util-middleware": "^4.0.2",
+				"fast-xml-parser": "4.4.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.775.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.775.0.tgz",
+			"integrity": "sha512-6ESVxwCbGm7WZ17kY1fjmxQud43vzJFoLd4bmlR+idQSWdqlzGDYdcfzpjDKTcivdtNrVYmFvcH1JBUwCRAZhw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "3.775.0",
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/property-provider": "^4.0.2",
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.775.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.775.0.tgz",
+			"integrity": "sha512-PjDQeDH/J1S0yWV32wCj2k5liRo0ssXMseCBEkCsD3SqsU8o5cU82b0hMX4sAib/RkglCSZqGO0xMiN0/7ndww==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "3.775.0",
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/fetch-http-handler": "^5.0.2",
+				"@smithy/node-http-handler": "^4.0.4",
+				"@smithy/property-provider": "^4.0.2",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/smithy-client": "^4.2.0",
+				"@smithy/types": "^4.2.0",
+				"@smithy/util-stream": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.782.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.782.0.tgz",
+			"integrity": "sha512-wd4KdRy2YjLsE4Y7pz00470Iip06GlRHkG4dyLW7/hFMzEO2o7ixswCWp6J2VGZVAX64acknlv2Q0z02ebjmhw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "3.775.0",
+				"@aws-sdk/credential-provider-env": "3.775.0",
+				"@aws-sdk/credential-provider-http": "3.775.0",
+				"@aws-sdk/credential-provider-process": "3.775.0",
+				"@aws-sdk/credential-provider-sso": "3.782.0",
+				"@aws-sdk/credential-provider-web-identity": "3.782.0",
+				"@aws-sdk/nested-clients": "3.782.0",
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/credential-provider-imds": "^4.0.2",
+				"@smithy/property-provider": "^4.0.2",
+				"@smithy/shared-ini-file-loader": "^4.0.2",
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.782.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.782.0.tgz",
+			"integrity": "sha512-HZiAF+TCEyKjju9dgysjiPIWgt/+VerGaeEp18mvKLNfgKz1d+/82A2USEpNKTze7v3cMFASx3CvL8yYyF7mJw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.775.0",
+				"@aws-sdk/credential-provider-http": "3.775.0",
+				"@aws-sdk/credential-provider-ini": "3.782.0",
+				"@aws-sdk/credential-provider-process": "3.775.0",
+				"@aws-sdk/credential-provider-sso": "3.782.0",
+				"@aws-sdk/credential-provider-web-identity": "3.782.0",
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/credential-provider-imds": "^4.0.2",
+				"@smithy/property-provider": "^4.0.2",
+				"@smithy/shared-ini-file-loader": "^4.0.2",
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.775.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.775.0.tgz",
+			"integrity": "sha512-A6k68H9rQp+2+7P7SGO90Csw6nrUEm0Qfjpn9Etc4EboZhhCLs9b66umUsTsSBHus4FDIe5JQxfCUyt1wgNogg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "3.775.0",
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/property-provider": "^4.0.2",
+				"@smithy/shared-ini-file-loader": "^4.0.2",
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.782.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.782.0.tgz",
+			"integrity": "sha512-1y1ucxTtTIGDSNSNxriQY8msinilhe9gGvQpUDYW9gboyC7WQJPDw66imy258V6osdtdi+xoHzVCbCz3WhosMQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.782.0",
+				"@aws-sdk/core": "3.775.0",
+				"@aws-sdk/token-providers": "3.782.0",
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/property-provider": "^4.0.2",
+				"@smithy/shared-ini-file-loader": "^4.0.2",
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.782.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.782.0.tgz",
+			"integrity": "sha512-xCna0opVPaueEbJoclj5C6OpDNi0Gynj+4d7tnuXGgQhTHPyAz8ZyClkVqpi5qvHTgxROdUEDxWqEO5jqRHZHQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "3.775.0",
+				"@aws-sdk/nested-clients": "3.782.0",
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/property-provider": "^4.0.2",
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.775.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.775.0.tgz",
+			"integrity": "sha512-tkSegM0Z6WMXpLB8oPys/d+umYIocvO298mGvcMCncpRl77L9XkvSLJIFzaHes+o7djAgIduYw8wKIMStFss2w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.775.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.775.0.tgz",
+			"integrity": "sha512-FaxO1xom4MAoUJsldmR92nT1G6uZxTdNYOFYtdHfd6N2wcNaTuxgjIvqzg5y7QIH9kn58XX/dzf1iTjgqUStZw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.775.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.775.0.tgz",
+			"integrity": "sha512-GLCzC8D0A0YDG5u3F5U03Vb9j5tcOEFhr8oc6PDk0k0vm5VwtZOE6LvK7hcCSoAB4HXyOUM0sQuXrbaAh9OwXA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.782.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.782.0.tgz",
+			"integrity": "sha512-i32H2R6IItX+bQ2p4+v2gGO2jA80jQoJO2m1xjU9rYWQW3+ErWy4I5YIuQHTBfb6hSdAHbaRfqPDgbv9J2rjEg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "3.775.0",
+				"@aws-sdk/types": "3.775.0",
+				"@aws-sdk/util-endpoints": "3.782.0",
+				"@smithy/core": "^3.2.0",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.775.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.775.0.tgz",
+			"integrity": "sha512-40iH3LJjrQS3LKUJAl7Wj0bln7RFPEvUYKFxtP8a+oKFDO0F65F52xZxIJbPn6sHkxWDAnZlGgdjZXM3p2g5wQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/node-config-provider": "^4.0.2",
+				"@smithy/types": "^4.2.0",
+				"@smithy/util-config-provider": "^4.0.0",
+				"@smithy/util-middleware": "^4.0.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/token-providers": {
+			"version": "3.782.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.782.0.tgz",
+			"integrity": "sha512-4tPuk/3+THPrzKaXW4jE2R67UyGwHLFizZ47pcjJWbhb78IIJAy94vbeqEQ+veS84KF5TXcU7g5jGTXC0D70Wg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/nested-clients": "3.782.0",
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/property-provider": "^4.0.2",
+				"@smithy/shared-ini-file-loader": "^4.0.2",
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/types": {
+			"version": "3.775.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.775.0.tgz",
+			"integrity": "sha512-ZoGKwa4C9fC9Av6bdfqcW6Ix5ot05F/S4VxWR2nHuMv7hzfmAjTOcUiWT7UR4hM/U0whf84VhDtXN/DWAk52KA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.782.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.782.0.tgz",
+			"integrity": "sha512-/RJOAO7o7HI6lEa4ASbFFLHGU9iPK876BhsVfnl54MvApPVYWQ9sHO0anOUim2S5lQTwd/6ghuH3rFYSq/+rdw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/types": "^4.2.0",
+				"@smithy/util-endpoints": "^3.0.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.775.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.775.0.tgz",
+			"integrity": "sha512-txw2wkiJmZKVdDbscK7VBK+u+TJnRtlUjRTLei+elZg2ADhpQxfVAQl436FUeIv6AhB/oRHW6/K/EAGXUSWi0A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/types": "^4.2.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-opensearch/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.782.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.782.0.tgz",
+			"integrity": "sha512-dMFkUBgh2Bxuw8fYZQoH/u3H4afQ12VSkzEi//qFiDTwbKYq+u+RYjc8GLDM6JSK1BShMu5AVR7HD4ap1TYUnA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/middleware-user-agent": "3.782.0",
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/node-config-provider": "^4.0.2",
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@aws-sdk/client-rds": {
 			"version": "3.725.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/client-rds/-/client-rds-3.725.0.tgz",
@@ -2098,6 +2519,220 @@
 			},
 			"engines": {
 				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients": {
+			"version": "3.782.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.782.0.tgz",
+			"integrity": "sha512-QOYC8q7luzHFXrP0xYAqBctoPkynjfV0r9dqntFu4/IWMTyC1vlo1UTxFAjIPyclYw92XJyEkVCVg9v/nQnsUA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "3.775.0",
+				"@aws-sdk/middleware-host-header": "3.775.0",
+				"@aws-sdk/middleware-logger": "3.775.0",
+				"@aws-sdk/middleware-recursion-detection": "3.775.0",
+				"@aws-sdk/middleware-user-agent": "3.782.0",
+				"@aws-sdk/region-config-resolver": "3.775.0",
+				"@aws-sdk/types": "3.775.0",
+				"@aws-sdk/util-endpoints": "3.782.0",
+				"@aws-sdk/util-user-agent-browser": "3.775.0",
+				"@aws-sdk/util-user-agent-node": "3.782.0",
+				"@smithy/config-resolver": "^4.1.0",
+				"@smithy/core": "^3.2.0",
+				"@smithy/fetch-http-handler": "^5.0.2",
+				"@smithy/hash-node": "^4.0.2",
+				"@smithy/invalid-dependency": "^4.0.2",
+				"@smithy/middleware-content-length": "^4.0.2",
+				"@smithy/middleware-endpoint": "^4.1.0",
+				"@smithy/middleware-retry": "^4.1.0",
+				"@smithy/middleware-serde": "^4.0.3",
+				"@smithy/middleware-stack": "^4.0.2",
+				"@smithy/node-config-provider": "^4.0.2",
+				"@smithy/node-http-handler": "^4.0.4",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/smithy-client": "^4.2.0",
+				"@smithy/types": "^4.2.0",
+				"@smithy/url-parser": "^4.0.2",
+				"@smithy/util-base64": "^4.0.0",
+				"@smithy/util-body-length-browser": "^4.0.0",
+				"@smithy/util-body-length-node": "^4.0.0",
+				"@smithy/util-defaults-mode-browser": "^4.0.8",
+				"@smithy/util-defaults-mode-node": "^4.0.8",
+				"@smithy/util-endpoints": "^3.0.2",
+				"@smithy/util-middleware": "^4.0.2",
+				"@smithy/util-retry": "^4.0.2",
+				"@smithy/util-utf8": "^4.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/core": {
+			"version": "3.775.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.775.0.tgz",
+			"integrity": "sha512-8vpW4WihVfz0DX+7WnnLGm3GuQER++b0IwQG35JlQMlgqnc44M//KbJPsIHA0aJUJVwJAEShgfr5dUbY8WUzaA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/core": "^3.2.0",
+				"@smithy/node-config-provider": "^4.0.2",
+				"@smithy/property-provider": "^4.0.2",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/signature-v4": "^5.0.2",
+				"@smithy/smithy-client": "^4.2.0",
+				"@smithy/types": "^4.2.0",
+				"@smithy/util-middleware": "^4.0.2",
+				"fast-xml-parser": "4.4.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.775.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.775.0.tgz",
+			"integrity": "sha512-tkSegM0Z6WMXpLB8oPys/d+umYIocvO298mGvcMCncpRl77L9XkvSLJIFzaHes+o7djAgIduYw8wKIMStFss2w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.775.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.775.0.tgz",
+			"integrity": "sha512-FaxO1xom4MAoUJsldmR92nT1G6uZxTdNYOFYtdHfd6N2wcNaTuxgjIvqzg5y7QIH9kn58XX/dzf1iTjgqUStZw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.775.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.775.0.tgz",
+			"integrity": "sha512-GLCzC8D0A0YDG5u3F5U03Vb9j5tcOEFhr8oc6PDk0k0vm5VwtZOE6LvK7hcCSoAB4HXyOUM0sQuXrbaAh9OwXA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.782.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.782.0.tgz",
+			"integrity": "sha512-i32H2R6IItX+bQ2p4+v2gGO2jA80jQoJO2m1xjU9rYWQW3+ErWy4I5YIuQHTBfb6hSdAHbaRfqPDgbv9J2rjEg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "3.775.0",
+				"@aws-sdk/types": "3.775.0",
+				"@aws-sdk/util-endpoints": "3.782.0",
+				"@smithy/core": "^3.2.0",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.775.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.775.0.tgz",
+			"integrity": "sha512-40iH3LJjrQS3LKUJAl7Wj0bln7RFPEvUYKFxtP8a+oKFDO0F65F52xZxIJbPn6sHkxWDAnZlGgdjZXM3p2g5wQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/node-config-provider": "^4.0.2",
+				"@smithy/types": "^4.2.0",
+				"@smithy/util-config-provider": "^4.0.0",
+				"@smithy/util-middleware": "^4.0.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/types": {
+			"version": "3.775.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.775.0.tgz",
+			"integrity": "sha512-ZoGKwa4C9fC9Av6bdfqcW6Ix5ot05F/S4VxWR2nHuMv7hzfmAjTOcUiWT7UR4hM/U0whf84VhDtXN/DWAk52KA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.782.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.782.0.tgz",
+			"integrity": "sha512-/RJOAO7o7HI6lEa4ASbFFLHGU9iPK876BhsVfnl54MvApPVYWQ9sHO0anOUim2S5lQTwd/6ghuH3rFYSq/+rdw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/types": "^4.2.0",
+				"@smithy/util-endpoints": "^3.0.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.775.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.775.0.tgz",
+			"integrity": "sha512-txw2wkiJmZKVdDbscK7VBK+u+TJnRtlUjRTLei+elZg2ADhpQxfVAQl436FUeIv6AhB/oRHW6/K/EAGXUSWi0A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/types": "^4.2.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.782.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.782.0.tgz",
+			"integrity": "sha512-dMFkUBgh2Bxuw8fYZQoH/u3H4afQ12VSkzEi//qFiDTwbKYq+u+RYjc8GLDM6JSK1BShMu5AVR7HD4ap1TYUnA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/middleware-user-agent": "3.782.0",
+				"@aws-sdk/types": "3.775.0",
+				"@smithy/node-config-provider": "^4.0.2",
+				"@smithy/types": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@aws-sdk/region-config-resolver": {
@@ -3989,11 +4624,12 @@
 			}
 		},
 		"node_modules/@smithy/abort-controller": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.0.tgz",
-			"integrity": "sha512-xFNL1ZfluscKiVI0qlPEnu7pL1UgNNIzQdjTPkaO7JCJtIkbArPYNtqbxohuNaQdksJ01Tn1wLbDA5oIp62P8w==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.2.tgz",
+			"integrity": "sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.0.0",
+				"@smithy/types": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4024,14 +4660,15 @@
 			}
 		},
 		"node_modules/@smithy/config-resolver": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.0.tgz",
-			"integrity": "sha512-29pIDlUY/a9+ChJPAarPiD9cU8fBtBh0wFnmnhj7j5AhgMzc+uyXdfzmziH6xx2jzw54waSP3HfnFkTANZuPYA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.0.tgz",
+			"integrity": "sha512-8smPlwhga22pwl23fM5ew4T9vfLUCeFXlcqNOCD5M5h8VmNPNUE9j6bQSuRXpDSV11L/E/SwEBQuW8hr6+nS1A==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.0.0",
-				"@smithy/types": "^4.0.0",
+				"@smithy/node-config-provider": "^4.0.2",
+				"@smithy/types": "^4.2.0",
 				"@smithy/util-config-provider": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.0",
+				"@smithy/util-middleware": "^4.0.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4039,16 +4676,17 @@
 			}
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.0.0.tgz",
-			"integrity": "sha512-pKaas7RWvPljJ8uByCeBa10rtbVJCy4N/Fr7OSPxFezcyG0SQuXWnESZqzXj7m2+A+kPzG6fKyP4wrKidl2Ikg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.2.0.tgz",
+			"integrity": "sha512-k17bgQhVZ7YmUvA8at4af1TDpl0NDMBuBKJl8Yg0nrefwmValU+CnA5l/AriVdQNthU/33H3nK71HrLgqOPr1Q==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/middleware-serde": "^4.0.0",
-				"@smithy/protocol-http": "^5.0.0",
-				"@smithy/types": "^4.0.0",
+				"@smithy/middleware-serde": "^4.0.3",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/types": "^4.2.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.0",
-				"@smithy/util-stream": "^4.0.0",
+				"@smithy/util-middleware": "^4.0.2",
+				"@smithy/util-stream": "^4.2.0",
 				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -4057,14 +4695,15 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.0.tgz",
-			"integrity": "sha512-+hTShyZHiq2AVFOxJja3k6O17DKU6TaZbwr2y1OH5HQtUw2a+7O3mMR+10LVmc39ef72SAj+uFX0IW9rJGaLQQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.2.tgz",
+			"integrity": "sha512-32lVig6jCaWBHnY+OEQ6e6Vnt5vDHaLiydGrwYMW9tPqO688hPGTYRamYJ1EptxEC2rAwJrHWmPoKRBl4iTa8w==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.0.0",
-				"@smithy/property-provider": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"@smithy/url-parser": "^4.0.0",
+				"@smithy/node-config-provider": "^4.0.2",
+				"@smithy/property-provider": "^4.0.2",
+				"@smithy/types": "^4.2.0",
+				"@smithy/url-parser": "^4.0.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4137,13 +4776,14 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.0.tgz",
-			"integrity": "sha512-jUEq+4056uqsDLRqQb1fm48rrSMBYcBxVvODfiP37ORcV5n9xWJQsINWcIffyYxWTM5K0Y/GOfhSQGDtWpAPpQ==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.2.tgz",
+			"integrity": "sha512-+9Dz8sakS9pe7f2cBocpJXdeVjMopUDLgZs1yWeu7h++WqSbjUYv/JAJwKwXw1HV6gq1jyWjxuyn24E2GhoEcQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.0.0",
-				"@smithy/querystring-builder": "^4.0.0",
-				"@smithy/types": "^4.0.0",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/querystring-builder": "^4.0.2",
+				"@smithy/types": "^4.2.0",
 				"@smithy/util-base64": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -4166,11 +4806,12 @@
 			}
 		},
 		"node_modules/@smithy/hash-node": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.0.tgz",
-			"integrity": "sha512-25OxGYGnG3JPEOTk4iFE03bfmoC6GXUQ4L13z4cNdsS3mkncH22AGSDRfKwwEqutNUxXQZWVy9f72Fm59C9qlg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.2.tgz",
+			"integrity": "sha512-VnTpYPnRUE7yVhWozFdlxcYknv9UN7CeOqSrMH+V877v4oqtVYuoqhIhtSjmGPvYrYnAkaM61sLMKHvxL138yg==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.0.0",
+				"@smithy/types": "^4.2.0",
 				"@smithy/util-buffer-from": "^4.0.0",
 				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
@@ -4193,11 +4834,12 @@
 			}
 		},
 		"node_modules/@smithy/invalid-dependency": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.0.tgz",
-			"integrity": "sha512-0GTyet02HX/sPctEhOExY+3HI7hwkVwOoJg0XnItTJ+Xw7JMuL9FOxALTmKVIV6+wg0kF6veLeg72hVSbD9UCw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.2.tgz",
+			"integrity": "sha512-GatB4+2DTpgWPday+mnUkoumP54u/MDM/5u44KF9hIu8jF0uafZtQLcdfIKkIcUNuF/fBojpLEHZS/56JqPeXQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.0.0",
+				"@smithy/types": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4249,12 +4891,13 @@
 			}
 		},
 		"node_modules/@smithy/middleware-content-length": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.0.tgz",
-			"integrity": "sha512-nM1RJqLwkSCidumGK8WwNEZ0a0D/4LkwqdPna+QmHrdPoAK6WGLyZFosdMpsAW1OIbDLWGa+r37Mo4Vth4S4kQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.2.tgz",
+			"integrity": "sha512-hAfEXm1zU+ELvucxqQ7I8SszwQ4znWMbNv6PLMndN83JJN41EPuS93AIyh2N+gJ6x8QFhzSO6b7q2e6oClDI8A==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.0.0",
-				"@smithy/types": "^4.0.0",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/types": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4262,17 +4905,18 @@
 			}
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.0.tgz",
-			"integrity": "sha512-/f6z5SqUurmqemhBZNhM0c+C7QW0AY/zJpic//sbdu26q98HSPAI/xvzStjYq+UhtWeAe/jaX6gamdL/2r3W1g==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.0.tgz",
+			"integrity": "sha512-xhLimgNCbCzsUppRTGXWkZywksuTThxaIB0HwbpsVLY5sceac4e1TZ/WKYqufQLaUy+gUSJGNdwD2jo3cXL0iA==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.0.0",
-				"@smithy/middleware-serde": "^4.0.0",
-				"@smithy/node-config-provider": "^4.0.0",
-				"@smithy/shared-ini-file-loader": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"@smithy/url-parser": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.0",
+				"@smithy/core": "^3.2.0",
+				"@smithy/middleware-serde": "^4.0.3",
+				"@smithy/node-config-provider": "^4.0.2",
+				"@smithy/shared-ini-file-loader": "^4.0.2",
+				"@smithy/types": "^4.2.0",
+				"@smithy/url-parser": "^4.0.2",
+				"@smithy/util-middleware": "^4.0.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4280,17 +4924,18 @@
 			}
 		},
 		"node_modules/@smithy/middleware-retry": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.0.tgz",
-			"integrity": "sha512-K6tsFp3Ik44H3694a+LWoXLV8mqy8zn6/vTw2feU72MaIzi51EHMVNNxxpL6e2GI6oxw8FFRGWgGn8+wQRrHZQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.0.tgz",
+			"integrity": "sha512-2zAagd1s6hAaI/ap6SXi5T3dDwBOczOMCSkkYzktqN1+tzbk1GAsHNAdo/1uzxz3Ky02jvZQwbi/vmDA6z4Oyg==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.0.0",
-				"@smithy/protocol-http": "^5.0.0",
-				"@smithy/service-error-classification": "^4.0.0",
-				"@smithy/smithy-client": "^4.0.0",
-				"@smithy/types": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.0",
-				"@smithy/util-retry": "^4.0.0",
+				"@smithy/node-config-provider": "^4.0.2",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/service-error-classification": "^4.0.2",
+				"@smithy/smithy-client": "^4.2.0",
+				"@smithy/types": "^4.2.0",
+				"@smithy/util-middleware": "^4.0.2",
+				"@smithy/util-retry": "^4.0.2",
 				"tslib": "^2.6.2",
 				"uuid": "^9.0.1"
 			},
@@ -4299,11 +4944,12 @@
 			}
 		},
 		"node_modules/@smithy/middleware-serde": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.0.tgz",
-			"integrity": "sha512-aW4Zo8Cm988RCvhysErzqrQ4YPKgZFhajvgPoZnsWIDaZfT419J17Ahr13Lul3kqGad2dCz7YOrXd7r+UAEj/w==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.3.tgz",
+			"integrity": "sha512-rfgDVrgLEVMmMn0BI8O+8OVr6vXzjV7HZj57l0QxslhzbvVfikZbVfBVthjLHqib4BW44QhcIgJpvebHlRaC9A==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.0.0",
+				"@smithy/types": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4311,11 +4957,12 @@
 			}
 		},
 		"node_modules/@smithy/middleware-stack": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.0.tgz",
-			"integrity": "sha512-4NFaX88RmgVrCyJv/3RsSdqMwxzI/EQa8nvhUDVxmLUMRS2JUdHnliD6IwKuqIwIzz+E1aZK3EhSHUM4HXp3ww==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.2.tgz",
+			"integrity": "sha512-eSPVcuJJGVYrFYu2hEq8g8WWdJav3sdrI4o2c6z/rjnYDd3xH9j9E7deZQCzFn4QvGPouLngH3dQ+QVTxv5bOQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.0.0",
+				"@smithy/types": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4323,13 +4970,14 @@
 			}
 		},
 		"node_modules/@smithy/node-config-provider": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.0.tgz",
-			"integrity": "sha512-Crp9rg1ewjqgM2i7pWSpNhfbBa0usyKGDVQLEXTOpu6trFqq3BFLLCgbCE1S18h6mxqKnOqUONq3nWOxUk75XA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.2.tgz",
+			"integrity": "sha512-WgCkILRZfJwJ4Da92a6t3ozN/zcvYyJGUTmfGbgS/FkCcoCjl7G4FJaCDN1ySdvLvemnQeo25FdkyMSTSwulsw==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/property-provider": "^4.0.0",
-				"@smithy/shared-ini-file-loader": "^4.0.0",
-				"@smithy/types": "^4.0.0",
+				"@smithy/property-provider": "^4.0.2",
+				"@smithy/shared-ini-file-loader": "^4.0.2",
+				"@smithy/types": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4337,14 +4985,15 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.0.tgz",
-			"integrity": "sha512-WvumtEaFyxaI95zmj6eYlF/vCFCKNyru3P/UUHCUS9BjvajUtNckH2cY3bBfi+qqMPX5gha4g26lcOlE/wPz/Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.4.tgz",
+			"integrity": "sha512-/mdqabuAT3o/ihBGjL94PUbTSPSRJ0eeVTdgADzow0wRJ0rN4A27EOrtlK56MYiO1fDvlO3jVTCxQtQmK9dZ1g==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/abort-controller": "^4.0.0",
-				"@smithy/protocol-http": "^5.0.0",
-				"@smithy/querystring-builder": "^4.0.0",
-				"@smithy/types": "^4.0.0",
+				"@smithy/abort-controller": "^4.0.2",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/querystring-builder": "^4.0.2",
+				"@smithy/types": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4352,11 +5001,12 @@
 			}
 		},
 		"node_modules/@smithy/property-provider": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.0.tgz",
-			"integrity": "sha512-AJSvY1k3SdM0stGrIjL8/FIjXO7X9I7KkznXDmr76RGz+yvaDHLsLm2hSHyzAlmwEQnHaafSU2dwaV0JcnR/4w==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.2.tgz",
+			"integrity": "sha512-wNRoQC1uISOuNc2s4hkOYwYllmiyrvVXWMtq+TysNRVQaHm4yoafYQyjN/goYZS+QbYlPIbb/QRjaUZMuzwQ7A==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.0.0",
+				"@smithy/types": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4364,11 +5014,12 @@
 			}
 		},
 		"node_modules/@smithy/protocol-http": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.0.tgz",
-			"integrity": "sha512-laAcIHWq9GQ5VdAS71DUrCj5HUHZ/89Ee+HRTLhFR5/E3toBlnZfPG+kqBajwfEB5aSdRuKslfzl5Dzrn3pr8A==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.0.tgz",
+			"integrity": "sha512-KxAOL1nUNw2JTYrtviRRjEnykIDhxc84qMBzxvu1MUfQfHTuBlCG7PA6EdVwqpJjH7glw7FqQoFxUJSyBQgu7g==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.0.0",
+				"@smithy/types": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4376,11 +5027,12 @@
 			}
 		},
 		"node_modules/@smithy/querystring-builder": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.0.tgz",
-			"integrity": "sha512-kMqPDRf+/hwm+Dmk8AQCaYTJxNWWpNdJJteeMm0jwDbmRDqSqHQ7oLEVzvOnbWJu1poVtOhv6v7jsbyx9JASsw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.2.tgz",
+			"integrity": "sha512-NTOs0FwHw1vimmQM4ebh+wFQvOwkEf/kQL6bSM1Lock+Bv4I89B3hGYoUEPkmvYPkDKyp5UdXJYu+PoTQ3T31Q==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.0.0",
+				"@smithy/types": "^4.2.0",
 				"@smithy/util-uri-escape": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -4389,11 +5041,12 @@
 			}
 		},
 		"node_modules/@smithy/querystring-parser": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.0.tgz",
-			"integrity": "sha512-SbogL1PNEmm28ya0eK2S0EZEbYwe0qpaqSGrODm+uYS6dQ7pekPLVNXjBRuuLIAT26ZF2wTsp6X7AVRBNZd8qw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.2.tgz",
+			"integrity": "sha512-v6w8wnmZcVXjfVLjxw8qF7OwESD9wnpjp0Dqry/Pod0/5vcEA3qxCr+BhbOHlxS8O+29eLpT3aagxXGwIoEk7Q==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.0.0",
+				"@smithy/types": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4401,22 +5054,24 @@
 			}
 		},
 		"node_modules/@smithy/service-error-classification": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.0.tgz",
-			"integrity": "sha512-hIZreT6aXSG0PK/psT1S+kfeGTnYnRRlf7rU3yDmH/crSVjTbS/5h5w2J7eO2ODrQb3xfhJcYxQBREdwsZk6TA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.2.tgz",
+			"integrity": "sha512-LA86xeFpTKn270Hbkixqs5n73S+LVM0/VZco8dqd+JT75Dyx3Lcw/MraL7ybjmz786+160K8rPOmhsq0SocoJQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.0.0"
+				"@smithy/types": "^4.2.0"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/shared-ini-file-loader": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.0.tgz",
-			"integrity": "sha512-Ktupe8msp2GPaKKVfiz3NNUNnslJiGGRoVh3BDpm/RChkQ5INQpqmTc2taE0XChNYumNynLfb3keekIPaiaZeg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.2.tgz",
+			"integrity": "sha512-J9/gTWBGVuFZ01oVA6vdb4DAjf1XbDhK6sLsu3OS9qmLrS6KB5ygpeHiM3miIbj1qgSJ96GYszXFWv6ErJ8QEw==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.0.0",
+				"@smithy/types": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4424,15 +5079,16 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.0.tgz",
-			"integrity": "sha512-zqcOR1sZTuoA6K3PBNwzu4YgT1pmIwz47tYpgaJjBTfGUIMtcjUaXKtuSKEScdv+0wx45/PbXz0//hk80fky3w==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.2.tgz",
+			"integrity": "sha512-Mz+mc7okA73Lyz8zQKJNyr7lIcHLiPYp0+oiqiMNc/t7/Kf2BENs5d63pEj7oPqdjaum6g0Fc8wC78dY1TgtXw==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/is-array-buffer": "^4.0.0",
-				"@smithy/protocol-http": "^5.0.0",
-				"@smithy/types": "^4.0.0",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/types": "^4.2.0",
 				"@smithy/util-hex-encoding": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.0",
+				"@smithy/util-middleware": "^4.0.2",
 				"@smithy/util-uri-escape": "^4.0.0",
 				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
@@ -4442,16 +5098,17 @@
 			}
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.0.0.tgz",
-			"integrity": "sha512-AgcZ6B+JuqArYioAbaYrCpTCjYsD3/1hPSXntbN2ipsfc4hE+72RFZevUPYgsKxpy3G+QxuLfqm11i3+oX4oSA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.0.tgz",
+			"integrity": "sha512-Qs65/w30pWV7LSFAez9DKy0Koaoh3iHhpcpCCJ4waj/iqwsuSzJna2+vYwq46yBaqO5ZbP9TjUsATUNxrKeBdw==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.0.0",
-				"@smithy/middleware-endpoint": "^4.0.0",
-				"@smithy/middleware-stack": "^4.0.0",
-				"@smithy/protocol-http": "^5.0.0",
-				"@smithy/types": "^4.0.0",
-				"@smithy/util-stream": "^4.0.0",
+				"@smithy/core": "^3.2.0",
+				"@smithy/middleware-endpoint": "^4.1.0",
+				"@smithy/middleware-stack": "^4.0.2",
+				"@smithy/protocol-http": "^5.1.0",
+				"@smithy/types": "^4.2.0",
+				"@smithy/util-stream": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4459,9 +5116,10 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.0.0.tgz",
-			"integrity": "sha512-aNwIGSOgDOhtTRY/rrn2aeuQeKw/IFrQ998yK5l6Ah853WeWIEmFPs/EO4OpfADEdcK+igWnZytm/oUgkLgUYg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.2.0.tgz",
+			"integrity": "sha512-7eMk09zQKCO+E/ivsjQv+fDlOupcFUCSC/L2YUPgwhvowVGWbPQHjEFcmjt7QQ4ra5lyowS92SV53Zc6XD4+fg==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -4470,12 +5128,13 @@
 			}
 		},
 		"node_modules/@smithy/url-parser": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.0.tgz",
-			"integrity": "sha512-2iPpuLoH0hCKpLtqVgilHtpPKsmHihbkwBm3h3RPuEctdmuiOlFRZ2ZI8IHSwl0o4ff5IdyyJ0yu/2tS9KpUug==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.2.tgz",
+			"integrity": "sha512-Bm8n3j2ScqnT+kJaClSVCMeiSenK6jVAzZCNewsYWuZtnBehEz4r2qP0riZySZVfzB+03XZHJeqfmJDkeeSLiQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/querystring-parser": "^4.0.0",
-				"@smithy/types": "^4.0.0",
+				"@smithy/querystring-parser": "^4.0.2",
+				"@smithy/types": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4541,13 +5200,14 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.0.tgz",
-			"integrity": "sha512-7wqsXkzaJkpSqV+Ca95pN9yQutXvhaKeCxGGmjWnRGXY1fW/yR7wr1ouNnUYCJuTS8MvmB61xp5Qdj8YMgIA2Q==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.8.tgz",
+			"integrity": "sha512-ZTypzBra+lI/LfTYZeop9UjoJhhGRTg3pxrNpfSTQLd3AJ37r2z4AXTKpq1rFXiiUIJsYyFgNJdjWRGP/cbBaQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/property-provider": "^4.0.0",
-				"@smithy/smithy-client": "^4.0.0",
-				"@smithy/types": "^4.0.0",
+				"@smithy/property-provider": "^4.0.2",
+				"@smithy/smithy-client": "^4.2.0",
+				"@smithy/types": "^4.2.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
@@ -4556,16 +5216,17 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.0.tgz",
-			"integrity": "sha512-P8VK885kiRT6TEtvcQvz+L/+xIhrDhCmM664ToUtrshFSBhwGYaJWlQNAH9fXlMhwnNvR+tmh1KngKJIgQP6bw==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.8.tgz",
+			"integrity": "sha512-Rgk0Jc/UDfRTzVthye/k2dDsz5Xxs9LZaKCNPgJTRyoyBoeiNCnHsYGOyu1PKN+sDyPnJzMOz22JbwxzBp9NNA==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/config-resolver": "^4.0.0",
-				"@smithy/credential-provider-imds": "^4.0.0",
-				"@smithy/node-config-provider": "^4.0.0",
-				"@smithy/property-provider": "^4.0.0",
-				"@smithy/smithy-client": "^4.0.0",
-				"@smithy/types": "^4.0.0",
+				"@smithy/config-resolver": "^4.1.0",
+				"@smithy/credential-provider-imds": "^4.0.2",
+				"@smithy/node-config-provider": "^4.0.2",
+				"@smithy/property-provider": "^4.0.2",
+				"@smithy/smithy-client": "^4.2.0",
+				"@smithy/types": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4573,12 +5234,13 @@
 			}
 		},
 		"node_modules/@smithy/util-endpoints": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.0.tgz",
-			"integrity": "sha512-kyOKbkg77lsIVN2jC08uEWm3s16eK1YdVDyi/nKeBDbUnjR30dmTEga79E5tiu5OEgTAdngNswA9V+L6xa65sA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.2.tgz",
+			"integrity": "sha512-6QSutU5ZyrpNbnd51zRTL7goojlcnuOB55+F9VBD+j8JpRY50IGamsjlycrmpn8PQkmJucFW8A0LSfXj7jjtLQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.0.0",
-				"@smithy/types": "^4.0.0",
+				"@smithy/node-config-provider": "^4.0.2",
+				"@smithy/types": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4597,11 +5259,12 @@
 			}
 		},
 		"node_modules/@smithy/util-middleware": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.0.tgz",
-			"integrity": "sha512-ncuvK6ekpDqtASHg7jx3d3nrkD2BsTzUmeVgvtepuHGxtySY8qUlb4SiNRdxHYcv3pL2SwdXs70RwKBU0edW5w==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.2.tgz",
+			"integrity": "sha512-6GDamTGLuBQVAEuQ4yDQ+ti/YINf/MEmIegrEeg7DdB/sld8BX1lqt9RRuIcABOhAGTA50bRbPzErez7SlDtDQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.0.0",
+				"@smithy/types": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4609,12 +5272,13 @@
 			}
 		},
 		"node_modules/@smithy/util-retry": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.0.tgz",
-			"integrity": "sha512-64WFoC19NVuHh3HQO2QbGw+n6GzQ6VH/drxwXLOU3GDLKxUUzIR9XNm9aTVqh8/7R+y+DgITiv5LpX5XdOy73A==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.2.tgz",
+			"integrity": "sha512-Qryc+QG+7BCpvjloFLQrmlSd0RsVRHejRXd78jNO3+oREueCjwG1CCEH1vduw/ZkM1U9TztwIKVIi3+8MJScGg==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/service-error-classification": "^4.0.0",
-				"@smithy/types": "^4.0.0",
+				"@smithy/service-error-classification": "^4.0.2",
+				"@smithy/types": "^4.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4622,13 +5286,14 @@
 			}
 		},
 		"node_modules/@smithy/util-stream": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.0.0.tgz",
-			"integrity": "sha512-ctcLq8Ogi2FQuGy2RxJXGGrozhFEb4p9FawB5SpTNAkNQWbNHcwrGcVSVI3FtdQtkNAINLiEdMnrx+UN/mafvw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.0.tgz",
+			"integrity": "sha512-Vj1TtwWnuWqdgQI6YTUF5hQ/0jmFiOYsc51CSMgj7QfyO+RF4EnT2HNjoviNlOOmgzgvf3f5yno+EiC4vrnaWQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^5.0.0",
-				"@smithy/node-http-handler": "^4.0.0",
-				"@smithy/types": "^4.0.0",
+				"@smithy/fetch-http-handler": "^5.0.2",
+				"@smithy/node-http-handler": "^4.0.4",
+				"@smithy/types": "^4.2.0",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-buffer-from": "^4.0.0",
 				"@smithy/util-hex-encoding": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
 		"@aws-sdk/client-elastic-load-balancing-v2": "^3.723.0",
 		"@aws-sdk/client-elasticache": "^3.723.0",
 		"@aws-sdk/client-lambda": "^3.723.0",
+		"@aws-sdk/client-opensearch": "^3.723.0",
 		"@aws-sdk/client-rds": "^3.725.0",
 		"@aws-sdk/client-redshift": "3.723.0",
 		"@aws-sdk/client-resource-explorer-2": "^3.723.0",

--- a/src/definitions/supported-services.ts
+++ b/src/definitions/supported-services.ts
@@ -18,6 +18,7 @@ import type * as ElastiCache from '@aws-sdk/client-elasticache'
 import type * as Redshift from '@aws-sdk/client-redshift'
 import type * as CloudWatch from '@aws-sdk/client-cloudwatch'
 import type * as Athena from '@aws-sdk/client-athena'
+import type * as OpenSearch from '@aws-sdk/client-opensearch'
 
 export enum AwsSupportedResources {
 	ATHENA_NAMED_QUERIES = 'ATHENA_NAMED_QUERIES',
@@ -49,6 +50,7 @@ export enum AwsSupportedResources {
 	ELBV1_LOAD_BALANCERS = 'ELBV1_LOAD_BALANCERS',
 	EKS_CLUSTERS = 'EKS_CLUSTERS',
 	LAMBDA_FUNCTIONS = 'LAMBDA_FUNCTIONS',
+	OPENSEARCH_DOMAINS = 'OPENSEARCH_DOMAINS',
 	REDSHIFT_CLUSTERS = 'REDSHIFT_CLUSTERS',
 	RDS_INSTANCES = 'RDS_INSTANCES',
 	RDS_CLUSTERS = 'RDS_CLUSTERS',
@@ -95,6 +97,7 @@ export const awsResourceNames: Record<AwsSupportedResources, string> = {
 	[AwsSupportedResources.ELBV1_LOAD_BALANCERS]: 'ELBv1 Load Balancers',
 	[AwsSupportedResources.EKS_CLUSTERS]: 'EKS Clusters',
 	[AwsSupportedResources.LAMBDA_FUNCTIONS]: 'Lambda Functions',
+	[AwsSupportedResources.OPENSEARCH_DOMAINS]: 'OpenSearch Domains',
 	[AwsSupportedResources.REDSHIFT_CLUSTERS]: 'Redshift Clusters',
 	[AwsSupportedResources.RDS_INSTANCES]: 'RDS Instances',
 	[AwsSupportedResources.RDS_CLUSTERS]: 'RDS Clusters',
@@ -141,6 +144,7 @@ export const awsTaggingFilterResourceTypes: Record<AwsSupportedResources, string
 	[AwsSupportedResources.ELBV1_LOAD_BALANCERS]: 'elasticloadbalancing:loadbalancer',
 	[AwsSupportedResources.EKS_CLUSTERS]: 'eks:cluster',
 	[AwsSupportedResources.LAMBDA_FUNCTIONS]: 'lambda:function',
+	[AwsSupportedResources.OPENSEARCH_DOMAINS]: 'es:domain',
 	[AwsSupportedResources.REDSHIFT_CLUSTERS]: 'redshift:cluster',
 	[AwsSupportedResources.RDS_INSTANCES]: 'rds:db',
 	[AwsSupportedResources.RDS_CLUSTERS]: 'rds:cluster',
@@ -185,6 +189,7 @@ export type AwsResourceDescriptionMap = {
 	[AwsSupportedResources.ELBV2_LOAD_BALANCERS]: ELBv2.LoadBalancer
 	[AwsSupportedResources.ELBV2_TARGET_GROUPS]: ELBv2.TargetGroup
 	[AwsSupportedResources.LAMBDA_FUNCTIONS]: Lambda.FunctionConfiguration
+	[AwsSupportedResources.OPENSEARCH_DOMAINS]: OpenSearch.DomainInfo
 	[AwsSupportedResources.RDS_CLUSTERS]: RDS.DBCluster
 	[AwsSupportedResources.RDS_INSTANCES]: RDS.DBInstance
 	[AwsSupportedResources.RDS_PROXIES]: RDS.DBProxy

--- a/src/scanners/scan-functions/aws/opensearch-domains.ts
+++ b/src/scanners/scan-functions/aws/opensearch-domains.ts
@@ -1,0 +1,54 @@
+import {
+	OpenSearchClient,
+	ListDomainNamesCommand,
+	DescribeDomainsCommand,
+	DescribeDomainCommand,
+} from '@aws-sdk/client-opensearch'
+import {AwsCredentials, AwsResourcesList, RateLimiter} from '@/types'
+import {AwsSupportedResources} from '@/definitions/supported-services'
+
+const MAX_DOMAINS_PER_REQUEST = 5
+
+export async function getOpenSearchDomains(
+	credentials: AwsCredentials,
+	rateLimiter: RateLimiter,
+	region: string,
+): Promise<AwsResourcesList<AwsSupportedResources.OPENSEARCH_DOMAINS>> {
+	const client = new OpenSearchClient({credentials, region})
+
+	const resources: AwsResourcesList<AwsSupportedResources.OPENSEARCH_DOMAINS> = {}
+
+	const listDomainNamesCommand = new ListDomainNamesCommand()
+	const listDomainNamesResponse = await rateLimiter.throttle(() => client.send(listDomainNamesCommand))
+	const domainNames = (listDomainNamesResponse.DomainNames || [])
+		.map((domain) => domain.DomainName)
+		.filter((domain) => domain !== undefined)
+
+	const domainChunks = splitDomainsIntoChunks(domainNames)
+	for (const chunk of domainChunks) {
+		const describeDomainsCommand = new DescribeDomainsCommand({
+			DomainNames: chunk,
+		})
+
+		const describeDomainsResponse = await rateLimiter.throttle(() => client.send(describeDomainsCommand))
+
+		if (describeDomainsResponse.DomainStatusList) {
+			for (const domain of describeDomainsResponse.DomainStatusList) {
+				if (domain.ARN) {
+					resources[domain.ARN] = domain
+				}
+			}
+		}
+	}
+
+	return resources
+}
+
+function splitDomainsIntoChunks(domains: string[]): string[][] {
+	const chunks: string[][] = []
+	for (let i = 0; i < domains.length; i += MAX_DOMAINS_PER_REQUEST) {
+		chunks.push(domains.slice(i, i + MAX_DOMAINS_PER_REQUEST))
+	}
+
+	return chunks
+}

--- a/src/scanners/scanner-configs.ts
+++ b/src/scanners/scanner-configs.ts
@@ -38,6 +38,7 @@ import {getCloudWatchMetricStreams} from './scan-functions/aws/cloudwatch-metric
 import {getEC2VpnGateways} from './scan-functions/aws/ec2-vpn-gateways'
 import {getEC2NetworkInterfaces} from './scan-functions/aws/ec2-network-interfaces'
 import {getAthenaNamedQueries} from './scan-functions/aws/athena-named-queries'
+import {getOpenSearchDomains} from './scan-functions/aws/opensearch-domains'
 
 export const scannerConfigs: {
 	[K in AwsSupportedResources]: AwsResourceScannerConfig<K>
@@ -158,6 +159,10 @@ export const scannerConfigs: {
 	[AwsSupportedResources.LAMBDA_FUNCTIONS]: {
 		service: AwsSupportedResources.LAMBDA_FUNCTIONS,
 		handler: getLambdaFunctions,
+	},
+	[AwsSupportedResources.OPENSEARCH_DOMAINS]: {
+		service: AwsSupportedResources.OPENSEARCH_DOMAINS,
+		handler: getOpenSearchDomains,
 	},
 	[AwsSupportedResources.RDS_INSTANCES]: {
 		service: AwsSupportedResources.RDS_INSTANCES,


### PR DESCRIPTION
This PR adds a new scanner for `opensearch-domains`.

This was tested locally, and produces data in the expected format:

```json
    "resources": {
      ...
      "arn:aws:es:eu-west-1:543998612913:domain/production-rtb": {
        "name": "production-rtb",
        "type": "es:domain",
        "tags": {
          "owner": "dbre",
          "segregated_customer": "rtb",
          "supportedby": "dbre",
          "environment": "production",
          "stream": "infrastructure",
          "service": "advanced-search",
          "contact": "slack channel: dbre_help",
          "function": "search",
          "Environment": "production",
          "Domain": "production-rtb",
          "costcenter": "000",
          "segregated": "true",
          "group": "aws_es"
        }
      },
      ...
    },
```