### PR TITLE
feat: Security updates will be grouped in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: 'daily'
     groups:
+      security-updates:
+        applies-to: security-updates
+        patterns: ['*']
       aws-sdk:
         patterns:
           - '@aws-sdk/*'


### PR DESCRIPTION
This PR involves adding a new dependabot group called `security-updates` which groups all the security updates in one PR