### PR TITLE
refactor: Decoupled and exported the tag key-value extraction util

### DIFF
--- a/.changeset/new-mangos-clap.md
+++ b/.changeset/new-mangos-clap.md
@@ -1,0 +1,5 @@
+---
+"@mirohq/cloud-data-import": patch
+---
+
+refactor: Decoupled and exported the tag key-value extraction util (`extractUniqueTagKeysAndValues` util exported)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mirohq/cloud-data-import",
-	"version": "0.12.7",
+	"version": "0.13.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mirohq/cloud-data-import",
-			"version": "0.12.7",
+			"version": "0.13.0",
 			"license": "MIT",
 			"dependencies": {
 				"@aws-sdk/client-athena": "^3.723.0",
@@ -3094,13 +3094,15 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-			"integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/highlight": "^7.24.7",
-				"picocolors": "^1.0.0"
+				"@babel/helper-validator-identifier": "^7.27.1",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -3248,19 +3250,21 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-			"integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-			"integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -3275,111 +3279,27 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.25.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
-			"integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.1.tgz",
+			"integrity": "sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.25.0",
-				"@babel/types": "^7.25.6"
+				"@babel/template": "^7.27.1",
+				"@babel/types": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/highlight": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-			"integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.24.7",
-				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0",
-				"picocolors": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
-		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.25.6",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
-			"integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+			"version": "7.27.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.2.tgz",
+			"integrity": "sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.25.6"
+				"@babel/types": "^7.27.1"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -3611,26 +3531,25 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-			"integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
+			"integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
 			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
-			"integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
+			"version": "7.27.2",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+			"integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.24.7",
-				"@babel/parser": "^7.25.0",
-				"@babel/types": "^7.25.0"
+				"@babel/code-frame": "^7.27.1",
+				"@babel/parser": "^7.27.2",
+				"@babel/types": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -3664,14 +3583,14 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.25.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
-			"integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
+			"integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.24.8",
-				"@babel/helper-validator-identifier": "^7.24.7",
-				"to-fast-properties": "^2.0.0"
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -8195,7 +8114,8 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
 			"version": "3.14.1",
@@ -9257,10 +9177,11 @@
 			}
 		},
 		"node_modules/picocolors": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-			"integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
-			"dev": true
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -9499,12 +9420,6 @@
 			"engines": {
 				"node": ">=8.10.0"
 			}
-		},
-		"node_modules/regenerator-runtime": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-			"dev": true
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
@@ -10070,15 +9985,6 @@
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
 			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
 			"dev": true
-		},
-		"node_modules/to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",

--- a/src/aws-app/process/index.ts
+++ b/src/aws-app/process/index.ts
@@ -4,6 +4,7 @@ import {getPlacementData} from './getPlacementData'
 import {getProcessedResources} from './resources'
 import {getProcessedContainers} from './containers'
 import {ProcessingErrorManager} from './utils/ProcessingErrorManager'
+import {extractUniqueTagKeysAndValues} from './utils/extractUniqueTagKeysAndValues'
 
 export const getAwsProcessedData = (resources: AwsResourcesList, resourceTags: AwsTags): AwsProcessedData => {
 	const processingErrorsManager = new ProcessingErrorManager()
@@ -19,24 +20,13 @@ export const getAwsProcessedData = (resources: AwsResourcesList, resourceTags: A
 	processingErrorsManager.render()
 
 	// Tag values
-	let possibleTagValues: {[key: string]: string[]} = {}
-	for (const [_arn, tags] of Object.entries(resourceTags)) {
-		for (const [key, value] of Object.entries(tags)) {
-			if (!possibleTagValues[key]) {
-				possibleTagValues[key] = []
-			}
-
-			if (value && !possibleTagValues[key].includes(value)) {
-				possibleTagValues[key].push(value)
-			}
-		}
-	}
+	const uniqueTagKeysAndValues = extractUniqueTagKeysAndValues(resourceTags)
 
 	// Return the processed data
 	return {
 		resources: processedResources,
 		connections: [],
 		containers,
-		tags: possibleTagValues,
+		tags: uniqueTagKeysAndValues,
 	}
 }

--- a/src/aws-app/process/utils/extractUniqueTagKeysAndValues.ts
+++ b/src/aws-app/process/utils/extractUniqueTagKeysAndValues.ts
@@ -1,0 +1,43 @@
+import {AwsTags} from '@/types'
+
+/**
+ * Extracts unique tag keys and their possible values from AWS resource tags
+ * @param resourceTags - Tags associated with AWS resources
+ * @returns An object mapping tag keys to arrays of their unique values
+ * @example
+ * ```ts
+ * const resourceTags = {
+ *   'arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0': {
+ *     'Environment': 'Production',
+ *     'Project': 'Alpha'
+ *   },
+ *   'arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef1': {
+ *     'Environment': 'Production',
+ *     'Project': 'Beta'
+ *   }
+ * }
+ *
+ * const tagKeysAndValues = extractUniqueTagKeysAndValues(resourceTags)
+ *
+ * // tagKeysAndValues = {
+ * //   'Environment': ['Production'],
+ * //   'Project': ['Alpha', 'Beta']
+ * // }
+ */
+export const extractUniqueTagKeysAndValues = (resourceTags: AwsTags): Record<string, string[]> => {
+	const tagKeyValueMap: Record<string, string[]> = {}
+
+	for (const [_arn, tags] of Object.entries(resourceTags)) {
+		for (const [key, value] of Object.entries(tags)) {
+			if (!tagKeyValueMap[key]) {
+				tagKeyValueMap[key] = []
+			}
+
+			if (value && !tagKeyValueMap[key].includes(value)) {
+				tagKeyValueMap[key].push(value)
+			}
+		}
+	}
+
+	return tagKeyValueMap
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -8,6 +8,15 @@ export type {
 } from '@/scanners'
 export type * from '@/types'
 
+export {
+	AwsSupportedResources,
+	AwsSupportedManagementServices,
+	AllSupportedAwsServices,
+	awsResourceNames,
+	awsManagementServiceNames,
+	awsTaggingFilterResourceTypes,
+	AwsResourceDescriptionMap,
+} from '@/definitions/supported-services'
 export {awsRegionIds} from '@/definitions/supported-regions'
 
 export {AWSRateLimitExhaustionRetryStrategy} from '@/aws-app/utils/AWSRateLimitExhaustionRetryStrategy'

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -17,9 +17,12 @@ export {
 	awsTaggingFilterResourceTypes,
 	AwsResourceDescriptionMap,
 } from '@/definitions/supported-services'
+
 export {awsRegionIds} from '@/definitions/supported-regions'
 
 export {AWSRateLimitExhaustionRetryStrategy} from '@/aws-app/utils/AWSRateLimitExhaustionRetryStrategy'
+
+export {extractUniqueTagKeysAndValues} from '@/aws-app/process/utils/extractUniqueTagKeysAndValues'
 
 /**
  * @public


### PR DESCRIPTION
To reuse the tag extraction function, we need to define it as a new function and export it via the library. This PR involves the necessary changes to make it happen.